### PR TITLE
Set default consistency level to ONE

### DIFF
--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -6,6 +6,7 @@ use crate::future::{CassFuture, CassResultValue};
 use crate::statement::CassStatement;
 use crate::statement::Statement;
 use crate::types::size_t;
+use scylla::frame::types::Consistency;
 use scylla::query::Query;
 use scylla::transport::errors::QueryError;
 use scylla::{QueryResult, Session};
@@ -134,7 +135,9 @@ pub unsafe extern "C" fn cass_session_prepare_n(
             .await
             .map_err(|err| (CassError::from(&err), err.msg()))?;
 
-        prepared.disable_paging(); // Cpp Driver by default disables paging
+        // Set Cpp Driver default configuration for queries:
+        prepared.disable_paging();
+        prepared.set_consistency(Consistency::One);
 
         Ok(CassResultValue::Prepared(Arc::new(prepared)))
     })

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -7,6 +7,7 @@ use crate::types::*;
 use crate::uuid::CassUuid;
 use scylla::frame::response::result::CqlValue;
 use scylla::frame::response::result::CqlValue::*;
+use scylla::frame::types::Consistency;
 use scylla::frame::value::MaybeUnset;
 use scylla::frame::value::MaybeUnset::{Set, Unset};
 use scylla::query::Query;
@@ -54,7 +55,10 @@ pub unsafe extern "C" fn cass_statement_new_n(
     };
 
     let mut query = Query::new(query_str.to_string());
-    query.disable_paging(); // Cpp Driver by default disables paging
+
+    // Set Cpp Driver default configuration for queries:
+    query.disable_paging();
+    query.set_consistency(Consistency::One);
 
     Box::into_raw(Box::new(CassStatement {
         statement: Statement::Simple(query),


### PR DESCRIPTION
Set the default consistency level for queries to ONE, as is the case in the Cpp Driver.