### PR TITLE
Generate size_t def at comptime, small refactor

### DIFF
--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -31,4 +31,16 @@ fn main() {
     bindings
         .write_to_file(out_path.join("cassandra_bindings.rs"))
         .expect("Couldn't write bindings!");
+
+    let basic_bindings = bindgen::Builder::default()
+        .header("extern/cassandra.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .layout_tests(true)
+        .generate_comments(false)
+        .allowlist_type("size_t")
+        .generate()
+        .expect("Unable to generate bindings");
+    basic_bindings
+        .write_to_file(out_path.join("basic_types.rs"))
+        .expect("Couldn't write bindings!");
 }

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -1,4 +1,4 @@
-use crate::size_t;
+use crate::types::size_t;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -8,9 +8,6 @@ pub mod future;
 pub mod query_result;
 pub mod session;
 pub mod statement;
-
-#[allow(non_camel_case_types)]
-pub type size_t = usize;
 pub mod types;
 
 lazy_static! {

--- a/scylla-rust-wrapper/src/types.rs
+++ b/scylla-rust-wrapper/src/types.rs
@@ -1,5 +1,8 @@
 #![allow(non_camel_case_types)]
 
+// Definition for size_t (and possibly other types in the future)
+include!(concat!(env!("OUT_DIR"), "/basic_types.rs"));
+
 pub type cass_bool_t = ::std::os::raw::c_uint;
 pub type cass_float_t = f32;
 pub type cass_double_t = f64;
@@ -13,4 +16,3 @@ pub type cass_int64_t = i64;
 pub type cass_uint64_t = u64;
 pub type cass_byte_t = cass_uint8_t;
 pub type cass_duration_t = cass_uint64_t;
-pub type size_t = ::std::os::raw::c_ulong;


### PR DESCRIPTION
Refactored statement.rs to use new argconv functions and marked functions as unsafe.
Generate size_t definition at compile time using bindgen.