### PR TITLE
Add support for paging

### DIFF
--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -26,5 +26,6 @@ pub unsafe extern "C" fn cass_prepared_bind(
     Box::into_raw(Box::new(CassStatement {
         statement,
         bound_values: Vec::new(),
+        paging_state: None,
     }))
 }

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -40,6 +40,12 @@ pub unsafe extern "C" fn cass_result_free(result_raw: *mut CassResult) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn cass_result_has_more_pages(result: *const CassResult) -> cass_bool_t {
+    let result = ptr_to_ref(result);
+    result.paging_state.is_some() as cass_bool_t
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn cass_iterator_free(iterator: *mut CassIterator) {
     free_boxed(iterator);
 }


### PR DESCRIPTION
Implement `cass_result_has_more_pages` and `cass_statement_set_paging_state`. In `cass_session_execute` invoke `_paged` versions of `execute` and `query`. Fix the default paging setting for queries (it's disabled in Cpp Driver). Add an example of paging to `main.c`.