### PR TITLE
First portion of cass_cluster_* implementations

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -390,9 +390,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "libloading"
@@ -808,7 +808,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "scylla"
 version = "0.2.1"
-source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#e5eed4bb020c363ba7aaff748ecee85ba04a6637"
+source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#73be705ad10f7edf7b54983eb7a18a61b3fd05af"
 dependencies = [
  "arc-swap",
  "bigdecimal",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "0.1.1"
-source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#e5eed4bb020c363ba7aaff748ecee85ba04a6637"
+source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#73be705ad10f7edf7b54983eb7a18a61b3fd05af"
 dependencies = [
  "quote",
  "syn",

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -3,35 +3,97 @@ use crate::cass_error::{self, CassError};
 use scylla::SessionBuilder;
 use std::os::raw::c_char;
 
-pub struct CassCluster(pub SessionBuilder);
+pub struct CassCluster {
+    session_builder: SessionBuilder,
 
-#[no_mangle]
-pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
-    Box::into_raw(Box::new(CassCluster(SessionBuilder::new())))
+    contact_points: Vec<String>,
+    port: u16,
+}
+
+pub fn build_session_builder(cluster: &CassCluster) -> SessionBuilder {
+    let known_nodes: Vec<_> = cluster
+        .contact_points
+        .clone()
+        .into_iter()
+        .map(|cp| format!("{}:{}", cp, cluster.port))
+        .collect();
+    cluster
+        .session_builder
+        .clone()
+        .known_nodes(&known_nodes)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_cluster_free(session_builder_raw: *mut CassCluster) {
-    free_boxed(session_builder_raw);
+pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
+    Box::into_raw(Box::new(CassCluster {
+        session_builder: SessionBuilder::new(),
+        port: 9042,
+        contact_points: Vec::new(),
+    }))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_free(cluster: *mut CassCluster) {
+    free_boxed(cluster);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_contact_points(
-    session_builder_raw: *mut CassCluster,
-    uri_raw: *const c_char,
+    cluster: *mut CassCluster,
+    contact_points: *const c_char,
 ) -> CassError {
-    match cluster_set_contact_points(session_builder_raw, uri_raw) {
+    let contact_points_str = ptr_to_cstr(contact_points).unwrap();
+    let contact_points_length = contact_points_str.len();
+
+    cass_cluster_set_contact_points_n(cluster, contact_points, contact_points_length as size_t)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_contact_points_n(
+    cluster: *mut CassCluster,
+    contact_points: *const c_char,
+    contact_points_length: size_t,
+) -> CassError {
+    match cluster_set_contact_points(cluster, contact_points, contact_points_length) {
         Ok(()) => cass_error::OK,
         Err(err) => err,
     }
 }
 
 unsafe fn cluster_set_contact_points(
-    session_builder_raw: *mut CassCluster,
-    uri_raw: *const c_char,
+    cluster_raw: *mut CassCluster,
+    contact_points_raw: *const c_char,
+    contact_points_length: size_t,
 ) -> Result<(), CassError> {
-    let session_builder = ptr_to_ref_mut(session_builder_raw);
-    let uri = ptr_to_cstr(uri_raw).ok_or(cass_error::LIB_BAD_PARAMS)?;
-    session_builder.0.config.add_known_node(uri);
+    let cluster = ptr_to_ref_mut(cluster_raw);
+    let mut contact_points = ptr_to_cstr_n(contact_points_raw, contact_points_length)
+        .ok_or(cass_error::LIB_BAD_PARAMS)?
+        .split(',')
+        .peekable();
+
+    if contact_points.peek().is_none() {
+        // If cass_cluster_set_contact_points() is called with empty
+        // set of contact points, the contact points should be cleared.
+        cluster.contact_points.clear();
+        return Ok(());
+    }
+
+    // cass_cluster_set_contact_points() will append
+    // in subsequent calls, not overwrite.
+    cluster.contact_points.extend(
+        contact_points
+            .map(|cp| cp.trim().to_string())
+            .filter(|cp| !cp.is_empty()),
+    );
     Ok(())
 }
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_port(
+    cluster_raw: *mut CassCluster,
+    port: c_int,
+) -> CassError {
+    let cluster = ptr_to_ref_mut(cluster_raw);
+    cluster.port = port as u16; // FIXME: validate port number
+    cass_error::OK
+}
+

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -156,6 +156,42 @@ pub unsafe extern "C" fn cass_cluster_set_port(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_credentials(
+    cluster: *mut CassCluster,
+    username: *const c_char,
+    password: *const c_char,
+) {
+    let username_str = ptr_to_cstr(username).unwrap();
+    let username_length = username_str.len();
+
+    let password_str = ptr_to_cstr(password).unwrap();
+    let password_length = password_str.len();
+
+    cass_cluster_set_credentials_n(
+        cluster,
+        username,
+        username_length as size_t,
+        password,
+        password_length as size_t,
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_credentials_n(
+    cluster_raw: *mut CassCluster,
+    username_raw: *const c_char,
+    username_length: size_t,
+    password_raw: *const c_char,
+    password_length: size_t,
+) {
+    let username = ptr_to_cstr_n(username_raw, username_length).unwrap();
+    let password = ptr_to_cstr_n(password_raw, password_length).unwrap();
+
+    let cluster = ptr_to_ref_mut(cluster_raw);
+    cluster.session_builder.config.auth_username = Some(username.to_string());
+    cluster.session_builder.config.auth_password = Some(password.to_string());
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_round_robin(cluster_raw: *mut CassCluster) {
     let cluster = ptr_to_ref_mut(cluster_raw);

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -1,6 +1,7 @@
 use crate::argconv::*;
 use crate::cass_error::{self, CassError};
 use crate::types::*;
+use core::time::Duration;
 use scylla::load_balancing::{
     DcAwareRoundRobinPolicy, LoadBalancingPolicy, RoundRobinPolicy, TokenAwarePolicy,
 };
@@ -125,6 +126,25 @@ unsafe fn cluster_set_contact_points(
     );
     Ok(())
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_tcp_nodelay(
+    cluster_raw: *mut CassCluster,
+    enabled: cass_bool_t,
+) {
+    let cluster = ptr_to_ref_mut(cluster_raw);
+    cluster.session_builder.config.tcp_nodelay = enabled != 0;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_connect_timeout(
+    cluster_raw: *mut CassCluster,
+    timeout_ms: c_uint,
+) {
+    let cluster = ptr_to_ref_mut(cluster_raw);
+    cluster.session_builder.config.connect_timeout = Duration::from_millis(timeout_ms.into());
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_port(
     cluster_raw: *mut CassCluster,

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -1,11 +1,13 @@
 use crate::argconv::*;
 use crate::cass_error;
+use crate::cluster::build_session_builder;
+use crate::cluster::CassCluster;
 use crate::future::{CassFuture, CassResultValue};
 use crate::statement::CassStatement;
 use crate::statement::Statement;
 use crate::types::size_t;
 use scylla::query::Query;
-use scylla::{QueryResult, Session, SessionBuilder};
+use scylla::{QueryResult, Session};
 use std::os::raw::c_char;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -20,14 +22,14 @@ pub unsafe extern "C" fn cass_session_new() -> *mut CassSession {
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_connect(
     session_raw: *mut CassSession,
-    session_builder_raw: *const SessionBuilder,
+    cluster_raw: *const CassCluster,
 ) -> *const CassFuture {
     let session_opt = ptr_to_ref(session_raw);
-    let builder = ptr_to_ref(session_builder_raw);
+    let cluster = ptr_to_ref(cluster_raw);
 
     CassFuture::make_raw(async move {
         // TODO: Proper error handling
-        let session = builder
+        let session = build_session_builder(cluster)
             .build()
             .await
             .map_err(|_| cass_error::LIB_NO_HOSTS_AVAILABLE)?;

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,8 @@ int main() {
     CassSession* session = cass_session_new();
 
     cass_cluster_set_contact_points(cluster, "127.0.1.1");
+    cass_cluster_set_load_balance_round_robin(cluster);
+    cass_cluster_set_token_aware_routing(cluster, 1);
     connect_future = cass_session_connect(session, cluster);
     cass_future_set_callback(connect_future, print_error_cb, NULL);
     cass_future_wait(connect_future);


### PR DESCRIPTION
#### Properly implement setting contact points
The previous implementation only supported adding a single contact 
point. This commit allows to pass multiple contact points (delimited
by ',' as in Cpp Driver). cass_cluster_set_contact_points_n is 
implemented additionally.

In order to support Cpp Driver's setting of port (which can happen
anytime), the contact points are stored in CassCluster. Just before
the session is built, build_session_builder "merges" the contact point
list together with last set port (I believe this is how Cpp Driver 
works).

Some minor type problems are fixed in session.rs: previously it
reinterpreted CassCluster pointer as SessionBuilder pointer (which
worked as CassCluster consisted only of SessionBuilder).

#### Add support for setting load balancing strategies
Implement most of the methods related to setting different load 
balancing strategies.

#### Add set_tcp_nodelay and set_connect_timeout

#### Add cass_cluster_set_credentials