### PR TITLE
Prepared statements

### DIFF
--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -6,6 +6,7 @@ mod argconv;
 pub mod cass_error;
 pub mod cluster;
 pub mod future;
+pub mod prepared;
 pub mod query_result;
 pub mod session;
 pub mod statement;

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -1,0 +1,9 @@
+use crate::argconv::*;
+use scylla::prepared_statement::PreparedStatement;
+
+pub type CassPrepared = PreparedStatement;
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_prepared_free(prepared_raw: *const CassPrepared) {
+    free_arced(prepared_raw);
+}

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -1,4 +1,9 @@
-use crate::argconv::*;
+use std::sync::Arc;
+
+use crate::{
+    argconv::*,
+    statement::{CassStatement, Statement},
+};
 use scylla::prepared_statement::PreparedStatement;
 
 pub type CassPrepared = PreparedStatement;
@@ -6,4 +11,20 @@ pub type CassPrepared = PreparedStatement;
 #[no_mangle]
 pub unsafe extern "C" fn cass_prepared_free(prepared_raw: *const CassPrepared) {
     free_arced(prepared_raw);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_prepared_bind(
+    prepared_raw: *const CassPrepared,
+) -> *mut CassStatement {
+    let prepared: Arc<_> = Arc::from_raw(prepared_raw);
+
+    // cloning prepared statement's arc, because creating CassStatement should not invalidate
+    // the CassPrepared argument
+    let statement = Statement::Prepared(prepared.clone());
+
+    Box::into_raw(Box::new(CassStatement {
+        statement,
+        bound_values: Vec::new(),
+    }))
 }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -2,6 +2,7 @@ use crate::argconv::*;
 use crate::cass_error;
 use crate::future::{CassFuture, CassResultValue};
 use crate::statement::CassStatement;
+use crate::statement::Statement;
 use scylla::{QueryResult, Session, SessionBuilder};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -40,19 +41,20 @@ pub unsafe extern "C" fn cass_session_execute(
 ) -> *const CassFuture {
     let session_opt = ptr_to_ref(session_raw);
     let statement_opt = ptr_to_ref(statement_raw);
-    let query = statement_opt.query.clone();
     let bound_values = statement_opt.bound_values.clone();
 
+    let statement = statement_opt.statement.clone();
+
     CassFuture::make_raw(async move {
-        // TODO: Proper error handling
-        let query_res: QueryResult = session_opt
-            .read()
-            .await
-            .as_ref()
-            .unwrap()
-            .query(query, bound_values)
-            .await
-            .map_err(|_| cass_error::LIB_NO_HOSTS_AVAILABLE)?;
+        let session_guard = session_opt.read().await;
+        let session = session_guard.as_ref().unwrap();
+
+        let query_res: QueryResult = match statement {
+            Statement::Simple(query) => session.query(query, bound_values).await,
+            Statement::Prepared(prepared) => session.execute(&prepared, bound_values).await,
+        }
+        .map_err(|_| cass_error::LIB_NO_HOSTS_AVAILABLE)?; // TODO: Proper error handling
+
         Ok(CassResultValue::QueryResult(Arc::new(query_res)))
     })
 }


### PR DESCRIPTION
Implemented
```c
cass_session_prepare
cass_future_get_prepared
cass_prepared_bind
cass_prepared_free
```
Modified `cass_session_execute` to support running prepared queries.