### PR TITLE
Initial implementation of CassStatement

### DIFF
--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cass_error;
 pub mod cluster;
 pub mod future;
 pub mod session;
+pub mod statement;
 
 #[allow(non_camel_case_types)]
 pub type size_t = usize;

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -6,6 +6,9 @@ pub mod cluster;
 pub mod future;
 pub mod session;
 
+#[allow(non_camel_case_types)]
+pub type size_t = usize;
+
 lazy_static! {
     pub static ref RUNTIME: Runtime = Runtime::new().unwrap();
 }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -1,7 +1,8 @@
 use crate::cass_error;
 use crate::future::{CassFuture, CassResultValue};
 use scylla::{Session, SessionBuilder};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 type CassSession = Arc<RwLock<Option<Session>>>;
 
@@ -25,7 +26,7 @@ pub extern "C" fn cass_session_connect(
             .await
             .map_err(|_| cass_error::LIB_NO_HOSTS_AVAILABLE)?;
 
-        *session_opt.write().unwrap() = Some(session);
+        *session_opt.write().await = Some(session);
         Ok(CassResultValue::Empty)
     })
 }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -16,7 +16,7 @@ pub extern "C" fn cass_session_connect(
     session_raw: *mut CassSession,
     session_builder_raw: *const SessionBuilder,
 ) -> *mut CassFuture {
-    let session_opt: &CassSession = unsafe { session_raw.as_ref().unwrap() };
+    let session_opt: CassSession = unsafe { session_raw.as_ref().unwrap() }.clone();
     let builder: &SessionBuilder = unsafe { session_builder_raw.as_ref().unwrap() }.clone();
 
     CassFuture::make_raw(async move {

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -1,0 +1,50 @@
+use crate::size_t;
+use scylla::query::Query;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::sync::Arc;
+
+pub struct CassStatement_ {
+    pub query: Query,
+}
+
+pub type CassStatement = Arc<CassStatement_>;
+
+#[no_mangle]
+pub extern "C" fn cass_statement_new(
+    query: *const c_char,
+    parameter_count: size_t,
+) -> *mut CassStatement {
+    let query_cstr = unsafe { CStr::from_ptr(query) };
+    let query_length = query_cstr.to_str().unwrap().len();
+
+    cass_statement_new_n(query, query_length, parameter_count)
+}
+
+#[no_mangle]
+pub extern "C" fn cass_statement_new_n(
+    query: *const c_char,
+    query_length: size_t,
+    parameter_count: size_t,
+) -> *mut CassStatement {
+    let query_str = unsafe {
+        std::str::from_utf8(std::slice::from_raw_parts(query as *const u8, query_length)).unwrap()
+    };
+
+    assert!(
+        parameter_count == 0,
+        "parameter_count > 0 not implemented yet"
+    );
+
+    Box::into_raw(Box::new(Arc::new(CassStatement_ {
+        query: Query::new(query_str.to_string()),
+    })))
+}
+
+#[no_mangle]
+pub extern "C" fn cass_statement_free(statement_raw: *mut CassStatement) {
+    if !statement_raw.is_null() {
+        let ptr = unsafe { Box::from_raw(statement_raw) };
+        drop(ptr); // Explicit drop, to make function clearer
+    }
+}

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,12 @@ int main() {
     printf("code: %d\n", cass_future_error_code(connect_future));
     cass_future_free(connect_future);
 
+    CassStatement* statement = cass_statement_new("INSERT INTO ks.t(pk, ck, v) VALUES (7, 8, 9)", 0);
+    CassFuture* statement_future = cass_session_execute(session, statement);
+    printf("code: %d\n", cass_future_error_code(statement_future));
+    cass_future_free(statement_future);
+    cass_statement_free(statement);
+
     cass_cluster_free(cluster);
     cass_session_free(session);
 }


### PR DESCRIPTION
First three commits fix minor things:
1. Defining `size_t` type
2. Replacing std `RwLock` with tokio's `RwLock`
3. Cloning `CassSession` in `cass_session_connect`

The last commit adds a initial (very bare-bones) implementation of `CassStatement`:
- `CassStatement` type
- `cass_statement_new`
- `cass_statement_new_n`
- `cass_statement_free`
- `cass_session_execute`

This initial implementation ignores parameter_count and does not support bindings. An example query is added to `main.c`.