### PR TITLE
Implement future callbacks

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -108,12 +108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
-name = "cc"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
-
-[[package]]
 name = "cexpr"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,12 +115,6 @@ checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
 dependencies = [
  "nom",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -316,25 +304,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061d3be1afec479d56fa3bd182bf966c7999ec175fcfdb87ac14d417241366c6"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -345,7 +320,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
@@ -383,7 +358,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -425,7 +400,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi",
 ]
 
@@ -444,18 +419,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
-dependencies = [
- "cfg-if 0.1.10",
- "generator",
- "scoped-tls",
+ "cfg-if",
 ]
 
 [[package]]
@@ -622,15 +586,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
-name = "oneshot"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d7085e4e51b36df4afa83db60d20ad2adf8e8587a193f93c9143bf7b375dec"
-dependencies = [
- "loom",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,7 +602,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall",
@@ -839,22 +794,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustversion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -894,7 +837,6 @@ version = "0.0.1"
 dependencies = [
  "bindgen",
  "lazy_static",
- "oneshot",
  "scylla",
  "tokio",
 ]
@@ -1075,7 +1017,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT OR Apache-2.0"
 scylla = { git = "https://github.com/hackathon-rust-cpp/scylla-rust-driver.git", branch = "main" }
 tokio = { version = "1.1.0", features = ["full"] }
 lazy_static = "1.4.0"
-oneshot = "0.1.2"
 
 [build-dependencies]
 bindgen = "0.59.1"

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -1,6 +1,7 @@
 use crate::types::size_t;
 use std::ffi::CStr;
 use std::os::raw::c_char;
+use std::sync::Arc;
 
 pub unsafe fn ptr_to_ref<T>(ptr: *const T) -> &'static T {
     ptr.as_ref().unwrap()
@@ -14,6 +15,13 @@ pub unsafe fn free_boxed<T>(ptr: *mut T) {
     if !ptr.is_null() {
         // This takes the ownership of the boxed value and drops it
         Box::from_raw(ptr);
+    }
+}
+
+pub unsafe fn free_arced<T>(ptr: *const T) {
+    if !ptr.is_null() {
+        // This decrements the arc's internal counter and potentially drops it
+        Arc::from_raw(ptr);
     }
 }
 

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -2,10 +2,9 @@ use crate::argconv::*;
 use crate::cass_error::{self, CassError};
 use crate::query_result::CassResult;
 use crate::RUNTIME;
-use oneshot::{channel, Receiver};
 use scylla::QueryResult;
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, Condvar, Mutex};
 
 pub enum CassResultValue {
     Empty,
@@ -14,104 +13,85 @@ pub enum CassResultValue {
 
 pub type CassFutureResult = Result<CassResultValue, CassError>;
 
-pub enum CassFuture {
-    Pending(Receiver<CassFutureResult>),
-    Done(CassFutureResult),
+#[derive(Default)]
+struct CassFutureState {
+    value: Option<CassFutureResult>,
+}
+
+pub struct CassFuture {
+    state: Mutex<CassFutureState>,
+    wait_for_value: Condvar,
 }
 
 impl CassFuture {
     pub fn make_raw(
         fut: impl Future<Output = CassFutureResult> + Send + Sync + 'static,
-    ) -> *mut CassFuture {
-        Self::new_from_future(fut).box_and_make_raw()
+    ) -> *const CassFuture {
+        Self::new_from_future(fut).into_raw()
     }
 
     pub fn new_from_future(
         fut: impl Future<Output = CassFutureResult> + Send + Sync + 'static,
-    ) -> CassFuture {
-        let (tx, rx) = channel::<CassFutureResult>();
-        RUNTIME.spawn(async move {
-            let _ = tx.send(fut.await);
+    ) -> Arc<CassFuture> {
+        let cass_fut = Arc::new(CassFuture {
+            state: Mutex::new(Default::default()),
+            wait_for_value: Condvar::new(),
         });
-        CassFuture::Pending(rx)
+        let cass_fut_clone = cass_fut.clone();
+        RUNTIME.spawn(async move {
+            let r = fut.await;
+            cass_fut_clone.state.lock().unwrap().value = Some(r);
+            cass_fut_clone.wait_for_value.notify_all();
+        });
+        cass_fut
     }
 
-    pub fn new_pending(r: Receiver<CassFutureResult>) -> Self {
-        CassFuture::Pending(r)
+    pub fn new_ready(r: CassFutureResult) -> Arc<Self> {
+        Arc::new(CassFuture {
+            state: Mutex::new(CassFutureState {
+                value: Some(r),
+                ..Default::default()
+            }),
+            wait_for_value: Condvar::new(),
+        })
     }
 
-    pub fn new_ready(r: CassFutureResult) -> Self {
-        CassFuture::Done(r)
+    pub fn with_waited_result<T>(&self, f: impl FnOnce(&mut CassFutureResult) -> T) -> T {
+        let mut guard = self
+            .wait_for_value
+            .wait_while(self.state.lock().unwrap(), |s| s.value.is_none())
+            .unwrap();
+        f((*guard).value.as_mut().unwrap())
     }
 
-    pub fn wait_for_result(&mut self) -> &CassFutureResult {
-        match self {
-            CassFuture::Pending(_) => {
-                let mut dummy = CassFuture::Done(Err(cass_error::LIB_INTERNAL_ERROR));
-                std::mem::swap(&mut dummy, self);
-
-                let result = dummy
-                    .consume_rx()
-                    .recv()
-                    .unwrap_or(Err(cass_error::LIB_INTERNAL_ERROR));
-                *self = CassFuture::Done(result);
-                self.get_ready_result()
-            }
-            CassFuture::Done(r) => r,
-        }
-    }
-
-    pub fn box_and_make_raw(self) -> *mut Self {
-        Box::into_raw(Box::new(self))
-    }
-
-    fn consume_rx(self) -> Receiver<CassFutureResult> {
-        match self {
-            CassFuture::Pending(rx) => rx,
-            CassFuture::Done(_) => unreachable!(),
-        }
-    }
-
-    fn get_ready_result(&self) -> &CassFutureResult {
-        match self {
-            CassFuture::Pending(_) => unreachable!(),
-            CassFuture::Done(v) => v,
-        }
-    }
-}
-
-impl<F: Future<Output = CassFutureResult> + Send + Sync + 'static> From<F> for CassFuture {
-    fn from(f: F) -> CassFuture {
-        CassFuture::new_from_future(f)
+    fn into_raw(self: Arc<Self>) -> *const Self {
+        Arc::into_raw(self)
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_future_error_code(future_raw: *mut CassFuture) -> CassError {
-    let future = ptr_to_ref_mut(future_raw);
-    match future.wait_for_result() {
+pub unsafe extern "C" fn cass_future_error_code(future_raw: *const CassFuture) -> CassError {
+    ptr_to_ref(future_raw).with_waited_result(|r: &mut CassFutureResult| match r {
         Ok(_) => cass_error::OK,
         Err(err) => *err,
-    }
+    })
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_future_free(future_raw: *mut CassFuture) {
-    free_boxed(future_raw);
+pub unsafe extern "C" fn cass_future_free(future_raw: *const CassFuture) {
+    free_arced(future_raw);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_future_get_result(future_raw: *mut CassFuture) -> *const CassResult {
-    let future: &mut CassFuture = ptr_to_ref_mut(future_raw);
-    let result: &CassResultValue = match future.wait_for_result() {
-        Ok(res) => res,
-        Err(_) => return std::ptr::null(),
-    };
-
-    let query_result: Arc<QueryResult> = match result {
-        CassResultValue::QueryResult(qr) => qr.clone(),
-        _ => return std::ptr::null(), // TODO other code?
-    };
-
-    Box::into_raw(Box::new(query_result))
+pub unsafe extern "C" fn cass_future_get_result(
+    future_raw: *const CassFuture,
+) -> *const CassResult {
+    ptr_to_ref(future_raw)
+        .with_waited_result(|r: &mut CassFutureResult| -> Option<CassResult> {
+            match r.as_ref().ok()? {
+                CassResultValue::QueryResult(qr) => Some(qr.clone()),
+                _ => None,
+            }
+        })
+        .map_or(std::ptr::null(), |qr| Box::into_raw(Box::new(qr)))
 }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -17,7 +17,7 @@ pub unsafe extern "C" fn cass_session_new() -> *mut CassSession {
 pub unsafe extern "C" fn cass_session_connect(
     session_raw: *mut CassSession,
     session_builder_raw: *const SessionBuilder,
-) -> *mut CassFuture {
+) -> *const CassFuture {
     let session_opt = ptr_to_ref(session_raw);
     let builder = ptr_to_ref(session_builder_raw);
 
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn cass_session_connect(
 pub unsafe extern "C" fn cass_session_execute(
     session_raw: *mut CassSession,
     statement_raw: *const CassStatement,
-) -> *mut CassFuture {
+) -> *const CassFuture {
     let session_opt = ptr_to_ref(session_raw);
     let statement_opt = ptr_to_ref(statement_raw);
     let query = statement_opt.query.clone();

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,10 @@ void do_simple_query(CassSession* session, const char* query_text) {
     cass_statement_free(statement);
 }
 
+static void print_error_cb(CassFuture* future, void* data) {
+    printf("code: %d\n", cass_future_error_code(future));
+}
+
 int main() {
     CassFuture* connect_future = NULL;
     CassCluster* cluster = cass_cluster_new();
@@ -19,7 +23,8 @@ int main() {
 
     cass_cluster_set_contact_points(cluster, "127.0.1.1");
     connect_future = cass_session_connect(session, cluster);
-    printf("code: %d\n", cass_future_error_code(connect_future));
+    cass_future_set_callback(connect_future, print_error_cb, NULL);
+    cass_future_wait(connect_future);
     cass_future_free(connect_future);
 
     do_simple_query(session, "CREATE KEYSPACE IF NOT EXISTS ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
@@ -32,7 +37,8 @@ int main() {
     cass_statement_bind_int32(statement, 2, 300);
 
     CassFuture* statement_future = cass_session_execute(session, statement);
-    printf("code: %d\n", cass_future_error_code(statement_future));
+    cass_future_set_callback(statement_future, print_error_cb, NULL);
+    cass_future_wait(statement_future);
     cass_future_free(statement_future);
     cass_statement_free(statement);
 


### PR DESCRIPTION
This PR adds support for setting callbacks for the CassFutures. In order to be able to do this, the implementation of CassFuture had to be changed to use mutexes and condition variables instead of oneshot channels.