### PR TITLE
Add *_by_name and *_by_name_n variants of statement bind functions

### DIFF
--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -1,3 +1,4 @@
+use scylla::frame::value::MaybeUnset::Unset;
 use std::sync::Arc;
 
 use crate::{
@@ -18,6 +19,7 @@ pub unsafe extern "C" fn cass_prepared_bind(
     prepared_raw: *const CassPrepared,
 ) -> *mut CassStatement {
     let prepared: Arc<_> = Arc::from_raw(prepared_raw);
+    let bound_values_size = prepared.get_metadata().col_count;
 
     // cloning prepared statement's arc, because creating CassStatement should not invalidate
     // the CassPrepared argument
@@ -25,7 +27,7 @@ pub unsafe extern "C" fn cass_prepared_bind(
 
     Box::into_raw(Box::new(CassStatement {
         statement,
-        bound_values: Vec::new(),
+        bound_values: vec![Unset; bound_values_size],
         paging_state: None,
     }))
 }

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -1,6 +1,6 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
-use crate::collection::{CassCollection, CassCollectionType};
+use crate::collection::CassCollection;
 use crate::inet::CassInet;
 use crate::query_result::CassResult;
 use crate::types::*;
@@ -247,27 +247,8 @@ pub unsafe extern "C" fn cass_statement_bind_collection(
     collection_raw: *const CassCollection,
 ) -> CassError {
     // FIXME: implement _by_name and _by_name_n variants
-    // FIXME: validate that collection items are correct
-    let collection = ptr_to_ref(collection_raw);
-
-    let collection_cql_value: CqlValue = match collection.collection_type {
-        CassCollectionType::CASS_COLLECTION_TYPE_LIST => List(collection.items.clone()),
-        CassCollectionType::CASS_COLLECTION_TYPE_MAP => {
-            let mut grouped_items = Vec::new();
-            // FIXME: validate even number of items
-            for i in (0..collection.items.len()).step_by(2) {
-                let key = collection.items[i].clone();
-                let value = collection.items[i + 1].clone();
-
-                grouped_items.push((key, value));
-            }
-
-            Map(grouped_items)
-        }
-        CassCollectionType::CASS_COLLECTION_TYPE_SET => CqlValue::Set(collection.items.clone()),
-    };
-
-    cass_statement_bind_cql_value(statement, index, collection_cql_value)
+    let collection = ptr_to_ref(collection_raw).clone();
+    cass_statement_bind_cql_value(statement, index, collection.into())
 }
 
 #[no_mangle]


### PR DESCRIPTION
Add *_by_name and *_by_name_n variants of statement bind functions, which work for prepared statements and allow to set a value based on the column name. 

Fix cass_prepared_bind to correctly initialize bound_values based on the received metadata. 

Small refactoring around CassCollection to CqlValue conversion.