### PR TITLE
Utility functions for converting C arguments

### DIFF
--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -1,0 +1,26 @@
+use crate::size_t;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+pub unsafe fn ptr_to_ref<T>(ptr: *const T) -> &'static T {
+    ptr.as_ref().unwrap()
+}
+
+pub unsafe fn ptr_to_ref_mut<T>(ptr: *mut T) -> &'static mut T {
+    ptr.as_mut().unwrap()
+}
+
+pub unsafe fn free_boxed<T>(ptr: *mut T) {
+    if !ptr.is_null() {
+        // This takes the ownership of the boxed value and drops it
+        Box::from_raw(ptr);
+    }
+}
+
+pub unsafe fn ptr_to_cstr(ptr: *const c_char) -> Option<&'static str> {
+    CStr::from_ptr(ptr).to_str().ok()
+}
+
+pub unsafe fn ptr_to_cstr_n(ptr: *const c_char, size: size_t) -> Option<&'static str> {
+    std::str::from_utf8(std::slice::from_raw_parts(ptr as *const u8, size as usize)).ok()
+}

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -1,35 +1,37 @@
+use crate::argconv::*;
 use crate::cass_error::{self, CassError};
 use scylla::SessionBuilder;
-use std::ffi::CStr;
 use std::os::raw::c_char;
 
 pub struct CassCluster(pub SessionBuilder);
 
 #[no_mangle]
-pub extern "C" fn cass_cluster_new() -> *mut CassCluster {
+pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
     Box::into_raw(Box::new(CassCluster(SessionBuilder::new())))
 }
 
 #[no_mangle]
-pub extern "C" fn cass_cluster_free(session_builder_raw: *mut CassCluster) {
-    if !session_builder_raw.is_null() {
-        let ptr = unsafe { Box::from_raw(session_builder_raw) };
-        drop(ptr);
-    }
+pub unsafe extern "C" fn cass_cluster_free(session_builder_raw: *mut CassCluster) {
+    free_boxed(session_builder_raw);
 }
 
 #[no_mangle]
-pub extern "C" fn cass_cluster_set_contact_points(
+pub unsafe extern "C" fn cass_cluster_set_contact_points(
     session_builder_raw: *mut CassCluster,
     uri_raw: *const c_char,
 ) -> CassError {
-    let session_builder: &mut CassCluster = unsafe { session_builder_raw.as_mut().unwrap() };
-    let uri_cstr = unsafe { CStr::from_ptr(uri_raw) };
-
-    if let Ok(uri) = uri_cstr.to_str() {
-        session_builder.0.config.add_known_node(uri);
-        cass_error::OK
-    } else {
-        cass_error::LIB_BAD_PARAMS
+    match cluster_set_contact_points(session_builder_raw, uri_raw) {
+        Ok(()) => cass_error::OK,
+        Err(err) => err,
     }
+}
+
+unsafe fn cluster_set_contact_points(
+    session_builder_raw: *mut CassCluster,
+    uri_raw: *const c_char,
+) -> Result<(), CassError> {
+    let session_builder = ptr_to_ref_mut(session_builder_raw);
+    let uri = ptr_to_cstr(uri_raw).ok_or(cass_error::LIB_BAD_PARAMS)?;
+    session_builder.0.config.add_known_node(uri);
+    Ok(())
 }

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -1,6 +1,7 @@
 use lazy_static::lazy_static;
 use tokio::runtime::Runtime;
 
+mod argconv;
 pub mod cass_error;
 pub mod cluster;
 pub mod future;
@@ -25,13 +26,13 @@ lazy_static! {
 
 // #[no_mangle]
 // pub unsafe extern "C" fn do(foo: *mut Foo) -> *mut Foo {
-//     let foo = foo.as_ref().unwrap(); // That's ptr::as_ref
+//     let foo = argconv::ptr_to_ref(foo);
 // }
 
 // To take over/destroy Rust object previously given to C:
 
 // #[no_mangle]
 // pub unsafe extern "C" fn free_foo(foo: *mut Foo) {
-//     assert!(!foo.is_null());
-//     Box::from_raw(foo); // Rust auto-drops it
+//     // Take the ownership of the value and it will be automatically dropped
+//     argconv::ptr_to_opt_box(foo);
 // }


### PR DESCRIPTION
- Adds utility functions which should simplify converting arguments from C to arguments usable by Rust
- Marks all extern functions as unsafe so that less `unsafe` blocks are needed
- Modifies existing functions so that they use the new utility functions