### PR TITLE
Cass types v2

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -390,9 +390,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "libloading"
@@ -857,6 +857,7 @@ version = "0.0.1"
 dependencies = [
  "bindgen",
  "lazy_static",
+ "libc",
  "machine-uid",
  "num-derive",
  "num-traits",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -19,6 +19,7 @@ machine-uid = "0.2.0"
 rand = "0.8.4"
 num-traits = "0.2"
 num-derive = "0.3"
+libc = "0.2.108"
 
 [build-dependencies]
 bindgen = "0.59.1"

--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -39,7 +39,9 @@ fn prepare_cppdriver_data(outfile: &str, allowed_types: &[&str], out_path: &Path
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .layout_tests(true)
         .generate_comments(false)
-        .default_enum_style(bindgen::EnumVariation::NewType { is_bitfield: false });
+        .default_enum_style(bindgen::EnumVariation::NewType { is_bitfield: false })
+        .derive_eq(true)
+        .derive_ord(true);
     for t in allowed_types {
         type_bindings = type_bindings.allowlist_type(t);
     }

--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -93,4 +93,9 @@ fn main() {
         &["CassUuid_", "CassUuid"],
         &out_path,
     );
+    prepare_cppdriver_data(
+        "cppdriver_data_types.rs",
+        &["CassValueType_", "CassValueType"],
+        &out_path,
+    );
 }

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -42,3 +42,10 @@ pub unsafe fn write_str_to_c(s: &str, c_str: *mut *const c_char, c_strlen: *mut 
     *c_str = s.as_ptr() as *const i8;
     *c_strlen = s.len() as u64;
 }
+
+pub unsafe fn strlen(ptr: *const c_char) -> size_t {
+    if ptr.is_null() {
+        return 0;
+    }
+    libc::strlen(ptr) as size_t
+}

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -104,14 +104,14 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
 
     let data_type = ptr_to_ref_mut(data_type_raw);
     match data_type {
-        CassDataType::ValueDataType(_) => crate::cass_error::LIB_INVALID_VALUE_TYPE,
+        CassDataType::ValueDataType(_) => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         CassDataType::UDTDataType(udt_data_type) => {
             // The Cpp Driver does not check whether field_types size
             // exceeded field_count.
             udt_data_type
                 .field_types
                 .push((name_string, sub_data_type.clone()));
-            crate::cass_error::OK
+            CassError::CASS_OK
         }
     }
 }
@@ -176,10 +176,10 @@ pub unsafe extern "C" fn cass_data_type_set_type_name_n(
         .to_string();
 
     match data_type {
-        CassDataType::ValueDataType(_) => crate::cass_error::LIB_INVALID_VALUE_TYPE,
+        CassDataType::ValueDataType(_) => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         CassDataType::UDTDataType(udt_data_type) => {
             udt_data_type.name = type_name_string;
-            crate::cass_error::OK
+            CassError::CASS_OK
         }
     }
 }
@@ -207,10 +207,10 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
         .to_string();
 
     match data_type {
-        CassDataType::ValueDataType(_) => crate::cass_error::LIB_INVALID_VALUE_TYPE,
+        CassDataType::ValueDataType(_) => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         CassDataType::UDTDataType(udt_data_type) => {
             udt_data_type.keyspace = keyspace_string;
-            crate::cass_error::OK
+            CassError::CASS_OK
         }
     }
 }

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -2,122 +2,199 @@ use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::types::*;
 use std::os::raw::c_char;
+use std::ptr;
+use std::sync::Arc;
 
 include!(concat!(env!("OUT_DIR"), "/cppdriver_data_types.rs"));
 
 #[derive(Clone)]
 pub struct UDTDataType {
-    pub field_count: usize,
-
     // Vec to preserve the order of types
-    pub field_types: Vec<(String, CassDataType)>,
+    pub field_types: Vec<(String, CassDataTypeArc)>,
 
     pub keyspace: String,
     pub name: String,
 }
 
