### PR TITLE
Remove reduntant Box in CassSession and CassResult

### DIFF
--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -18,6 +18,11 @@ pub unsafe fn free_boxed<T>(ptr: *mut T) {
     }
 }
 
+pub unsafe fn clone_arced<T>(ptr: *const T) -> Arc<T> {
+    Arc::increment_strong_count(ptr);
+    Arc::from_raw(ptr)
+}
+
 pub unsafe fn free_arced<T>(ptr: *const T) {
     if !ptr.is_null() {
         // This decrements the arc's internal counter and potentially drops it

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -9,11 +9,13 @@ use scylla::SessionBuilder;
 use std::os::raw::{c_char, c_int, c_uint};
 use std::sync::Arc;
 
+#[derive(Clone)]
 enum CassClusterChildLoadBalancingPolicy {
     RoundRobinPolicy(RoundRobinPolicy),
     DcAwareRoundRobinPolicy(DcAwareRoundRobinPolicy),
 }
 
+#[derive(Clone)]
 pub struct CassCluster {
     session_builder: SessionBuilder,
 


### PR DESCRIPTION
Currently CassSession and CassResult are Arc<...> but are still returned to user using `Box::into_raw(Box::new(...))`. This PR removes this redundant Box and instead uses `Arc::into_raw`.