### PR TITLE
Initial support for binding values to statements (only int32)

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -865,8 +865,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "scylla"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19ff835deaf406d42020180b948ee5d8991d43999e10a7f1ebdbf5fe08be407"
+source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#e5eed4bb020c363ba7aaff748ecee85ba04a6637"
 dependencies = [
  "arc-swap",
  "bigdecimal",
@@ -902,9 +901,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e63cc30f40e947c537079b2744a076b3099bbdb661dd52f2c5a28ce1f5cea4"
+version = "0.1.1"
+source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#e5eed4bb020c363ba7aaff748ecee85ba04a6637"
 dependencies = [
  "quote",
  "syn",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-scylla = { version = "0.2.1"}
+scylla = { git = "https://github.com/hackathon-rust-cpp/scylla-rust-driver.git", branch = "main" }
 tokio = { version = "1.1.0", features = ["full"] }
 lazy_static = "1.4.0"
 oneshot = "0.1.2"

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -40,6 +40,8 @@ pub unsafe extern "C" fn cass_session_execute(
 ) -> *mut CassFuture {
     let session_opt = ptr_to_ref(session_raw);
     let statement_opt = ptr_to_ref(statement_raw);
+    let query = statement_opt.query.clone();
+    let bound_values = statement_opt.bound_values.clone();
 
     CassFuture::make_raw(async move {
         // TODO: Proper error handling
@@ -48,7 +50,7 @@ pub unsafe extern "C" fn cass_session_execute(
             .await
             .as_ref()
             .unwrap()
-            .query(statement_opt.query.clone(), ())
+            .query(query, bound_values)
             .await
             .map_err(|_| cass_error::LIB_NO_HOSTS_AVAILABLE)?;
         Ok(CassResultValue::Empty)

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -2,13 +2,10 @@ use crate::argconv::*;
 use crate::types::size_t;
 use scylla::query::Query;
 use std::os::raw::c_char;
-use std::sync::Arc;
 
-pub struct CassStatement_ {
+pub struct CassStatement {
     pub query: Query,
 }
-
-pub type CassStatement = Arc<CassStatement_>;
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_statement_new(
@@ -36,9 +33,9 @@ pub unsafe extern "C" fn cass_statement_new_n(
         "parameter_count > 0 not implemented yet"
     );
 
-    Box::into_raw(Box::new(Arc::new(CassStatement_ {
+    Box::into_raw(Box::new(CassStatement {
         query: Query::new(query_str.to_string()),
-    })))
+    }))
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -1,10 +1,16 @@
 use crate::argconv::*;
+use crate::cass_error::CassError;
 use crate::types::size_t;
+use scylla::frame::response::result::CqlValue;
+use scylla::frame::response::result::CqlValue::Int;
+use scylla::frame::value::MaybeUnset;
+use scylla::frame::value::MaybeUnset::{Set, Unset};
 use scylla::query::Query;
 use std::os::raw::c_char;
 
 pub struct CassStatement {
     pub query: Query,
+    pub bound_values: Vec<MaybeUnset<Option<CqlValue>>>,
 }
 
 #[no_mangle]
@@ -28,14 +34,23 @@ pub unsafe extern "C" fn cass_statement_new_n(
     // TODO: error handling
     let query_str = ptr_to_cstr_n(query, query_length).unwrap();
 
-    assert!(
-        parameter_count == 0,
-        "parameter_count > 0 not implemented yet"
-    );
-
     Box::into_raw(Box::new(CassStatement {
         query: Query::new(query_str.to_string()),
+        bound_values: vec![Unset; parameter_count as usize],
     }))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_statement_bind_int32(
+    statement_raw: *mut CassStatement,
+    index: size_t,
+    value: i32,
+) -> CassError {
+    // FIXME: Bounds check
+    let statement = ptr_to_ref_mut(statement_raw);
+    statement.bound_values[index as usize] = Set(Some(Int(value)));
+
+    crate::cass_error::OK
 }
 
 #[no_mangle]

--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,11 @@ int main() {
     printf("code: %d\n", cass_future_error_code(connect_future));
     cass_future_free(connect_future);
 
-    CassStatement* statement = cass_statement_new("INSERT INTO ks.t(pk, ck, v) VALUES (7, 8, 9)", 0);
+    CassStatement* statement = cass_statement_new("INSERT INTO ks.t(pk, ck, v) VALUES (?, ?, ?)", 3);
+    cass_statement_bind_int32(statement, 0, 100);
+    cass_statement_bind_int32(statement, 1, 200);
+    cass_statement_bind_int32(statement, 2, 300);
+
     CassFuture* statement_future = cass_session_execute(session, statement);
     printf("code: %d\n", cass_future_error_code(statement_future));
     cass_future_free(statement_future);


### PR DESCRIPTION
First, switch to our fork of Rust Driver, as some `Clone` traits were missing for necessary types and this version supports serializing `CqlValue`.

Second, I unwrap `CassStatement` from `Arc`, as this data type doesn't need to be thread-safe. This unwrapping makes it also easier to mutate this structure.

Finally, I implemented basic version of binding values to statements. On each `CassStatement` a `Vec` of bound values is stored (initially it is `Unset`). Newly implemented `cass_statement_bind_int32` allows for changing those values. Finally `cass_session_execute` now uses those bound values.