+impl UDTDataType {
+    pub fn new() -> UDTDataType {
+        UDTDataType {
+            field_types: Vec::new(),
+            keyspace: "".to_string(),
+            name: "".to_string(),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> UDTDataType {
+        UDTDataType {
+            field_types: Vec::with_capacity(capacity),
+            keyspace: "".to_string(),
+            name: "".to_string(),
+        }
+    }
+
+    pub fn add_field(&mut self, name: String, field_type: CassDataTypeArc) {
+        self.field_types.push((name, field_type));
+    }
+
+    pub fn get_field_by_name(&self, name: &str) -> Option<&CassDataTypeArc> {
+        for (field_name, field_type) in self.field_types.iter() {
+            if field_name == name {
+                return Some(field_type);
+            }
+        }
+        None
+    }
+
+    pub fn get_field_by_index(&self, index: usize) -> Option<&CassDataTypeArc> {
+        self.field_types.get(index).map(|(_, b)| b)
+    }
+}
+
 #[derive(Clone)]
 pub enum CassDataType {
-    ValueDataType(CassValueType),
-    UDTDataType(UDTDataType),
+    Value(CassValueType),
+    UDT(UDTDataType),
+    List(Option<CassDataTypeArc>),
+    Set(Option<CassDataTypeArc>),
+    Map(Option<CassDataTypeArc>, Option<CassDataTypeArc>),
+    Tuple(Vec<CassDataTypeArc>),
+    Custom(String),
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn cass_data_type_new(value_type: CassValueType) -> *mut CassDataType {
-    Box::into_raw(Box::new(CassDataType::ValueDataType(value_type)))
-}
+pub type CassDataTypeArc = Arc<CassDataType>;
 
-#[no_mangle]
-pub unsafe extern "C" fn cass_data_type_new_from_existing(
-    data_type_raw: *const CassDataType,
-) -> *mut CassDataType {
-    let data_type = ptr_to_ref(data_type_raw);
-    Box::into_raw(Box::new(data_type.clone()))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_data_type_new_udt(field_count: size_t) -> *mut CassDataType {
-    Box::into_raw(Box::new(CassDataType::UDTDataType(UDTDataType {
-        // The defaults of Cpp Driver
-        keyspace: "".to_string(),
-        name: "".to_string(),
-
-        field_count: field_count as usize,
-        field_types: Vec::with_capacity(field_count as usize),
-    })))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
-    data_type: *mut CassDataType,
-    name: *const c_char,
-    sub_data_type: *const CassDataType,
-) -> CassError {
-    let name_str = ptr_to_cstr(name).unwrap();
-    let name_length = name_str.len();
-
-    cass_data_type_add_sub_type_by_name_n(data_type, name, name_length as size_t, sub_data_type)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
-    data_type_raw: *mut CassDataType,
-    name: *const c_char,
-    name_length: size_t,
-    sub_data_type_raw: *const CassDataType,
-) -> CassError {
-    let name_string = ptr_to_cstr_n(name, name_length).unwrap().to_string();
-    let sub_data_type = ptr_to_ref(sub_data_type_raw);
-
-    let data_type = ptr_to_ref_mut(data_type_raw);
-    match data_type {
-        CassDataType::ValueDataType(_) => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
-        CassDataType::UDTDataType(udt_data_type) => {
-            // The Cpp Driver does not check whether field_types size
-            // exceeded field_count.
-            udt_data_type
+impl CassDataType {
+    fn get_sub_data_type(&self, index: usize) -> Option<&CassDataTypeArc> {
+        match self {
+            CassDataType::UDT(udt_data_type) => udt_data_type
                 .field_types
-                .push((name_string, sub_data_type.clone()));
-            CassError::CASS_OK
+                .get(index as usize)
+                .map(|(_, b)| b),
+            CassDataType::List(t) | CassDataType::Set(t) => {
+                if index > 0 {
+                    None
+                } else {
+                    t.as_ref()
+                }
+            }
+            CassDataType::Map(t1, t2) => match index {
+                0 => t1.as_ref(),
+                1 => t2.as_ref(),
+                _ => None,
+            },
+            CassDataType::Tuple(v) => v.get(index as usize),
+            _ => None,
+        }
+    }
+
+    fn add_sub_data_type(&mut self, sub_type: CassDataTypeArc) -> Result<(), CassError> {
+        match self {
+            CassDataType::List(t) | CassDataType::Set(t) => match t {
+                Some(_) => Err(CassError::CASS_ERROR_LIB_BAD_PARAMS),
+                None => {
+                    *t = Some(sub_type);
+                    Ok(())
+                }
+            },
+            CassDataType::Map(t1, t2) => {
+                if t1.is_some() && t2.is_some() {
+                    Err(CassError::CASS_ERROR_LIB_BAD_PARAMS)
+                } else if t1.is_none() {
+                    *t1 = Some(sub_type);
+                    Ok(())
+                } else {
+                    *t2 = Some(sub_type);
+                    Ok(())
+                }
+            }
+            CassDataType::Tuple(types) => {
+                types.push(sub_type);
+                Ok(())
+            }
+            _ => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
         }
     }
 }
 
+// Changed return type to const ptr - Arc::into_raw is const.
+// It's probably not a good idea - but cppdriver doesn't guarantee
+// thread safety apart from CassSession and CassFuture.
+// This comment also applies to other functions that create CassDataType.
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
-    data_type: *mut CassDataType,
-    name: *const c_char,
-    sub_value_type: CassValueType,
-) -> CassError {
-    let sub_data_type = CassDataType::ValueDataType(sub_value_type);
-    cass_data_type_add_sub_type_by_name(data_type, name, &sub_data_type)
+pub unsafe extern "C" fn cass_data_type_new(value_type: CassValueType) -> *const CassDataType {
+    let data_type = match value_type {
+        CassValueType::CASS_VALUE_TYPE_LIST => CassDataType::List(None),
+        CassValueType::CASS_VALUE_TYPE_SET => CassDataType::Set(None),
+        CassValueType::CASS_VALUE_TYPE_TUPLE => CassDataType::Tuple(Vec::new()),
+        CassValueType::CASS_VALUE_TYPE_MAP => CassDataType::Map(None, None),
+        CassValueType::CASS_VALUE_TYPE_UDT => CassDataType::UDT(UDTDataType::new()),
+        CassValueType::CASS_VALUE_TYPE_CUSTOM => CassDataType::Custom("".to_string()),
+        CassValueType::CASS_VALUE_TYPE_UNKNOWN => return ptr::null_mut(),
+        t if t < CassValueType::CASS_VALUE_TYPE_LAST_ENTRY => CassDataType::Value(t),
+        _ => return ptr::null_mut(),
+    };
+    Arc::into_raw(Arc::new(data_type))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
-    data_type: *mut CassDataType,
-    name: *const c_char,
-    name_length: size_t,
-    sub_value_type: CassValueType,
-) -> CassError {
-    let sub_data_type = CassDataType::ValueDataType(sub_value_type);
-    cass_data_type_add_sub_type_by_name_n(data_type, name, name_length, &sub_data_type)
+pub unsafe extern "C" fn cass_data_type_new_from_existing(
+    data_type: *const CassDataType,
+) -> *const CassDataType {
+    let data_type = ptr_to_ref(data_type);
+    Arc::into_raw(Arc::new(data_type.clone()))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_sub_type_count(
-    data_type_raw: *const CassDataType,
-) -> size_t {
-    let data_type = ptr_to_ref(data_type_raw);
+pub unsafe extern "C" fn cass_data_type_new_tuple(item_count: size_t) -> *const CassDataType {
+    Arc::into_raw(Arc::new(CassDataType::Tuple(Vec::with_capacity(
+        item_count as usize,
+    ))))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new_udt(field_count: size_t) -> *const CassDataType {
+    Arc::into_raw(Arc::new(CassDataType::UDT(UDTDataType::with_capacity(
+        field_count as usize,
+    ))))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_free(data_type: *mut CassDataType) {
+    free_arced(data_type);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_type(data_type: *const CassDataType) -> CassValueType {
+    let data_type = ptr_to_ref(data_type);
     match data_type {
-        CassDataType::ValueDataType(_) => 0,
-        CassDataType::UDTDataType(udt_data_type) => udt_data_type.field_count as size_t,
+        CassDataType::Value(value_data_type) => *value_data_type,
+        CassDataType::UDT { .. } => CassValueType::CASS_VALUE_TYPE_UDT,
+        CassDataType::List(..) => CassValueType::CASS_VALUE_TYPE_LIST,
+        CassDataType::Set(..) => CassValueType::CASS_VALUE_TYPE_SET,
+        CassDataType::Map(..) => CassValueType::CASS_VALUE_TYPE_MAP,
+        CassDataType::Tuple(..) => CassValueType::CASS_VALUE_TYPE_TUPLE,
+        CassDataType::Custom(..) => CassValueType::CASS_VALUE_TYPE_CUSTOM,
     }
 }
 
+// #[no_mangle]
+// pub unsafe extern "C" fn cass_data_type_is_frozen(data_type: *const CassDataType) -> cass_bool_t {}
+
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_sub_type_count(data_type: *const CassDataType) -> size_t {
-    cass_data_type_sub_type_count(data_type)
+pub unsafe extern "C" fn cass_data_type_type_name(
+    data_type: *const CassDataType,
+    type_name: *mut *const c_char,
+    type_name_length: *mut size_t,
+) -> CassError {
+    let data_type = ptr_to_ref(data_type);
+    match data_type {
+        CassDataType::UDT(UDTDataType { name, .. }) => {
+            write_str_to_c(name, type_name, type_name_length);
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
 }
 
 #[no_mangle]
@@ -125,10 +202,7 @@ pub unsafe extern "C" fn cass_data_type_set_type_name(
     data_type: *mut CassDataType,
     type_name: *const c_char,
 ) -> CassError {
-    let type_name_str = ptr_to_cstr(type_name).unwrap();
-    let type_name_length = type_name_str.len();
-
-    cass_data_type_set_type_name_n(data_type, type_name, type_name_length as size_t)
+    cass_data_type_set_type_name_n(data_type, type_name, strlen(type_name))
 }
 
 #[no_mangle]
@@ -143,11 +217,27 @@ pub unsafe extern "C" fn cass_data_type_set_type_name_n(
         .to_string();
 
     match data_type {
-        CassDataType::ValueDataType(_) => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
-        CassDataType::UDTDataType(udt_data_type) => {
+        CassDataType::UDT(udt_data_type) => {
             udt_data_type.name = type_name_string;
             CassError::CASS_OK
         }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_keyspace(
+    data_type: *const CassDataType,
+    keyspace: *mut *const c_char,
+    keyspace_length: *mut size_t,
+) -> CassError {
+    let data_type = ptr_to_ref(data_type);
+    match data_type {
+        CassDataType::UDT(UDTDataType { name, .. }) => {
+            write_str_to_c(name, keyspace, keyspace_length);
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
     }
 }
 
@@ -156,42 +246,219 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace(
     data_type: *mut CassDataType,
     keyspace: *const c_char,
 ) -> CassError {
-    let keyspace_str = ptr_to_cstr(keyspace).unwrap();
-    let keyspace_length = keyspace_str.len();
-
-    cass_data_type_set_keyspace_n(data_type, keyspace, keyspace_length as size_t)
+    cass_data_type_set_keyspace_n(data_type, keyspace, strlen(keyspace))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
-    data_type_raw: *mut CassDataType,
+    data_type: *mut CassDataType,
     keyspace: *const c_char,
     keyspace_length: size_t,
 ) -> CassError {
-    let data_type = ptr_to_ref_mut(data_type_raw);
+    let data_type = ptr_to_ref_mut(data_type);
     let keyspace_string = ptr_to_cstr_n(keyspace, keyspace_length)
         .unwrap()
         .to_string();
 
     match data_type {
-        CassDataType::ValueDataType(_) => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
-        CassDataType::UDTDataType(udt_data_type) => {
+        CassDataType::UDT(udt_data_type) => {
             udt_data_type.keyspace = keyspace_string;
             CassError::CASS_OK
         }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_type(data_type_raw: *const CassDataType) -> CassValueType {
-    let data_type = ptr_to_ref(data_type_raw);
+pub unsafe extern "C" fn cass_data_type_class_name(
+    data_type: *const CassDataType,
+    class_name: *mut *const ::std::os::raw::c_char,
+    class_name_length: *mut size_t,
+) -> CassError {
+    let data_type = ptr_to_ref(data_type);
     match data_type {
-        CassDataType::ValueDataType(value_data_type) => *value_data_type,
-        CassDataType::UDTDataType { .. } => CassValueType::CASS_VALUE_TYPE_UDT,
+        CassDataType::Custom(name) => {
+            write_str_to_c(&name, class_name, class_name_length);
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_free(data_type: *mut CassDataType) {
-    free_boxed(data_type);
+pub unsafe extern "C" fn cass_data_type_set_class_name(
+    data_type: *mut CassDataType,
+    class_name: *const ::std::os::raw::c_char,
+) -> CassError {
+    cass_data_type_set_class_name_n(data_type, class_name, strlen(class_name))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_class_name_n(
+    data_type: *mut CassDataType,
+    class_name: *const ::std::os::raw::c_char,
+    class_name_length: size_t,
+) -> CassError {
+    let data_type = ptr_to_ref_mut(data_type);
+    let class_string = ptr_to_cstr_n(class_name, class_name_length)
+        .unwrap()
+        .to_string();
+    match data_type {
+        CassDataType::Custom(name) => {
+            *name = class_string;
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_type_count(data_type: *const CassDataType) -> size_t {
+    let data_type = ptr_to_ref(data_type);
+    match data_type {
+        CassDataType::Value(..) => 0,
+        CassDataType::UDT(udt_data_type) => udt_data_type.field_types.len() as size_t,
+        CassDataType::List(t) | CassDataType::Set(t) => t.is_some() as size_t,
+        CassDataType::Map(t1, t2) => t1.is_some() as size_t + t2.is_some() as size_t,
+        CassDataType::Tuple(v) => v.len() as size_t,
+        CassDataType::Custom(..) => 0,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_sub_type_count(data_type: *const CassDataType) -> size_t {
+    cass_data_type_sub_type_count(data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_data_type(
+    data_type: *const CassDataType,
+    index: size_t,
+) -> *const CassDataType {
+    let data_type = ptr_to_ref(data_type);
+    let sub_type: Option<&CassDataTypeArc> = data_type.get_sub_data_type(index as usize);
+
+    match sub_type {
+        None => std::ptr::null(),
+        // Semantic from cppdriver which also returns non-owning pointer
+        Some(arc) => Arc::as_ptr(arc),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name(
+    data_type: *const CassDataType,
+    name: *const ::std::os::raw::c_char,
+) -> *const CassDataType {
+    cass_data_type_sub_data_type_by_name_n(data_type, name, strlen(name))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n(
+    data_type: *const CassDataType,
+    name: *const ::std::os::raw::c_char,
+    name_length: size_t,
+) -> *const CassDataType {
+    let data_type = ptr_to_ref(data_type);
+    let name_str = ptr_to_cstr_n(name, name_length).unwrap();
+    match data_type {
+        CassDataType::UDT(udt) => match udt.get_field_by_name(name_str) {
+            None => std::ptr::null(),
+            Some(t) => Arc::as_ptr(t),
+        },
+        _ => std::ptr::null(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_type_name(
+    data_type: *const CassDataType,
+    index: size_t,
+    name: *mut *const ::std::os::raw::c_char,
+    name_length: *mut size_t,
+) -> CassError {
+    let data_type = ptr_to_ref(data_type);
+    match data_type {
+        CassDataType::UDT(udt) => match udt.field_types.get(index as usize) {
+            None => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
+            Some((field_name, _)) => {
+                write_str_to_c(field_name, name, name_length);
+                CassError::CASS_OK
+            }
+        },
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_type(
+    data_type: *mut CassDataType,
+    sub_data_type: *const CassDataType,
+) -> CassError {
+    let data_type = ptr_to_ref_mut(data_type);
+    match data_type.add_sub_data_type(clone_arced(sub_data_type)) {
+        Ok(()) => CassError::CASS_OK,
+        Err(e) => e,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    sub_data_type: *const CassDataType,
+) -> CassError {
+    cass_data_type_add_sub_type_by_name_n(data_type, name, strlen(name), sub_data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
+    data_type_raw: *mut CassDataType,
+    name: *const c_char,
+    name_length: size_t,
+    sub_data_type_raw: *const CassDataType,
+) -> CassError {
+    let name_string = ptr_to_cstr_n(name, name_length).unwrap().to_string();
+    let sub_data_type = clone_arced(sub_data_type_raw);
+
+    let data_type = ptr_to_ref_mut(data_type_raw);
+    match data_type {
+        CassDataType::UDT(udt_data_type) => {
+            // The Cpp Driver does not check whether field_types size
+            // exceeded field_count.
+            udt_data_type.field_types.push((name_string, sub_data_type));
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_value_type(
+    data_type: *mut CassDataType,
+    sub_value_type: CassValueType,
+) -> CassError {
+    let sub_data_type = Arc::new(CassDataType::Value(sub_value_type));
+    cass_data_type_add_sub_type(data_type, Arc::as_ptr(&sub_data_type))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    sub_value_type: CassValueType,
+) -> CassError {
+    let sub_data_type = Arc::new(CassDataType::Value(sub_value_type));
+    cass_data_type_add_sub_type_by_name(data_type, name, Arc::as_ptr(&sub_data_type))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    name_length: size_t,
+    sub_value_type: CassValueType,
+) -> CassError {
+    let sub_data_type = Arc::new(CassDataType::Value(sub_value_type));
+    cass_data_type_add_sub_type_by_name_n(data_type, name, name_length, Arc::as_ptr(&sub_data_type))
 }

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -1,0 +1,230 @@
+use crate::argconv::*;
+use crate::cass_error::CassError;
+use crate::types::*;
+use std::os::raw::c_char;
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum CassValueType {
+    CASS_VALUE_TYPE_UNKNOWN = 65535,
+    CASS_VALUE_TYPE_CUSTOM = 0,
+    CASS_VALUE_TYPE_ASCII = 1,
+    CASS_VALUE_TYPE_BIGINT = 2,
+    CASS_VALUE_TYPE_BLOB = 3,
+    CASS_VALUE_TYPE_BOOLEAN = 4,
+    CASS_VALUE_TYPE_COUNTER = 5,
+    CASS_VALUE_TYPE_DECIMAL = 6,
+    CASS_VALUE_TYPE_DOUBLE = 7,
+    CASS_VALUE_TYPE_FLOAT = 8,
+    CASS_VALUE_TYPE_INT = 9,
+    CASS_VALUE_TYPE_TEXT = 10,
+    CASS_VALUE_TYPE_TIMESTAMP = 11,
+    CASS_VALUE_TYPE_UUID = 12,
+    CASS_VALUE_TYPE_VARCHAR = 13,
+    CASS_VALUE_TYPE_VARINT = 14,
+    CASS_VALUE_TYPE_TIMEUUID = 15,
+    CASS_VALUE_TYPE_INET = 16,
+    CASS_VALUE_TYPE_DATE = 17,
+    CASS_VALUE_TYPE_TIME = 18,
+    CASS_VALUE_TYPE_SMALL_INT = 19,
+    CASS_VALUE_TYPE_TINY_INT = 20,
+    CASS_VALUE_TYPE_DURATION = 21,
+    CASS_VALUE_TYPE_LIST = 32,
+    CASS_VALUE_TYPE_MAP = 33,
+    CASS_VALUE_TYPE_SET = 34,
+    CASS_VALUE_TYPE_UDT = 48,
+    CASS_VALUE_TYPE_TUPLE = 49,
+    CASS_VALUE_TYPE_LAST_ENTRY = 50,
+}
+
+#[derive(Clone)]
+pub struct UDTDataType {
+    pub field_count: usize,
+
+    // Vec to preserve the order of types
+    pub field_types: Vec<(String, CassDataType)>,
+
+    pub keyspace: String,
+    pub name: String,
+}
+
+#[derive(Clone)]
+pub enum CassDataType {
+    ValueDataType(CassValueType),
+    UDTDataType(UDTDataType),
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new(value_type: CassValueType) -> *mut CassDataType {
+    Box::into_raw(Box::new(CassDataType::ValueDataType(value_type)))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new_from_existing(
+    data_type_raw: *const CassDataType,
+) -> *mut CassDataType {
+    let data_type = ptr_to_ref(data_type_raw);
+    Box::into_raw(Box::new(data_type.clone()))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new_udt(field_count: size_t) -> *mut CassDataType {
+    Box::into_raw(Box::new(CassDataType::UDTDataType(UDTDataType {
+        // The defaults of Cpp Driver
+        keyspace: "".to_string(),
+        name: "".to_string(),
+
+        field_count: field_count as usize,
+        field_types: Vec::with_capacity(field_count as usize),
+    })))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    sub_data_type: *const CassDataType,
+) -> CassError {
+    let name_str = ptr_to_cstr(name).unwrap();
+    let name_length = name_str.len();
+
+    cass_data_type_add_sub_type_by_name_n(data_type, name, name_length as size_t, sub_data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
+    data_type_raw: *mut CassDataType,
+    name: *const c_char,
+    name_length: size_t,
+    sub_data_type_raw: *const CassDataType,
+) -> CassError {
+    let name_string = ptr_to_cstr_n(name, name_length).unwrap().to_string();
+    let sub_data_type = ptr_to_ref(sub_data_type_raw);
+
+    let data_type = ptr_to_ref_mut(data_type_raw);
+    match data_type {
+        CassDataType::ValueDataType(_) => crate::cass_error::LIB_INVALID_VALUE_TYPE,
+        CassDataType::UDTDataType(udt_data_type) => {
+            // The Cpp Driver does not check whether field_types size
+            // exceeded field_count.
+            udt_data_type
+                .field_types
+                .push((name_string, sub_data_type.clone()));
+            crate::cass_error::OK
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    sub_value_type: CassValueType,
+) -> CassError {
+    let sub_data_type = CassDataType::ValueDataType(sub_value_type);
+    cass_data_type_add_sub_type_by_name(data_type, name, &sub_data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    name_length: size_t,
+    sub_value_type: CassValueType,
+) -> CassError {
+    let sub_data_type = CassDataType::ValueDataType(sub_value_type);
+    cass_data_type_add_sub_type_by_name_n(data_type, name, name_length, &sub_data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_type_count(
+    data_type_raw: *const CassDataType,
+) -> size_t {
+    let data_type = ptr_to_ref(data_type_raw);
+    match data_type {
+        CassDataType::ValueDataType(_) => 0,
+        CassDataType::UDTDataType(udt_data_type) => udt_data_type.field_count as size_t,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_sub_type_count(data_type: *const CassDataType) -> size_t {
+    cass_data_type_sub_type_count(data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_type_name(
+    data_type: *mut CassDataType,
+    type_name: *const c_char,
+) -> CassError {
+    let type_name_str = ptr_to_cstr(type_name).unwrap();
+    let type_name_length = type_name_str.len();
+
+    cass_data_type_set_type_name_n(data_type, type_name, type_name_length as size_t)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_type_name_n(
+    data_type_raw: *mut CassDataType,
+    type_name: *const c_char,
+    type_name_length: size_t,
+) -> CassError {
+    let data_type = ptr_to_ref_mut(data_type_raw);
+    let type_name_string = ptr_to_cstr_n(type_name, type_name_length)
+        .unwrap()
+        .to_string();
+
+    match data_type {
+        CassDataType::ValueDataType(_) => crate::cass_error::LIB_INVALID_VALUE_TYPE,
+        CassDataType::UDTDataType(udt_data_type) => {
+            udt_data_type.name = type_name_string;
+            crate::cass_error::OK
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_keyspace(
+    data_type: *mut CassDataType,
+    keyspace: *const c_char,
+) -> CassError {
+    let keyspace_str = ptr_to_cstr(keyspace).unwrap();
+    let keyspace_length = keyspace_str.len();
+
+    cass_data_type_set_keyspace_n(data_type, keyspace, keyspace_length as size_t)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
+    data_type_raw: *mut CassDataType,
+    keyspace: *const c_char,
+    keyspace_length: size_t,
+) -> CassError {
+    let data_type = ptr_to_ref_mut(data_type_raw);
+    let keyspace_string = ptr_to_cstr_n(keyspace, keyspace_length)
+        .unwrap()
+        .to_string();
+
+    match data_type {
+        CassDataType::ValueDataType(_) => crate::cass_error::LIB_INVALID_VALUE_TYPE,
+        CassDataType::UDTDataType(udt_data_type) => {
+            udt_data_type.keyspace = keyspace_string;
+            crate::cass_error::OK
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_type(data_type_raw: *const CassDataType) -> CassValueType {
+    let data_type = ptr_to_ref(data_type_raw);
+    match data_type {
+        CassDataType::ValueDataType(value_data_type) => *value_data_type,
+        CassDataType::UDTDataType { .. } => CassValueType::CASS_VALUE_TYPE_UDT,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_free(data_type: *mut CassDataType) {
+    free_boxed(data_type);
+}

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -3,40 +3,7 @@ use crate::cass_error::CassError;
 use crate::types::*;
 use std::os::raw::c_char;
 
-#[allow(non_camel_case_types)]
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub enum CassValueType {
-    CASS_VALUE_TYPE_UNKNOWN = 65535,
-    CASS_VALUE_TYPE_CUSTOM = 0,
-    CASS_VALUE_TYPE_ASCII = 1,
-    CASS_VALUE_TYPE_BIGINT = 2,
-    CASS_VALUE_TYPE_BLOB = 3,
-    CASS_VALUE_TYPE_BOOLEAN = 4,
-    CASS_VALUE_TYPE_COUNTER = 5,
-    CASS_VALUE_TYPE_DECIMAL = 6,
-    CASS_VALUE_TYPE_DOUBLE = 7,
-    CASS_VALUE_TYPE_FLOAT = 8,
-    CASS_VALUE_TYPE_INT = 9,
-    CASS_VALUE_TYPE_TEXT = 10,
-    CASS_VALUE_TYPE_TIMESTAMP = 11,
-    CASS_VALUE_TYPE_UUID = 12,
-    CASS_VALUE_TYPE_VARCHAR = 13,
-    CASS_VALUE_TYPE_VARINT = 14,
-    CASS_VALUE_TYPE_TIMEUUID = 15,
-    CASS_VALUE_TYPE_INET = 16,
-    CASS_VALUE_TYPE_DATE = 17,
-    CASS_VALUE_TYPE_TIME = 18,
-    CASS_VALUE_TYPE_SMALL_INT = 19,
-    CASS_VALUE_TYPE_TINY_INT = 20,
-    CASS_VALUE_TYPE_DURATION = 21,
-    CASS_VALUE_TYPE_LIST = 32,
-    CASS_VALUE_TYPE_MAP = 33,
-    CASS_VALUE_TYPE_SET = 34,
-    CASS_VALUE_TYPE_UDT = 48,
-    CASS_VALUE_TYPE_TUPLE = 49,
-    CASS_VALUE_TYPE_LAST_ENTRY = 50,
-}
+include!(concat!(env!("OUT_DIR"), "/cppdriver_data_types.rs"));
 
 #[derive(Clone)]
 pub struct UDTDataType {

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -51,6 +51,12 @@ impl UDTDataType {
     }
 }
 
+impl Default for UDTDataType {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Clone)]
 pub enum CassDataType {
     Value(CassValueType),
@@ -278,7 +284,7 @@ pub unsafe extern "C" fn cass_data_type_class_name(
     let data_type = ptr_to_ref(data_type);
     match data_type {
         CassDataType::Custom(name) => {
-            write_str_to_c(&name, class_name, class_name_length);
+            write_str_to_c(name, class_name, class_name_length);
             CassError::CASS_OK
         }
         _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -15,6 +15,7 @@ pub mod query_result;
 pub mod session;
 pub mod statement;
 pub mod types;
+pub mod user_type;
 pub mod uuid;
 
 lazy_static! {

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -4,6 +4,7 @@ use tokio::runtime::Runtime;
 
 mod argconv;
 pub mod cass_error;
+pub mod cass_types;
 pub mod cluster;
 pub mod collection;
 pub mod future;

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -431,15 +431,7 @@ pub unsafe extern "C" fn cass_statement_bind_user_type(
     // FIXME: implement _by_name and _by_name_n variants
     let user_type = ptr_to_ref(user_type_raw);
 
-    cass_statement_bind_cql_value(
-        statement,
-        index,
-        CqlValue::UserDefinedType {
-            keyspace: user_type.udt_data_type.keyspace.clone(),
-            type_name: user_type.udt_data_type.name.clone(),
-            fields: user_type.field_values.clone(),
-        },
-    )
+    cass_statement_bind_cql_value(statement, index, user_type.into())
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -437,7 +437,7 @@ pub unsafe extern "C" fn cass_statement_bind_user_type(
         CqlValue::UserDefinedType {
             keyspace: user_type.udt_data_type.keyspace.clone(),
             type_name: user_type.udt_data_type.name.clone(),
-            fields: user_type.field_values.clone().into_iter().collect(),
+            fields: user_type.field_values.clone(),
         },
     )
 }

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn cass_user_type_new_from_data_type(
     let data_type = ptr_to_ref(data_type_raw);
 
     match data_type {
-        CassDataType::UDTDataType(udt_data_type) => {
+        CassDataType::UDT(udt_data_type) => {
             let field_values = udt_data_type
                 .field_types
                 .iter()

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -1,36 +1,100 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::cass_types::CassDataType;
-use crate::cass_types::UDTDataType;
+use crate::cass_types::{CassDataTypeArc, UDTDataType};
+use crate::collection::CassCollection;
+use crate::inet::CassInet;
 use crate::types::*;
+use crate::uuid::CassUuid;
 use scylla::frame::response::result::CqlValue;
 use scylla::frame::response::result::CqlValue::*;
+use std::convert::TryInto;
 use std::os::raw::c_char;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct CassUserType {
-    pub udt_data_type: UDTDataType,
+    pub data_type: CassDataTypeArc,
 
     // Vec to preserve the order of fields
-    pub field_values: Vec<(String, Option<CqlValue>)>,
+    pub field_values: Vec<Option<CqlValue>>,
+}
+
+fn is_compatible_type(_data_type: &CassDataType, _value: &Option<CqlValue>) -> bool {
+    // TODO: cppdriver actually checks types.
+    // TODO: this function should probably somewhere else
+    true
+}
+
+impl CassUserType {
+    pub fn get_udt_type(&self) -> &UDTDataType {
+        match &*self.data_type {
+            CassDataType::UDT(udt) => udt,
+            _ => unreachable!(),
+        }
+    }
+
+    unsafe fn set_option_by_index(&mut self, index: usize, value: Option<CqlValue>) -> CassError {
+        if index >= self.field_values.len() {
+            return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
+        }
+        if !is_compatible_type(&*self.get_udt_type().field_types[index].1, &value) {
+            return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
+        }
+        self.field_values[index] = value;
+        CassError::CASS_OK
+    }
+
+    //TODO: some hashtable for name lookup?
+    unsafe fn set_option_by_name(&mut self, name: &str, value: Option<CqlValue>) -> CassError {
+        let mut indices = Vec::new();
+        for (i, (field_name, _)) in self.get_udt_type().field_types.iter().enumerate() {
+            if *field_name == name {
+                indices.push(i);
+            }
+        }
+
+        if indices.is_empty() {
+            return CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST;
+        }
+
+        for i in indices.into_iter() {
+            let rc = self.set_option_by_index(i, value.clone());
+            if rc != CassError::CASS_OK {
+                return rc;
+            }
+        }
+
+        CassError::CASS_OK
+    }
+}
+
+impl From<&CassUserType> for CqlValue {
+    fn from(user_type: &CassUserType) -> Self {
+        CqlValue::UserDefinedType {
+            keyspace: user_type.get_udt_type().keyspace.clone(),
+            type_name: user_type.get_udt_type().name.clone(),
+            fields: user_type
+                .field_values
+                .iter()
+                .zip(user_type.get_udt_type().field_types.iter())
+                .map(|(v, (name, _))| (name.clone(), v.clone()))
+                .collect(),
+        }
+    }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_user_type_new_from_data_type(
     data_type_raw: *const CassDataType,
 ) -> *mut CassUserType {
-    let data_type = ptr_to_ref(data_type_raw);
+    let data_type = clone_arced(data_type_raw);
 
-    match data_type {
+    match &*data_type {
         CassDataType::UDT(udt_data_type) => {
-            let field_values = udt_data_type
-                .field_types
-                .iter()
-                .map(|(field_name, _)| (field_name.clone(), None))
-                .collect();
-
+            let field_values = vec![None; udt_data_type.field_types.len()];
             Box::into_raw(Box::new(CassUserType {
-                udt_data_type: udt_data_type.clone(),
+                data_type,
                 field_values,
             }))
         }
@@ -38,283 +102,214 @@ pub unsafe extern "C" fn cass_user_type_new_from_data_type(
     }
 }
 
-unsafe fn cass_user_type_set_option_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: Option<CqlValue>,
-) -> CassError {
-    let name_str = ptr_to_cstr(name).unwrap();
-    let name_length = name_str.len();
-
-    cass_user_type_set_option_by_name_n(user_type, name, name_length as size_t, value)
-}
-
-unsafe fn cass_user_type_set_option_by_name_n(
-    user_type_raw: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: Option<CqlValue>,
-) -> CassError {
-    let name_string = ptr_to_cstr_n(name, name_length).unwrap().to_string();
-
-    let user_type = ptr_to_ref_mut(user_type_raw);
-    for (field_name, field_value) in &mut user_type.field_values {
-        if *field_name == name_string {
-            // The Cpp driver does not validate whether value is
-            // of the correct type as far as I checked.
-            *field_value = value;
-            return CassError::CASS_OK;
-        }
-    }
-
-    CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST
-}
-
-unsafe fn cass_user_type_set_cql_value_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: CqlValue,
-) -> CassError {
-    cass_user_type_set_option_by_name(user_type, name, Some(value))
-}
-
-unsafe fn cass_user_type_set_cql_value_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: CqlValue,
-) -> CassError {
-    cass_user_type_set_option_by_name_n(user_type, name, name_length, Some(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_null_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-) -> CassError {
-    cass_user_type_set_option_by_name(user_type, name, None)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_null_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-) -> CassError {
-    cass_user_type_set_option_by_name_n(user_type, name, name_length, None)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_int8_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: cass_int8_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name(user_type, name, TinyInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_int8_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: cass_int8_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, TinyInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_int16_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: cass_int16_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name(user_type, name, SmallInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_int16_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: cass_int16_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, SmallInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_int32_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: cass_int32_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name(user_type, name, Int(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_int32_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: cass_int32_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Int(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_uint32_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: cass_uint32_t,
-) -> CassError {
-    // cass_user_type_set_uint32_by_name is only used to set a DATE.
-    cass_user_type_set_cql_value_by_name(user_type, name, Date(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_uint32_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: cass_uint32_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Date(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_int64_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: cass_int64_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name(user_type, name, BigInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_int64_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: cass_int64_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, BigInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_float_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: cass_float_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name(user_type, name, Float(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_float_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: cass_float_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Float(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_double_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: cass_double_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name(user_type, name, Double(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_double_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: cass_double_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Double(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_bool_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: cass_bool_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name(user_type, name, Boolean(value != 0))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_bool_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: cass_bool_t,
-) -> CassError {
-    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Boolean(value != 0))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_string_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: *const c_char,
-) -> CassError {
-    let value_str = ptr_to_cstr(value).unwrap();
-    let value_length = value_str.len();
-
-    let name_str = ptr_to_cstr(name).unwrap();
-    let name_length = name_str.len();
-
-    cass_user_type_set_string_by_name_n(
-        user_type,
-        name,
-        name_length as size_t,
-        value,
-        value_length as size_t,
-    )
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_string_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: *const c_char,
-    value_length: size_t,
-) -> CassError {
-    // TODO: Error handling
-    let value_string = ptr_to_cstr_n(value, value_length).unwrap().to_string();
-    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Text(value_string))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_bytes_by_name(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    value: *const cass_byte_t,
-    value_size: size_t,
-) -> CassError {
-    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
-    cass_user_type_set_cql_value_by_name(user_type, name, Blob(value_vec))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_user_type_set_bytes_by_name_n(
-    user_type: *mut CassUserType,
-    name: *const c_char,
-    name_length: size_t,
-    value: *const cass_byte_t,
-    value_size: size_t,
-) -> CassError {
-    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
-    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Blob(value_vec))
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn cass_user_type_free(user_type: *mut CassUserType) {
     free_boxed(user_type);
 }
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_data_type(
+    user_type: *const CassUserType,
+) -> *const CassDataType {
+    Arc::as_ptr(&ptr_to_ref(user_type).data_type)
+}
+
+macro_rules! make_binders {
+    (@index $fn_by_idx:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
+        #[no_mangle]
+        #[allow(clippy::redundant_closure_call)]
+        pub unsafe extern "C" fn $fn_by_idx(
+            user_type: *mut CassUserType,
+            index: size_t,
+            $($arg: $t), *
+        ) -> CassError {
+            match ($e)($($arg), *) {
+                Ok(v) => ptr_to_ref_mut(user_type).set_option_by_index(index as usize, v),
+                Err(e) => e,
+            }
+        }
+    };
+    (@name $fn_by_name:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
+        #[no_mangle]
+        #[allow(clippy::redundant_closure_call)]
+        pub unsafe extern "C" fn $fn_by_name(
+            user_type: *mut CassUserType,
+            name: *const c_char,
+            $($arg: $t), *
+        ) -> CassError {
+            let name = ptr_to_cstr(name).unwrap();
+            match ($e)($($arg), *) {
+                Ok(v) => ptr_to_ref_mut(user_type).set_option_by_name(name, v),
+                Err(e) => e,
+            }
+        }
+    };
+    (@name_n $fn_by_name_n:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
+        #[no_mangle]
+        #[allow(clippy::redundant_closure_call)]
+        pub unsafe extern "C" fn $fn_by_name_n(
+            user_type: *mut CassUserType,
+            name: *const c_char,
+            name_length: size_t,
+            $($arg: $t), *
+        ) -> CassError {
+            let name = ptr_to_cstr_n(name, name_length).unwrap();
+            match ($e)($($arg), *) {
+                Ok(v) => ptr_to_ref_mut(user_type).set_option_by_name(name, v),
+                Err(e) => e,
+            }
+        }
+    };
+    (@multi $m_fn_by_idx:ident, $m_fn_by_name:ident, $m_fn_by_name_n:ident,
+        $e1:expr, [$($arg1:ident @ $t1:ty), *],
+        $e2:expr, [$($arg2:ident @ $t2:ty), *],
+        $e3:expr, [$($arg3:ident @ $t3:ty), *]) => {
+            make_binders!(@index $m_fn_by_idx, $e1, [$($arg1 @ $t1), *]);
+            make_binders!(@name $m_fn_by_name, $e2, [$($arg2 @ $t2), *]);
+            make_binders!(@name_n $m_fn_by_name_n, $e3, [$($arg3 @ $t3), *]);
+    };
+
+    ($fn_by_idx:ident, $fn_by_name:ident, $fn_by_name_n:ident, $e:expr, $($arg:ident @ $t:ty), *) => {
+        make_binders!(@multi $fn_by_idx, $fn_by_name, $fn_by_name_n, $e, [$($arg @ $t), *], $e, [$($arg @ $t), *], $e, [$($arg @ $t), *]);
+    }
+}
+
+make_binders!(
+    cass_user_type_set_null,
+    cass_user_type_set_null_by_name,
+    cass_user_type_set_null_by_name_n,
+    || Ok(None),
+);
+
+make_binders!(
+    cass_user_type_set_int8,
+    cass_user_type_set_int8_by_name,
+    cass_user_type_set_int8_by_name_n,
+    |v| Ok(Some(TinyInt(v))),
+    v @ cass_int8_t
+);
+
+make_binders!(
+    cass_user_type_set_int16,
+    cass_user_type_set_int16_by_name,
+    cass_user_type_set_int16_by_name_n,
+    |v| Ok(Some(SmallInt(v))),
+    v @ cass_int16_t
+);
+
+make_binders!(
+    cass_user_type_set_int32,
+    cass_user_type_set_int32_by_name,
+    cass_user_type_set_int32_by_name_n,
+    |v| Ok(Some(Int(v))),
+    v @ cass_int32_t
+);
+
+make_binders!(
+    cass_user_type_set_uint32,
+    cass_user_type_set_uint32_by_name,
+    cass_user_type_set_uint32_by_name_n,
+    |v| Ok(Some(Date(v))),
+    v @ cass_uint32_t
+);
+
+make_binders!(
+    cass_user_type_set_int64,
+    cass_user_type_set_int64_by_name,
+    cass_user_type_set_int64_by_name_n,
+    |v| Ok(Some(BigInt(v))),
+    v @ cass_int64_t
+);
+
+make_binders!(
+    cass_user_type_set_float,
+    cass_user_type_set_float_by_name,
+    cass_user_type_set_float_by_name_n,
+    |v| Ok(Some(Float(v))),
+    v @ cass_float_t
+);
+
+make_binders!(
+    cass_user_type_set_double,
+    cass_user_type_set_double_by_name,
+    cass_user_type_set_double_by_name_n,
+    |v| Ok(Some(Double(v))),
+    v @ cass_double_t
+);
+
+make_binders!(
+    cass_user_type_set_bool,
+    cass_user_type_set_bool_by_name,
+    cass_user_type_set_bool_by_name_n,
+    |v| Ok(Some(Boolean(v != 0))),
+    v @ cass_bool_t
+);
+
+make_binders!(@multi
+    cass_user_type_set_string,
+    cass_user_type_set_string_by_name,
+    cass_user_type_set_string_by_name_n,
+    |v, n| Ok(Some(Text(ptr_to_cstr_n(v, n).unwrap().to_string()))),
+    [v @ *const c_char, n @ size_t],
+    |v| Ok(Some(Text(ptr_to_cstr(v).unwrap().to_string()))),
+    [v @ *const c_char],
+    |v, n| Ok(Some(Text(ptr_to_cstr_n(v, n).unwrap().to_string()))),
+    [v @ *const c_char, n @ size_t]
+);
+
+make_binders!(
+    cass_user_type_set_bytes,
+    cass_user_type_set_bytes_by_name,
+    cass_user_type_set_bytes_by_name_n,
+    |v, v_size| {
+        let v_vec = std::slice::from_raw_parts(v, v_size as usize).to_vec();
+        Ok(Some(Blob(v_vec)))
+    },
+    v @ *const cass_byte_t,
+    v_size @ size_t
+);
+
+make_binders!(
+    cass_user_type_set_uuid,
+    cass_user_type_set_uuid_by_name,
+    cass_user_type_set_uuid_by_name_n,
+    |v: CassUuid| Ok(Some(Uuid(v.into()))),
+    v @ CassUuid
+);
+
+make_binders!(
+    cass_user_type_set_inet,
+    cass_user_type_set_inet_by_name,
+    cass_user_type_set_inet_by_name_n,
+    |v: CassInet| {
+        // Err if length in struct is invalid.
+        // cppdriver doesn't check this - it encodes any length given to it
+        // but it doesn't seem like something we wanna do. Also, rust driver can't
+        // really do it afaik.
+        match v.try_into() {
+            Ok(v) => Ok(Some(Inet(v))),
+            Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
+        }
+    },
+    v @ CassInet
+);
+
+make_binders!(
+    cass_user_type_set_collection,
+    cass_user_type_set_collection_by_name,
+    cass_user_type_set_collection_by_name_n,
+    |p: *const CassCollection| {
+        match ptr_to_ref(p).clone().try_into() {
+            Ok(v) => Ok(Some(v)),
+            Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
+        }
+    },
+    p @ *const CassCollection
+);
+
+make_binders!(
+    cass_user_type_set_user_type,
+    cass_user_type_set_user_type_by_name,
+    cass_user_type_set_user_type_by_name_n,
+    |p: *const CassUserType| Ok(Some(ptr_to_ref(p).into())),
+    p @ *const CassUserType
+);

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -1,0 +1,320 @@
+use crate::argconv::*;
+use crate::cass_error::CassError;
+use crate::cass_types::CassDataType;
+use crate::cass_types::UDTDataType;
+use crate::types::*;
+use scylla::frame::response::result::CqlValue;
+use scylla::frame::response::result::CqlValue::*;
+use std::os::raw::c_char;
+
+#[derive(Clone)]
+pub struct CassUserType {
+    pub udt_data_type: UDTDataType,
+
+    // Vec to preserve the order of fields
+    pub field_values: Vec<(String, Option<CqlValue>)>,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_new_from_data_type(
+    data_type_raw: *const CassDataType,
+) -> *mut CassUserType {
+    let data_type = ptr_to_ref(data_type_raw);
+
+    match data_type {
+        CassDataType::UDTDataType(udt_data_type) => {
+            let field_values = udt_data_type
+                .field_types
+                .iter()
+                .map(|(field_name, _)| (field_name.clone(), None))
+                .collect();
+
+            Box::into_raw(Box::new(CassUserType {
+                udt_data_type: udt_data_type.clone(),
+                field_values,
+            }))
+        }
+        _ => std::ptr::null_mut(),
+    }
+}
+
+unsafe fn cass_user_type_set_option_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: Option<CqlValue>,
+) -> CassError {
+    let name_str = ptr_to_cstr(name).unwrap();
+    let name_length = name_str.len();
+
+    cass_user_type_set_option_by_name_n(user_type, name, name_length as size_t, value)
+}
+
+unsafe fn cass_user_type_set_option_by_name_n(
+    user_type_raw: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: Option<CqlValue>,
+) -> CassError {
+    let name_string = ptr_to_cstr_n(name, name_length).unwrap().to_string();
+
+    let user_type = ptr_to_ref_mut(user_type_raw);
+    for (field_name, field_value) in &mut user_type.field_values {
+        if *field_name == name_string {
+            // The Cpp driver does not validate whether value is
+            // of the correct type as far as I checked.
+            *field_value = value;
+            return CassError::CASS_OK;
+        }
+    }
+
+    CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST
+}
+
+unsafe fn cass_user_type_set_cql_value_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: CqlValue,
+) -> CassError {
+    cass_user_type_set_option_by_name(user_type, name, Some(value))
+}
+
+unsafe fn cass_user_type_set_cql_value_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: CqlValue,
+) -> CassError {
+    cass_user_type_set_option_by_name_n(user_type, name, name_length, Some(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_null_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+) -> CassError {
+    cass_user_type_set_option_by_name(user_type, name, None)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_null_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+) -> CassError {
+    cass_user_type_set_option_by_name_n(user_type, name, name_length, None)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int8_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_int8_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, TinyInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int8_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_int8_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, TinyInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int16_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_int16_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, SmallInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int16_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_int16_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, SmallInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int32_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_int32_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, Int(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int32_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_int32_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Int(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_uint32_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_uint32_t,
+) -> CassError {
+    // cass_user_type_set_uint32_by_name is only used to set a DATE.
+    cass_user_type_set_cql_value_by_name(user_type, name, Date(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_uint32_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_uint32_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Date(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int64_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_int64_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, BigInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_int64_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_int64_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, BigInt(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_float_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_float_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, Float(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_float_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_float_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Float(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_double_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_double_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, Double(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_double_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_double_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Double(value))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_bool_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: cass_bool_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name(user_type, name, Boolean(value != 0))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_bool_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: cass_bool_t,
+) -> CassError {
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Boolean(value != 0))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_string_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: *const c_char,
+) -> CassError {
+    let value_str = ptr_to_cstr(value).unwrap();
+    let value_length = value_str.len();
+
+    let name_str = ptr_to_cstr(name).unwrap();
+    let name_length = name_str.len();
+
+    cass_user_type_set_string_by_name_n(
+        user_type,
+        name,
+        name_length as size_t,
+        value,
+        value_length as size_t,
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_string_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: *const c_char,
+    value_length: size_t,
+) -> CassError {
+    // TODO: Error handling
+    let value_string = ptr_to_cstr_n(value, value_length).unwrap().to_string();
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Text(value_string))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_bytes_by_name(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    value: *const cass_byte_t,
+    value_size: size_t,
+) -> CassError {
+    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
+    cass_user_type_set_cql_value_by_name(user_type, name, Blob(value_vec))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_set_bytes_by_name_n(
+    user_type: *mut CassUserType,
+    name: *const c_char,
+    name_length: size_t,
+    value: *const cass_byte_t,
+    value_size: size_t,
+) -> CassError {
+    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
+    cass_user_type_set_cql_value_by_name_n(user_type, name, name_length, Blob(value_vec))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_free(user_type: *mut CassUserType) {
+    free_boxed(user_type);
+}


### PR DESCRIPTION
This is a continuation of https://github.com/hackathon-rust-cpp/cpp-rust-driver/pull/18
Changes from original PR:
- Derive PartialOrd and PartialEq for generated enums
- Reorder functions in cass_types to the same order as in spreadsheet.
- Reimplement cass_data_type_new - it's behaviour should depend on argument, as in cppdriver
- Add strlen helper function
- Implement missing variants of CassDataType
- Implement missing function of CassDataType - apart from is_frozen (I can't see a scenario where it returns true)
- CassDataType is now Arc, otherwise it's impossible to be semantically compatible with cppdriver.
- Overhaul of CassUserType (use macros to generate binding functions, binders for more values)