### PR TITLE
Implement CassDataType, CassValueType and CassUserType

### DIFF
--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -1,0 +1,230 @@
+use crate::argconv::*;
+use crate::cass_error::CassError;
+use crate::types::*;
+use std::os::raw::c_char;
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum CassValueType {
+    CASS_VALUE_TYPE_UNKNOWN = 65535,
+    CASS_VALUE_TYPE_CUSTOM = 0,
+    CASS_VALUE_TYPE_ASCII = 1,
+    CASS_VALUE_TYPE_BIGINT = 2,
+    CASS_VALUE_TYPE_BLOB = 3,
+    CASS_VALUE_TYPE_BOOLEAN = 4,
+    CASS_VALUE_TYPE_COUNTER = 5,
+    CASS_VALUE_TYPE_DECIMAL = 6,
+    CASS_VALUE_TYPE_DOUBLE = 7,
+    CASS_VALUE_TYPE_FLOAT = 8,
+    CASS_VALUE_TYPE_INT = 9,
+    CASS_VALUE_TYPE_TEXT = 10,
+    CASS_VALUE_TYPE_TIMESTAMP = 11,
+    CASS_VALUE_TYPE_UUID = 12,
+    CASS_VALUE_TYPE_VARCHAR = 13,
+    CASS_VALUE_TYPE_VARINT = 14,
+    CASS_VALUE_TYPE_TIMEUUID = 15,
+    CASS_VALUE_TYPE_INET = 16,
+    CASS_VALUE_TYPE_DATE = 17,
+    CASS_VALUE_TYPE_TIME = 18,
+    CASS_VALUE_TYPE_SMALL_INT = 19,
+    CASS_VALUE_TYPE_TINY_INT = 20,
+    CASS_VALUE_TYPE_DURATION = 21,
+    CASS_VALUE_TYPE_LIST = 32,
+    CASS_VALUE_TYPE_MAP = 33,
+    CASS_VALUE_TYPE_SET = 34,
+    CASS_VALUE_TYPE_UDT = 48,
+    CASS_VALUE_TYPE_TUPLE = 49,
+    CASS_VALUE_TYPE_LAST_ENTRY = 50,
+}
+
+#[derive(Clone)]
+pub struct UDTDataType {
+    pub field_count: usize,
+
+    // Vec to preserve the order of types
+    pub field_types: Vec<(String, CassDataType)>,
+
+    pub keyspace: String,
+    pub name: String,
+}
+
+#[derive(Clone)]
+pub enum CassDataType {
+    ValueDataType(CassValueType),
+    UDTDataType(UDTDataType),
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new(value_type: CassValueType) -> *mut CassDataType {
+    Box::into_raw(Box::new(CassDataType::ValueDataType(value_type)))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new_from_existing(
+    data_type_raw: *const CassDataType,
+) -> *mut CassDataType {
+    let data_type = ptr_to_ref(data_type_raw);
+    Box::into_raw(Box::new(data_type.clone()))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new_udt(field_count: size_t) -> *mut CassDataType {
+    Box::into_raw(Box::new(CassDataType::UDTDataType(UDTDataType {
+        // The defaults of Cpp Driver
+        keyspace: "".to_string(),
+        name: "".to_string(),
+
+        field_count: field_count as usize,
+        field_types: Vec::with_capacity(field_count as usize),
+    })))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    sub_data_type: *const CassDataType,
+) -> CassError {
+    let name_str = ptr_to_cstr(name).unwrap();
+    let name_length = name_str.len();
+
+    cass_data_type_add_sub_type_by_name_n(data_type, name, name_length as size_t, sub_data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
+    data_type_raw: *mut CassDataType,
+    name: *const c_char,
+    name_length: size_t,
+    sub_data_type_raw: *const CassDataType,
+) -> CassError {
+    let name_string = ptr_to_cstr_n(name, name_length).unwrap().to_string();
+    let sub_data_type = ptr_to_ref(sub_data_type_raw);
+
+    let data_type = ptr_to_ref_mut(data_type_raw);
+    match data_type {
+        CassDataType::ValueDataType(_) => crate::cass_error::LIB_INVALID_VALUE_TYPE,
+        CassDataType::UDTDataType(udt_data_type) => {
+            // The Cpp Driver does not check whether field_types size
+            // exceeded field_count.
+            udt_data_type
+                .field_types
+                .push((name_string, sub_data_type.clone()));
+            crate::cass_error::OK
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    sub_value_type: CassValueType,
+) -> CassError {
+    let sub_data_type = CassDataType::ValueDataType(sub_value_type);
+    cass_data_type_add_sub_type_by_name(data_type, name, &sub_data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    name_length: size_t,
+    sub_value_type: CassValueType,
+) -> CassError {
+    let sub_data_type = CassDataType::ValueDataType(sub_value_type);
+    cass_data_type_add_sub_type_by_name_n(data_type, name, name_length, &sub_data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_type_count(
+    data_type_raw: *const CassDataType,
+) -> size_t {
+    let data_type = ptr_to_ref(data_type_raw);
+    match data_type {
+        CassDataType::ValueDataType(_) => 0,
+        CassDataType::UDTDataType(udt_data_type) => udt_data_type.field_count as size_t,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_sub_type_count(data_type: *const CassDataType) -> size_t {
+    cass_data_type_sub_type_count(data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_type_name(
+    data_type: *mut CassDataType,
+    type_name: *const c_char,
+) -> CassError {
+    let type_name_str = ptr_to_cstr(type_name).unwrap();
+    let type_name_length = type_name_str.len();
+
+    cass_data_type_set_type_name_n(data_type, type_name, type_name_length as size_t)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_type_name_n(
+    data_type_raw: *mut CassDataType,
+    type_name: *const c_char,
+    type_name_length: size_t,
+) -> CassError {
+    let data_type = ptr_to_ref_mut(data_type_raw);
+    let type_name_string = ptr_to_cstr_n(type_name, type_name_length)
+        .unwrap()
+        .to_string();
+
+    match data_type {
+        CassDataType::ValueDataType(_) => crate::cass_error::LIB_INVALID_VALUE_TYPE,
+        CassDataType::UDTDataType(udt_data_type) => {
+            udt_data_type.name = type_name_string;
+            crate::cass_error::OK
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_keyspace(
+    data_type: *mut CassDataType,
+    keyspace: *const c_char,
+) -> CassError {
+    let keyspace_str = ptr_to_cstr(keyspace).unwrap();
+    let keyspace_length = keyspace_str.len();
+
+    cass_data_type_set_keyspace_n(data_type, keyspace, keyspace_length as size_t)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
+    data_type_raw: *mut CassDataType,
+    keyspace: *const c_char,
+    keyspace_length: size_t,
+) -> CassError {
+    let data_type = ptr_to_ref_mut(data_type_raw);
+    let keyspace_string = ptr_to_cstr_n(keyspace, keyspace_length)
+        .unwrap()
+        .to_string();
+
+    match data_type {
+        CassDataType::ValueDataType(_) => crate::cass_error::LIB_INVALID_VALUE_TYPE,
+        CassDataType::UDTDataType(udt_data_type) => {
+            udt_data_type.keyspace = keyspace_string;
+            crate::cass_error::OK
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_type(data_type_raw: *const CassDataType) -> CassValueType {
+    let data_type = ptr_to_ref(data_type_raw);
+    match data_type {
+        CassDataType::ValueDataType(value_data_type) => *value_data_type,
+        CassDataType::UDTDataType { .. } => CassValueType::CASS_VALUE_TYPE_UDT,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_free(data_type: *mut CassDataType) {
+    free_boxed(data_type);
+}

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -13,6 +13,7 @@ pub mod query_result;
 pub mod session;
 pub mod statement;
 pub mod types;
+pub mod user_type;
 
 lazy_static! {
     pub static ref RUNTIME: Runtime = Runtime::new().unwrap();

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -4,6 +4,7 @@ use tokio::runtime::Runtime;
 
 mod argconv;
 pub mod cass_error;
+pub mod cass_types;
 pub mod cluster;
 pub mod collection;
 pub mod future;

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -1,0 +1,320 @@
+use crate::argconv::*;
+use crate::cass_error::CassError;
+use crate::cass_types::CassDataType;
+use crate::cass_types::UDTDataType;
+use crate::types::*;
+use scylla::frame::response::result::CqlValue;
+use scylla::frame::response::result::CqlValue::*;
+use std::os::raw::c_char;
+
+#[derive(Clone)]
+pub struct CassUserType {
+    pub udt_data_type: UDTDataType,
+
+    // Vec to preserve the order of fields
+    pub field_values: Vec<(String, Option<CqlValue>)>,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_new_from_data_type(
+    data_type_raw: *const CassDataType,
+) -> *mut CassUserType {
+    let data_type = ptr_to_ref(data_type_raw);
+
+    match data_type {
+        CassDataType::UDTDataType(udt_data_type) => {
+            let field_values = udt_data_type
+                .field_types
+                .iter()
+                .map(|(field_name, _)| (field_name.clone(), None))
+                .collect();
+
+            Box::into_raw(Box::new(CassUserType {
+                udt_data_type: udt_data_type.clone(),
+                field_values,
+            }))
+        }
+        _ => std::ptr::null_mut(),
+    }
+}
+
+unsafe fn cass_user_type_set_option_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: Option<CqlValue>,
+) -> CassError {
+    let name_str = ptr_to_cstr(name).unwrap();
+    let name_length = name_str.len();
+
+    cass_user_type_set_option_by_name_n(user_type, name, name_length as size_t, value)
+}
+
+unsafe fn cass_user_type_set_option_by_name_n(
+    user_type_raw: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: Option<CqlValue>,
+) -> CassError {
+    let name_string = ptr_to_cstr_n(name, name_length).unwrap().to_string();
+
+    let user_type = ptr_to_ref_mut(user_type_raw);
+    for (field_name, field_value) in &mut user_type.field_values {
+        if *field_name == name_string {
+            // The Cpp driver does not validate whether value is
+            // of the correct type as far as I checked.
+            *field_value = value;
+            return crate::cass_error::OK;
+        }
+    }
+
+    crate::cass_error::LIB_NAME_DOES_NOT_EXIST
+}
+
+unsafe fn cass_user_type_set_cql_value_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: CqlValue,
+) -> CassError {
+    cass_user_type_set_option_by_name(user_type, name, Some(value))
+}
+
+unsafe fn cass_user_type_set_cql_value_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: CqlValue,
+) -> CassError {
+    cass_user_type_set_option_by_name_n(user_type, name, name_length, Some(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_null_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+) -> CassError {
+    cass_user_type_set_option_by_name(user_type, name, None)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_null_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+) -> CassError {
+    cass_user_type_set_option_by_name_n(user_type, name, name_length, None)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int8_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_int8_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, TinyInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int8_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_int8_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, TinyInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int16_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_int16_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, SmallInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int16_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_int16_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, SmallInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int32_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_int32_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, Int(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int32_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_int32_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Int(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_uint32_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_uint32_t,
+) -> CassError {
+    // cass_user_type_set_uint32_by_name is only used to set a DATE.
+    cass_user_type_set_cql_value_by_name(user_type, name, Date(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_uint32_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_uint32_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Date(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int64_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_int64_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, BigInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int64_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_int64_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, BigInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_float_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_float_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, Float(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_float_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_float_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Float(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_double_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_double_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, Double(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_double_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_double_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Double(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_bool_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_bool_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, Boolean(value != 0))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_bool_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_bool_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Boolean(value != 0))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_string_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: *const c_char,
+) -> CassError {
+    let value_str = ptr_to_cstr(value).unwrap();
+    let value_length = value_str.len();
+
+    let name_str = ptr_to_cstr(name).unwrap();
+    let name_length = name_str.len();
+
+    cass_user_type_set_string_by_name_n(
+        user_type,
+        name,
+        name_length as size_t,
+        value,
+        value_length as size_t,
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_string_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: *const c_char,
+    value_length: size_t,
+) -> CassError {
+    // TODO: Error handling
+    let value_string = ptr_to_cstr_n(value, value_length).unwrap().to_string();
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Text(value_string))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_bytes_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: *const cass_byte_t,
+    value_size: size_t,
+) -> CassError {
+    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
+    cass_user_type_set_cql_value_by_name(user_type, name, Blob(value_vec))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_bytes_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: *const cass_byte_t,
+    value_size: size_t,
+) -> CassError {
+    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Blob(value_vec))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_free(user_type: *mut CassUserType) {
+    free_boxed(user_type);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,9 @@ int main() {
     cass_statement_free(statement);
 
     do_simple_query(session, "DROP TABLE IF EXISTS ks.t2");
-    do_simple_query(session, "CREATE TABLE IF NOT EXISTS ks.t2 (pk int, ck int, v list<int>, v2 map<text, float>, primary key (pk, ck))");
+    do_simple_query(session, "DROP TYPE IF EXISTS ks.my_type");
+    do_simple_query(session, "CREATE TYPE IF NOT EXISTS ks.my_type(c text, a int, b float)");
+    do_simple_query(session, "CREATE TABLE IF NOT EXISTS ks.t2 (pk int, ck int, v list<int>, v2 map<text, float>, v3 my_type, primary key (pk, ck))");
 
     CassCollection* list = cass_collection_new(CASS_COLLECTION_TYPE_LIST, 3);
     cass_collection_append_int32(list, 123);
@@ -75,13 +77,26 @@ int main() {
     cass_collection_append_string(map, "k2");
     cass_collection_append_float(map, 20.0);
 
-    CassStatement* collection_statement = cass_statement_new("INSERT INTO ks.t2(pk, ck, v, v2) VALUES (?, ?, ?, ?)", 4);
+    CassDataType* udt_type = cass_data_type_new_udt(3);
+    cass_data_type_add_sub_value_type_by_name(udt_type, "c", CASS_VALUE_TYPE_TEXT);
+    cass_data_type_add_sub_value_type_by_name(udt_type, "a", CASS_VALUE_TYPE_INT);
+    cass_data_type_add_sub_value_type_by_name(udt_type, "b", CASS_VALUE_TYPE_FLOAT);
+
+    CassUserType* user_type = cass_user_type_new_from_data_type(udt_type);
+    cass_data_type_free(udt_type);
+    cass_user_type_set_string_by_name(user_type, "c", "UDT!");
+    cass_user_type_set_int32_by_name(user_type, "a", 15);
+    cass_user_type_set_float_by_name(user_type, "b", 3.14);
+
+    CassStatement* collection_statement = cass_statement_new("INSERT INTO ks.t2(pk, ck, v, v2, v3) VALUES (?, ?, ?, ?, ?)", 5);
     cass_statement_bind_int32(collection_statement, 0, 1);
     cass_statement_bind_int32(collection_statement, 1, 2);
     cass_statement_bind_collection(collection_statement, 2, list);
     cass_statement_bind_collection(collection_statement, 3, map);
+    cass_statement_bind_user_type(collection_statement, 4, user_type);
     cass_collection_free(list);
     cass_collection_free(map);
+    cass_user_type_free(user_type);
 
     CassFuture* collection_statement_future = cass_session_execute(session, collection_statement);
     cass_future_set_callback(collection_statement_future, print_error_cb, NULL);


### PR DESCRIPTION
The first commit implements `CassDataType`, `CassValueType` and a portion of related `cass_data_type*` functions.

The second commit implements `CassUserType` and a portion of related `cass_user_type*` functions.

The third commit implements `cass_statement_bind_user_type` and adds an example UDT insert to `main.c`.