### PR TITLE
Make clippy CI actually fail

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,4 +16,4 @@ jobs:
     - uses: actions/checkout@v2
     - name: Clippy check
       working-directory: ./scylla-rust-wrapper
-      run: cargo clippy --verbose --examples -- -D warnings
+      run: cargo clippy --verbose -- -D warnings

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -173,5 +173,5 @@ pub unsafe extern "C" fn cass_future_get_prepared(
                 _ => None,
             }
         })
-        .map_or(std::ptr::null(), |p| Arc::into_raw(p))
+        .map_or(std::ptr::null(), Arc::into_raw)
 }

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -21,7 +21,7 @@ pub unsafe extern "C" fn cass_prepared_bind(
 
     // cloning prepared statement's arc, because creating CassStatement should not invalidate
     // the CassPrepared argument
-    let statement = Statement::Prepared(prepared.clone());
+    let statement = Statement::Prepared(prepared);
 
     Box::into_raw(Box::new(CassStatement {
         statement,


### PR DESCRIPTION
With `--examples` flag, even though clippy found some warnings, it didn't fail the build as it was only executed on "examples" (This seems like a mistake?).