### PR TITLE
Implement CassTuples, improved binding macros

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -4,27 +4,27 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "arc-swap"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6df5aef5c5830360ce5218cecb8f018af3438af5686ae945094affc86fdec63"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "atty"
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -84,18 +84,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,9 +97,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cexpr"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
@@ -137,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
+checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
 dependencies = [
  "glob",
  "libc",
@@ -148,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -192,9 +180,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -204,16 +192,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -226,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -236,15 +218,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -253,18 +235,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -272,23 +252,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -298,8 +277,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -396,9 +373,9 @@ checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "libloading"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -433,9 +410,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -461,13 +444,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
- "bitvec",
- "funty",
  "memchr",
+ "minimal-lexical",
  "version_check",
 ]
 
@@ -650,9 +632,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-crate"
@@ -665,22 +647,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -693,12 +663,6 @@ checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -792,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -815,9 +779,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 
 [[package]]
 name = "scopeguard"
@@ -828,7 +792,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "scylla"
 version = "0.2.1"
-source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#73be705ad10f7edf7b54983eb7a18a61b3fd05af"
+source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#47d0d02e5df4c0dbe949a0f06f93689e423c5987"
 dependencies = [
  "arc-swap",
  "bigdecimal",
@@ -870,7 +834,7 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "0.1.1"
-source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#73be705ad10f7edf7b54983eb7a18a61b3fd05af"
+source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#47d0d02e5df4c0dbe949a0f06f93689e423c5987"
 dependencies = [
  "quote",
  "syn",
@@ -884,9 +848,9 @@ checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "itoa",
  "ryu",
@@ -934,20 +898,14 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -999,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1019,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1113,10 +1071,12 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
 dependencies = [
+ "either",
+ "lazy_static",
  "libc",
 ]
 
@@ -1159,9 +1119,3 @@ checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -88,6 +88,11 @@ macro_rules! make_appender {
     }
 }
 
+// TODO: Types for which binding is not implemented yet:
+// custom - Not implemented in Rust driver?
+// decimal
+// duration - DURATION not implemented in Rust Driver
+
 macro_rules! binders_maker_types {
     (null, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
         $macro_name!($this, $consume_v, $fn, || Ok(None), []);

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -1,0 +1,261 @@
+use crate::cass_types::CassDataType;
+use scylla::frame::response::result::CqlValue;
+
+pub fn is_compatible_type(_data_type: &CassDataType, _value: &Option<CqlValue>) -> bool {
+    // TODO: cppdriver actually checks types.
+    true
+}
+
+macro_rules! make_index_binder {
+    ($this:ty, $consume_v:expr, $fn_by_idx:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
+        #[no_mangle]
+        #[allow(clippy::redundant_closure_call)]
+        pub unsafe extern "C" fn $fn_by_idx(
+            this: *mut $this,
+            index: size_t,
+            $($arg: $t), *
+        ) -> CassError {
+            // For some reason detected as unused, which is not true
+            #[allow(unused_imports)]
+            use scylla::frame::response::result::CqlValue::*;
+            match ($e)($($arg), *) {
+                Ok(v) => $consume_v(ptr_to_ref_mut(this), index as usize, v),
+                Err(e) => e,
+            }
+        }
+    }
+}
+
+macro_rules! make_name_binder {
+    ($this:ty, $consume_v:expr, $fn_by_name:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
+        #[no_mangle]
+        #[allow(clippy::redundant_closure_call)]
+        pub unsafe extern "C" fn $fn_by_name(
+            this: *mut $this,
+            name: *const c_char,
+            $($arg: $t), *
+        ) -> CassError {
+            // For some reason detected as unused, which is not true
+            #[allow(unused_imports)]
+            use scylla::frame::response::result::CqlValue::*;
+            let name = ptr_to_cstr(name).unwrap();
+            match ($e)($($arg), *) {
+                Ok(v) => $consume_v(ptr_to_ref_mut(this), name, v),
+                Err(e) => e,
+            }
+        }
+    }
+}
+
+macro_rules! make_name_n_binder {
+    ($this:ty, $consume_v:expr, $fn_by_name_n:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
+        #[no_mangle]
+        #[allow(clippy::redundant_closure_call)]
+        pub unsafe extern "C" fn $fn_by_name_n(
+            this: *mut $this,
+            name: *const c_char,
+            name_length: size_t,
+            $($arg: $t), *
+        ) -> CassError {
+            // For some reason detected as unused, which is not true
+            #[allow(unused_imports)]
+            use scylla::frame::response::result::CqlValue::*;
+            let name = ptr_to_cstr_n(name, name_length).unwrap();
+            match ($e)($($arg), *) {
+                Ok(v) => $consume_v(ptr_to_ref_mut(this), name, v),
+                Err(e) => e,
+            }
+        }
+    }
+}
+
+macro_rules! binders_maker_types {
+    (null, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!($this, $consume_v, $fn, || Ok(None), []);
+    };
+    (int8, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(TinyInt(v))),
+            [v @ cass_int8_t]
+        );
+    };
+    (int16, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(SmallInt(v))),
+            [v @ cass_int16_t]
+        );
+    };
+    (int32, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Int(v))),
+            [v @ cass_int32_t]
+        );
+    };
+    (uint32, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Date(v))),
+            [v @ cass_uint32_t]
+        );
+    };
+    (int64, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(BigInt(v))),
+            [v @ cass_int64_t]
+        );
+    };
+    (float, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Float(v))),
+            [v @ cass_float_t]
+        );
+    };
+    (double, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Double(v))),
+            [v @ cass_double_t]
+        );
+    };
+    (bool, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Boolean(v != 0))),
+            [v @ cass_bool_t]
+        );
+    };
+    (string, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Text(ptr_to_cstr(v).unwrap().to_string()))),
+            [v @ *const std::os::raw::c_char]
+        );
+    };
+    (string_n, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v, n| Ok(Some(Text(ptr_to_cstr_n(v, n).unwrap().to_string()))),
+            [v @ *const std::os::raw::c_char, n @ size_t]
+        );
+    };
+    (bytes, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v, v_size| {
+                let v_vec = std::slice::from_raw_parts(v, v_size as usize).to_vec();
+                Ok(Some(Blob(v_vec)))
+            },
+            [v @ *const cass_byte_t, v_size @ size_t]
+        );
+    };
+    (uuid, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v: crate::uuid::CassUuid| Ok(Some(Uuid(v.into()))),
+            [v @ crate::uuid::CassUuid]
+        );
+    };
+    (inet, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v: crate::inet::CassInet| {
+                // Err if length in struct is invalid.
+                // cppdriver doesn't check this - it encodes any length given to it
+                // but it doesn't seem like something we wanna do. Also, rust driver can't
+                // really do it afaik.
+                match std::convert::TryInto::try_into(v) {
+                    Ok(v) => Ok(Some(Inet(v))),
+                    Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
+                }
+            },
+            [v @ crate::inet::CassInet]
+        );
+    };
+    (collection, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |p: *const crate::collection::CassCollection| {
+                match std::convert::TryInto::try_into(ptr_to_ref(p).clone()) {
+                    Ok(v) => Ok(Some(v)),
+                    Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
+                }
+            },
+            [p @ *const crate::collection::CassCollection]
+        );
+    };
+    (user_type, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |p: *const crate::user_type::CassUserType| Ok(Some(ptr_to_ref(p).into())),
+            [p @ *const crate::user_type::CassUserType]
+        );
+    };
+}
+
+macro_rules! prepare_binders_macro {
+    (@only_index $this:ty, $consume_v:expr) => {
+        macro_rules! make_binders {
+            ($t:ident, $fn:ident) => {
+                binders_maker_types!($t, make_index_binder, $this, $consume_v, $fn);
+            };
+        }
+    };
+    (@index_and_name $this:ty, $consume_v_idx:expr, $consume_v_name:expr) => {
+        macro_rules! make_binders {
+            ($t:ident, $fn_idx:ident, $fn_name:ident, $fn_name_n:ident) => {
+                binders_maker_types!($t, make_index_binder, $this, $consume_v_idx, $fn_idx);
+                binders_maker_types!($t, make_name_binder, $this, $consume_v_name, $fn_name);
+                binders_maker_types!($t, make_name_n_binder, $this, $consume_v_name, $fn_name_n);
+            };
+            ($t_idx:ident, $fn_idx:ident, $t_name:ident, $fn_name:ident, $t_name_n:ident, $fn_name_n:ident) => {
+                binders_maker_types!($t_idx, make_index_binder, $this, $consume_v_idx, $fn_idx);
+                binders_maker_types!($t_name, make_name_binder, $this, $consume_v_name, $fn_name);
+                binders_maker_types!($t_name_n, make_name_n_binder, $this, $consume_v_name, $fn_name_n);
+            };
+            (@index $t:ident, $fn_idx:ident) => {
+                binders_maker_types!($t, make_index_binder, $this, $consume_v_idx, $fn_idx);
+            };
+            (@name $t:ident, $fn_name:ident) => {
+                binders_maker_types!($t, make_name_binder, $this, $consume_v_name, $fn_name);
+            };
+            (@name_n $t:ident, $fn_name_n:ident) => {
+                binders_maker_types!($t, make_name_n_binder, $this, $consume_v_name, $fn_name_n);
+            };
+        }
+    };
+}

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -208,7 +208,7 @@ macro_rules! binders_maker_types {
             $consume_v,
             $fn,
             |p: *const crate::collection::CassCollection| {
-                match std::convert::TryInto::try_into(ptr_to_ref(p).clone()) {
+                match std::convert::TryInto::try_into(ptr_to_ref(p)) {
                     Ok(v) => Ok(Some(v)),
                     Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
                 }

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -216,6 +216,20 @@ macro_rules! binders_maker_types {
             [p @ *const crate::collection::CassCollection]
         );
     };
+    (tuple, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |p: *const crate::tuple::CassTuple| {
+                match std::convert::TryInto::try_into(ptr_to_ref(p)) {
+                    Ok(v) => Ok(Some(v)),
+                    Err(e) => Err(e),
+                }
+            },
+            [p @ *const crate::tuple::CassTuple]
+        );
+    };
     (user_type, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
         $macro_name!(
             $this,

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -147,12 +147,12 @@ pub unsafe extern "C" fn cass_collection_free(collection: *mut CassCollection) {
     free_boxed(collection);
 }
 
-impl TryFrom<CassCollection> for CqlValue {
+impl TryFrom<&CassCollection> for CqlValue {
     type Error = ();
-    fn try_from(collection: CassCollection) -> Result<Self, Self::Error> {
+    fn try_from(collection: &CassCollection) -> Result<Self, Self::Error> {
         // FIXME: validate that collection items are correct
         match collection.collection_type {
-            CassCollectionType::CASS_COLLECTION_TYPE_LIST => Ok(List(collection.items)),
+            CassCollectionType::CASS_COLLECTION_TYPE_LIST => Ok(List(collection.items.clone())),
             CassCollectionType::CASS_COLLECTION_TYPE_MAP => {
                 let mut grouped_items = Vec::new();
                 // FIXME: validate even number of items
@@ -165,7 +165,9 @@ impl TryFrom<CassCollection> for CqlValue {
 
                 Ok(Map(grouped_items))
             }
-            CassCollectionType::CASS_COLLECTION_TYPE_SET => Ok(CqlValue::Set(collection.items)),
+            CassCollectionType::CASS_COLLECTION_TYPE_SET => {
+                Ok(CqlValue::Set(collection.items.clone()))
+            }
             _ => Err(()),
         }
     }

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -4,7 +4,6 @@ use crate::types::*;
 use scylla::frame::response::result::CqlValue;
 use scylla::frame::response::result::CqlValue::*;
 use std::convert::TryFrom;
-use std::os::raw::c_char;
 
 include!(concat!(env!("OUT_DIR"), "/cppdriver_data_collection.rs"));
 
@@ -15,136 +14,13 @@ pub struct CassCollection {
     pub items: Vec<CqlValue>,
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_new(
-    collection_type: CassCollectionType,
-    item_count: size_t,
-) -> *mut CassCollection {
-    let capacity = match collection_type {
-        // Maps consist of a key and a value, so twice
-        // the number of CqlValue will be stored.
-        CassCollectionType::CASS_COLLECTION_TYPE_MAP => item_count * 2,
-        _ => item_count,
-    } as usize;
-
-    Box::into_raw(Box::new(CassCollection {
-        collection_type,
-        capacity,
-        items: Vec::with_capacity(capacity),
-    }))
-}
-
-unsafe fn cass_collection_append_cql_value(
-    collection_raw: *mut CassCollection,
-    value: CqlValue,
-) -> CassError {
-    // FIXME: Bounds check
-    let collection = ptr_to_ref_mut(collection_raw);
-    collection.items.push(value);
-
-    CassError::CASS_OK
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_int8(
-    collection: *mut CassCollection,
-    value: cass_int8_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, TinyInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_int16(
-    collection: *mut CassCollection,
-    value: cass_int16_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, SmallInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_int32(
-    collection: *mut CassCollection,
-    value: cass_int32_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, Int(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_uint32(
-    collection: *mut CassCollection,
-    value: cass_uint32_t,
-) -> CassError {
-    // cass_collection_append_uint32 is only used to set a DATE.
-    cass_collection_append_cql_value(collection, Date(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_int64(
-    collection: *mut CassCollection,
-    value: cass_int64_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, BigInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_float(
-    collection: *mut CassCollection,
-    value: cass_float_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, Float(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_double(
-    collection: *mut CassCollection,
-    value: cass_double_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, Double(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_bool(
-    collection: *mut CassCollection,
-    value: cass_bool_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, Boolean(value != 0))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_string(
-    collection: *mut CassCollection,
-    value: *const c_char,
-) -> CassError {
-    let value_str = ptr_to_cstr(value).unwrap();
-    let value_length = value_str.len();
-
-    cass_collection_append_string_n(collection, value, value_length as size_t)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_string_n(
-    collection: *mut CassCollection,
-    value: *const c_char,
-    value_length: size_t,
-) -> CassError {
-    // TODO: Error handling
-    let value_string = ptr_to_cstr_n(value, value_length).unwrap().to_string();
-    cass_collection_append_cql_value(collection, Text(value_string))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_bytes(
-    collection: *mut CassCollection,
-    value: *const cass_byte_t,
-    value_size: size_t,
-) -> CassError {
-    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
-    cass_collection_append_cql_value(collection, Blob(value_vec))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_free(collection: *mut CassCollection) {
-    free_boxed(collection);
+impl CassCollection {
+    pub fn append_cql_value(&mut self, value: Option<CqlValue>) -> CassError {
+        // FIXME: Bounds check, type check
+        // There is no API to append null, so unwrap is safe
+        self.items.push(value.unwrap());
+        CassError::CASS_OK
+    }
 }
 
 impl TryFrom<&CassCollection> for CqlValue {
@@ -172,3 +48,40 @@ impl TryFrom<&CassCollection> for CqlValue {
         }
     }
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_collection_new(
+    collection_type: CassCollectionType,
+    item_count: size_t,
+) -> *mut CassCollection {
+    let capacity = match collection_type {
+        // Maps consist of a key and a value, so twice
+        // the number of CqlValue will be stored.
+        CassCollectionType::CASS_COLLECTION_TYPE_MAP => item_count * 2,
+        _ => item_count,
+    } as usize;
+
+    Box::into_raw(Box::new(CassCollection {
+        collection_type,
+        capacity,
+        items: Vec::with_capacity(capacity),
+    }))
+}
+
+prepare_binders_macro!(@append CassCollection, |collection: &mut CassCollection, v| collection.append_cql_value(v));
+make_binders!(int8, cass_collection_append_int8);
+make_binders!(int16, cass_collection_append_int16);
+make_binders!(int32, cass_collection_append_int32);
+make_binders!(uint32, cass_collection_append_uint32);
+make_binders!(int64, cass_collection_append_int64);
+make_binders!(float, cass_collection_append_float);
+make_binders!(double, cass_collection_append_double);
+make_binders!(bool, cass_collection_append_bool);
+make_binders!(string, cass_collection_append_string);
+make_binders!(string_n, cass_collection_append_string_n);
+make_binders!(bytes, cass_collection_append_bytes);
+make_binders!(uuid, cass_collection_append_uuid);
+make_binders!(inet, cass_collection_append_inet);
+make_binders!(collection, cass_collection_append_collection);
+make_binders!(tuple, cass_collection_append_tuple);
+make_binders!(user_type, cass_collection_append_user_type);

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -16,6 +16,7 @@ pub mod query_error;
 pub mod query_result;
 pub mod session;
 pub mod statement;
+pub mod tuple;
 pub mod types;
 pub mod user_type;
 pub mod uuid;

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -2,6 +2,8 @@
 use lazy_static::lazy_static;
 use tokio::runtime::Runtime;
 
+#[macro_use]
+mod binding;
 mod argconv;
 pub mod cass_error;
 pub mod cass_types;

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -317,7 +317,7 @@ make_binders!(
     cass_statement_bind_collection_by_name_n,
     *const CassCollection,
     |p: *const CassCollection| {
-        match ptr_to_ref(p).clone().try_into() {
+        match ptr_to_ref(p).try_into() {
             Ok(v) => Ok(v),
             Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
         }

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -1,20 +1,14 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
-use crate::collection::CassCollection;
-use crate::inet::CassInet;
 use crate::query_result::CassResult;
 use crate::types::*;
-use crate::user_type::CassUserType;
-use crate::uuid::CassUuid;
 use scylla::frame::response::result::CqlValue;
-use scylla::frame::response::result::CqlValue::*;
 use scylla::frame::types::Consistency;
 use scylla::frame::value::MaybeUnset;
 use scylla::frame::value::MaybeUnset::{Set, Unset};
 use scylla::query::Query;
 use scylla::statement::prepared_statement::PreparedStatement;
 use scylla::Bytes;
-use std::convert::TryInto;
 use std::os::raw::{c_char, c_int};
 use std::sync::Arc;
 
@@ -29,6 +23,31 @@ pub struct CassStatement {
     pub statement: Statement,
     pub bound_values: Vec<MaybeUnset<Option<CqlValue>>>,
     pub paging_state: Option<Bytes>,
+}
+
+impl CassStatement {
+    fn bind_cql_value(&mut self, index: usize, value: Option<CqlValue>) -> CassError {
+        if index as usize >= self.bound_values.len() {
+            CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS
+        } else {
+            self.bound_values[index] = Set(value);
+            CassError::CASS_OK
+        }
+    }
+
+    fn bind_cql_value_by_name(&mut self, name: &str, value: Option<CqlValue>) -> CassError {
+        match &self.statement {
+            Statement::Prepared(prepared) => {
+                for (i, col) in prepared.get_metadata().col_specs.iter().enumerate() {
+                    if col.name == name {
+                        return self.bind_cql_value(i, value);
+                    }
+                }
+                CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST
+            }
+            Statement::Simple(_) => CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST,
+        }
+    }
 }
 
 #[no_mangle]
@@ -69,382 +88,9 @@ pub unsafe extern "C" fn cass_statement_new_n(
     }))
 }
 
-// TODO: Bind methods currently not implemented:
-// cass_statement_bind_decimal
-//
-// cass_statement_bind_duration - DURATION not implemented in Rust Driver
-//
-// (methods requiring implementing cpp driver data structures)
-// cass_statement_bind_custom
-// cass_statement_bind_custom_n
-// cass_statement_bind_tuple
-
-unsafe fn cass_statement_bind_maybe_unset(
-    statement_raw: *mut CassStatement,
-    index: size_t,
-    value: MaybeUnset<Option<CqlValue>>,
-) -> CassError {
-    let statement = ptr_to_ref_mut(statement_raw);
-
-    if index as usize >= statement.bound_values.len() {
-        CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS
-    } else {
-        statement.bound_values[index as usize] = value;
-        CassError::CASS_OK
-    }
-}
-
-unsafe fn cass_statement_bind_maybe_unset_by_name(
-    statement: *mut CassStatement,
-    name: *const c_char,
-    value: MaybeUnset<Option<CqlValue>>,
-) -> CassError {
-    let name_str = ptr_to_cstr(name).unwrap();
-    let name_length = name_str.len();
-
-    cass_statement_bind_maybe_unset_by_name_n(statement, name, name_length as size_t, value)
-}
-
-unsafe fn cass_statement_bind_maybe_unset_by_name_n(
-    statement_raw: *mut CassStatement,
-    name: *const c_char,
-    name_length: size_t,
-    value: MaybeUnset<Option<CqlValue>>,
-) -> CassError {
-    let name_str = ptr_to_cstr_n(name, name_length).unwrap();
-    let statement = &ptr_to_ref_mut(statement_raw).statement;
-
-    match &statement {
-        Statement::Prepared(prepared) => {
-            for (i, col) in prepared.get_metadata().col_specs.iter().enumerate() {
-                if col.name == name_str {
-                    return cass_statement_bind_maybe_unset(statement_raw, i as size_t, value);
-                }
-            }
-            CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST
-        }
-        Statement::Simple(_) => CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST,
-    }
-}
-
-unsafe fn cass_statement_bind_cql_value(
-    statement: *mut CassStatement,
-    index: size_t,
-    value: CqlValue,
-) -> CassError {
-    cass_statement_bind_maybe_unset(statement, index, Set(Some(value)))
-}
-
-unsafe fn cass_statement_bind_cql_value_by_name(
-    statement: *mut CassStatement,
-    name: *const c_char,
-    value: CqlValue,
-) -> CassError {
-    cass_statement_bind_maybe_unset_by_name(statement, name, Set(Some(value)))
-}
-
-unsafe fn cass_statement_bind_cql_value_by_name_n(
-    statement: *mut CassStatement,
-    name: *const c_char,
-    name_length: size_t,
-    value: CqlValue,
-) -> CassError {
-    cass_statement_bind_maybe_unset_by_name_n(statement, name, name_length, Set(Some(value)))
-}
-
 #[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_null(
-    statement: *mut CassStatement,
-    index: size_t,
-) -> CassError {
-    cass_statement_bind_maybe_unset(statement, index, Set(None))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_null_by_name(
-    statement: *mut CassStatement,
-    name: *const c_char,
-) -> CassError {
-    cass_statement_bind_maybe_unset_by_name(statement, name, Set(None))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_null_by_name_n(
-    statement: *mut CassStatement,
-    name: *const c_char,
-    name_length: size_t,
-) -> CassError {
-    cass_statement_bind_maybe_unset_by_name_n(statement, name, name_length, Set(None))
-}
-
-macro_rules! make_binders {
-    ($fn_by_idx:ident, $fn_by_name:ident, $fn_by_name_n:ident, $t:ty, $e:expr) => {
-        #[no_mangle]
-        #[allow(clippy::redundant_closure_call)]
-        pub unsafe extern "C" fn $fn_by_idx(
-            statement: *mut CassStatement,
-            index: size_t,
-            value: $t,
-        ) -> CassError {
-            match ($e)(value) {
-                Ok(v) => cass_statement_bind_cql_value(statement, index, v),
-                Err(e) => e,
-            }
-        }
-
-        #[no_mangle]
-        #[allow(clippy::redundant_closure_call)]
-        pub unsafe extern "C" fn $fn_by_name(
-            statement: *mut CassStatement,
-            name: *const c_char,
-            value: $t,
-        ) -> CassError {
-            match ($e)(value) {
-                Ok(v) => cass_statement_bind_cql_value_by_name(statement, name, v),
-                Err(e) => e,
-            }
-        }
-
-        #[no_mangle]
-        #[allow(clippy::redundant_closure_call)]
-        pub unsafe extern "C" fn $fn_by_name_n(
-            statement: *mut CassStatement,
-            name: *const c_char,
-            name_length: size_t,
-            value: $t,
-        ) -> CassError {
-            match ($e)(value) {
-                Ok(v) => cass_statement_bind_cql_value_by_name_n(statement, name, name_length, v),
-                Err(e) => e,
-            }
-        }
-    };
-}
-
-make_binders!(
-    cass_statement_bind_int8,
-    cass_statement_bind_int8_by_name,
-    cass_statement_bind_int8_by_name_n,
-    cass_int8_t,
-    |v| Ok(TinyInt(v))
-);
-
-make_binders!(
-    cass_statement_bind_int16,
-    cass_statement_bind_int16_by_name,
-    cass_statement_bind_int16_by_name_n,
-    cass_int16_t,
-    |v| Ok(SmallInt(v))
-);
-
-make_binders!(
-    cass_statement_bind_int32,
-    cass_statement_bind_int32_by_name,
-    cass_statement_bind_int32_by_name_n,
-    cass_int32_t,
-    |v| Ok(Int(v))
-);
-
-// cass_statement_bind_uint32 is only used to set a DATE.
-make_binders!(
-    cass_statement_bind_uint32,
-    cass_statement_bind_uint32_by_name,
-    cass_statement_bind_uint32_by_name_n,
-    cass_uint32_t,
-    |v| Ok(Date(v))
-);
-
-make_binders!(
-    cass_statement_bind_int64,
-    cass_statement_bind_int64_by_name,
-    cass_statement_bind_int64_by_name_n,
-    cass_int64_t,
-    |v| Ok(BigInt(v))
-);
-
-make_binders!(
-    cass_statement_bind_float,
-    cass_statement_bind_float_by_name,
-    cass_statement_bind_float_by_name_n,
-    cass_float_t,
-    |v| Ok(Float(v))
-);
-
-make_binders!(
-    cass_statement_bind_double,
-    cass_statement_bind_double_by_name,
-    cass_statement_bind_double_by_name_n,
-    cass_double_t,
-    |v| Ok(Double(v))
-);
-
-make_binders!(
-    cass_statement_bind_bool,
-    cass_statement_bind_bool_by_name,
-    cass_statement_bind_bool_by_name_n,
-    cass_bool_t,
-    |v| Ok(Boolean(v != 0))
-);
-
-make_binders!(
-    cass_statement_bind_inet,
-    cass_statement_bind_inet_by_name,
-    cass_statement_bind_inet_by_name_n,
-    CassInet,
-    |v: CassInet| {
-        // Err if length in struct is invalid.
-        // cppdriver doesn't check this - it encodes any length given to it
-        // but it doesn't seem like something we wanna do. Also, rust driver can't
-        // really do it afaik.
-        match v.try_into() {
-            Ok(v) => Ok(Inet(v)),
-            Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
-        }
-    }
-);
-
-make_binders!(
-    cass_statement_bind_uuid,
-    cass_statement_bind_uuid_by_name,
-    cass_statement_bind_uuid_by_name_n,
-    CassUuid,
-    |v: CassUuid| Ok(Uuid(v.into()))
-);
-
-make_binders!(
-    cass_statement_bind_collection,
-    cass_statement_bind_collection_by_name,
-    cass_statement_bind_collection_by_name_n,
-    *const CassCollection,
-    |p: *const CassCollection| {
-        match ptr_to_ref(p).try_into() {
-            Ok(v) => Ok(v),
-            Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
-        }
-    }
-);
-
-// The following four functions cannot be realized with make_binders!
-// because of the string length for the value
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_string(
-    statement: *mut CassStatement,
-    index: size_t,
-    value: *const c_char,
-) -> CassError {
-    let value_str = ptr_to_cstr(value).unwrap();
-    let value_length = value_str.len();
-
-    cass_statement_bind_string_n(statement, index, value, value_length as size_t)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_string_by_name(
-    statement: *mut CassStatement,
-    name: *const c_char,
-    value: *const c_char,
-) -> CassError {
-    let value_str = ptr_to_cstr(value).unwrap();
-    let value_length = value_str.len();
-
-    let name_str = ptr_to_cstr(name).unwrap();
-    let name_length = name_str.len();
-
-    cass_statement_bind_string_by_name_n(
-        statement,
-        name,
-        name_length as size_t,
-        value,
-        value_length as size_t,
-    )
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_string_n(
-    statement: *mut CassStatement,
-    index: size_t,
-    value: *const c_char,
-    value_length: size_t,
-) -> CassError {
-    // TODO: Error handling
-    let value_string = ptr_to_cstr_n(value, value_length).unwrap().to_string();
-    cass_statement_bind_cql_value(statement, index, Text(value_string))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_string_by_name_n(
-    statement: *mut CassStatement,
-    name: *const c_char,
-    name_length: size_t,
-    value: *const c_char,
-    value_length: size_t,
-) -> CassError {
-    // TODO: Error handling
-    let value_string = ptr_to_cstr_n(value, value_length).unwrap().to_string();
-    cass_statement_bind_cql_value_by_name_n(statement, name, name_length, Text(value_string))
-}
-
-// The following three functions cannot be realized with make_binders!
-// because of the bytes length for the value
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_bytes(
-    statement: *mut CassStatement,
-    index: size_t,
-    value: *const cass_byte_t,
-    value_size: size_t,
-) -> CassError {
-    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
-    cass_statement_bind_cql_value(statement, index, Blob(value_vec))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_bytes_by_name(
-    statement: *mut CassStatement,
-    name: *const c_char,
-    value: *const cass_byte_t,
-    value_size: size_t,
-) -> CassError {
-    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
-    cass_statement_bind_cql_value_by_name(statement, name, Blob(value_vec))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_bytes_by_name_n(
-    statement: *mut CassStatement,
-    name: *const c_char,
-    name_length: size_t,
-    value: *const cass_byte_t,
-    value_size: size_t,
-) -> CassError {
-    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
-    cass_statement_bind_cql_value_by_name_n(statement, name, name_length, Blob(value_vec))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_bind_user_type(
-    statement: *mut CassStatement,
-    index: size_t,
-    user_type_raw: *const CassUserType,
-) -> CassError {
-    // FIXME: implement _by_name and _by_name_n variants
-    let user_type = ptr_to_ref(user_type_raw);
-
-    cass_statement_bind_cql_value(statement, index, user_type.into())
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_set_tracing(
-    statement_raw: *mut CassStatement,
-    enabled: cass_bool_t,
-) -> CassError {
-    match &mut ptr_to_ref_mut(statement_raw).statement {
-        Statement::Simple(inner) => inner.set_tracing(enabled != 0),
-        Statement::Prepared(inner) => Arc::make_mut(inner).set_tracing(enabled != 0),
-    }
-
-    CassError::CASS_OK
+pub unsafe extern "C" fn cass_statement_free(statement_raw: *mut CassStatement) {
+    free_boxed(statement_raw);
 }
 
 #[no_mangle]
@@ -499,6 +145,115 @@ pub unsafe extern "C" fn cass_statement_set_is_idempotent(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_statement_free(statement_raw: *mut CassStatement) {
-    free_boxed(statement_raw);
+pub unsafe extern "C" fn cass_statement_set_tracing(
+    statement_raw: *mut CassStatement,
+    enabled: cass_bool_t,
+) -> CassError {
+    match &mut ptr_to_ref_mut(statement_raw).statement {
+        Statement::Simple(inner) => inner.set_tracing(enabled != 0),
+        Statement::Prepared(inner) => Arc::make_mut(inner).set_tracing(enabled != 0),
+    }
+
+    CassError::CASS_OK
 }
+
+prepare_binders_macro!(@index_and_name CassStatement,
+    |s: &mut CassStatement, idx, v| s.bind_cql_value(idx, v),
+    |s: &mut CassStatement, name, v| s.bind_cql_value_by_name(name, v));
+make_binders!(
+    null,
+    cass_statement_bind_null,
+    cass_statement_bind_null_by_name,
+    cass_statement_bind_null_by_name_n
+);
+make_binders!(
+    int8,
+    cass_statement_bind_int8,
+    cass_statement_bind_int8_by_name,
+    cass_statement_bind_int8_by_name_n
+);
+make_binders!(
+    int16,
+    cass_statement_bind_int16,
+    cass_statement_bind_int16_by_name,
+    cass_statement_bind_int16_by_name_n
+);
+make_binders!(
+    int32,
+    cass_statement_bind_int32,
+    cass_statement_bind_int32_by_name,
+    cass_statement_bind_int32_by_name_n
+);
+make_binders!(
+    uint32,
+    cass_statement_bind_uint32,
+    cass_statement_bind_uint32_by_name,
+    cass_statement_bind_uint32_by_name_n
+);
+make_binders!(
+    int64,
+    cass_statement_bind_int64,
+    cass_statement_bind_int64_by_name,
+    cass_statement_bind_int64_by_name_n
+);
+make_binders!(
+    float,
+    cass_statement_bind_float,
+    cass_statement_bind_float_by_name,
+    cass_statement_bind_float_by_name_n
+);
+make_binders!(
+    double,
+    cass_statement_bind_double,
+    cass_statement_bind_double_by_name,
+    cass_statement_bind_double_by_name_n
+);
+make_binders!(
+    bool,
+    cass_statement_bind_bool,
+    cass_statement_bind_bool_by_name,
+    cass_statement_bind_bool_by_name_n
+);
+make_binders!(
+    string,
+    cass_statement_bind_string,
+    cass_statement_bind_string_by_name,
+    cass_statement_bind_string_by_name_n
+);
+make_binders!(@index string_n, cass_statement_bind_string_n);
+make_binders!(
+    bytes,
+    cass_statement_bind_bytes,
+    cass_statement_bind_bytes_by_name,
+    cass_statement_bind_bytes_by_name_n
+);
+make_binders!(
+    uuid,
+    cass_statement_bind_uuid,
+    cass_statement_bind_uuid_by_name,
+    cass_statement_bind_uuid_by_name_n
+);
+make_binders!(
+    inet,
+    cass_statement_bind_inet,
+    cass_statement_bind_inet_by_name,
+    cass_statement_bind_inet_by_name_n
+);
+make_binders!(
+    collection,
+    cass_statement_bind_collection,
+    cass_statement_bind_collection_by_name,
+    cass_statement_bind_collection_by_name_n
+);
+make_binders!(
+    tuple,
+    cass_statement_bind_tuple,
+    cass_statement_bind_tuple_by_name,
+    cass_statement_bind_tuple_by_name_n
+);
+make_binders!(
+    user_type,
+    cass_statement_bind_user_type,
+    cass_statement_bind_user_type_by_name,
+    cass_statement_bind_user_type_by_name_n
+);

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -1,0 +1,92 @@
+use crate::argconv::*;
+use crate::binding;
+use crate::cass_error::CassError;
+use crate::cass_types::CassDataType;
+use crate::cass_types::CassDataTypeArc;
+use crate::types::*;
+use scylla::frame::response::result::CqlValue;
+use scylla::frame::value::MaybeUnset;
+use scylla::frame::value::MaybeUnset::{Set, Unset};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct CassTuple {
+    pub data_type: CassDataTypeArc,
+    pub items: Vec<MaybeUnset<Option<CqlValue>>>,
+}
+
+impl CassTuple {
+    fn get_types(&self) -> &Vec<CassDataTypeArc> {
+        match *self.data_type {
+            CassDataType::Tuple(ref v) => v,
+            _ => unreachable!(),
+        }
+    }
+
+    fn bind_value(&mut self, index: usize, v: Option<CqlValue>) -> CassError {
+        if index >= self.items.len() {
+            return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
+        }
+
+        let inner_types = self.get_types();
+        if inner_types.len() > index && !binding::is_compatible_type(&inner_types[index], &v) {
+            return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
+        }
+
+        self.items[index] = Set(v);
+
+        CassError::CASS_OK
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_tuple_new(item_count: size_t) -> *mut CassTuple {
+    Box::into_raw(Box::new(CassTuple {
+        data_type: Arc::new(CassDataType::Tuple(Vec::new())),
+        items: vec![Unset; item_count as usize],
+    }))
+}
+
+#[no_mangle]
+unsafe extern "C" fn cass_tuple_new_from_data_type(
+    data_type: *const CassDataType,
+) -> *mut CassTuple {
+    let data_type = clone_arced(data_type);
+    let item_count = match &*data_type {
+        CassDataType::Tuple(v) => v.len(),
+        // TODO: I think cppdriver doesn't return error here, but maybe we should?
+        _ => panic!("Invalid data type passed to tuple!"),
+    };
+    Box::into_raw(Box::new(CassTuple {
+        data_type,
+        items: vec![Unset; item_count],
+    }))
+}
+
+#[no_mangle]
+unsafe extern "C" fn cass_tuple_free(tuple: *mut CassTuple) {
+    free_boxed(tuple)
+}
+
+#[no_mangle]
+unsafe extern "C" fn cass_tuple_data_type(tuple: *const CassTuple) -> *const CassDataType {
+    Arc::as_ptr(&ptr_to_ref(tuple).data_type)
+}
+
+prepare_binders_macro!(@only_index CassTuple, |tuple: &mut CassTuple, index, v| tuple.bind_value(index, v));
+make_binders!(null, cass_tuple_set_null);
+make_binders!(int8, cass_tuple_set_int8);
+make_binders!(int16, cass_tuple_set_int16);
+make_binders!(int32, cass_tuple_set_int32);
+make_binders!(uint32, cass_tuple_set_uint32);
+make_binders!(int64, cass_tuple_set_int64);
+make_binders!(float, cass_tuple_set_float);
+make_binders!(double, cass_tuple_set_double);
+make_binders!(bool, cass_tuple_set_bool);
+make_binders!(string, cass_tuple_set_string);
+make_binders!(string_n, cass_tuple_set_string_n);
+make_binders!(bytes, cass_tuple_set_bytes);
+make_binders!(uuid, cass_tuple_set_uuid);
+make_binders!(inet, cass_tuple_set_inet);
+make_binders!(collection, cass_tuple_set_collection);
+make_binders!(user_type, cass_tuple_set_user_type);

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -3,13 +3,8 @@ use crate::binding::is_compatible_type;
 use crate::cass_error::CassError;
 use crate::cass_types::CassDataType;
 use crate::cass_types::{CassDataTypeArc, UDTDataType};
-use crate::collection::CassCollection;
-use crate::inet::CassInet;
 use crate::types::*;
-use crate::uuid::CassUuid;
 use scylla::frame::response::result::CqlValue;
-use scylla::frame::response::result::CqlValue::*;
-use std::convert::TryInto;
 use std::os::raw::c_char;
 use std::sync::Arc;
 
@@ -108,203 +103,106 @@ pub unsafe extern "C" fn cass_user_type_data_type(
     Arc::as_ptr(&ptr_to_ref(user_type).data_type)
 }
 
-macro_rules! make_binders {
-    (@index $fn_by_idx:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
-        #[no_mangle]
-        #[allow(clippy::redundant_closure_call)]
-        pub unsafe extern "C" fn $fn_by_idx(
-            user_type: *mut CassUserType,
-            index: size_t,
-            $($arg: $t), *
-        ) -> CassError {
-            match ($e)($($arg), *) {
-                Ok(v) => ptr_to_ref_mut(user_type).set_option_by_index(index as usize, v),
-                Err(e) => e,
-            }
-        }
-    };
-    (@name $fn_by_name:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
-        #[no_mangle]
-        #[allow(clippy::redundant_closure_call)]
-        pub unsafe extern "C" fn $fn_by_name(
-            user_type: *mut CassUserType,
-            name: *const c_char,
-            $($arg: $t), *
-        ) -> CassError {
-            let name = ptr_to_cstr(name).unwrap();
-            match ($e)($($arg), *) {
-                Ok(v) => ptr_to_ref_mut(user_type).set_option_by_name(name, v),
-                Err(e) => e,
-            }
-        }
-    };
-    (@name_n $fn_by_name_n:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
-        #[no_mangle]
-        #[allow(clippy::redundant_closure_call)]
-        pub unsafe extern "C" fn $fn_by_name_n(
-            user_type: *mut CassUserType,
-            name: *const c_char,
-            name_length: size_t,
-            $($arg: $t), *
-        ) -> CassError {
-            let name = ptr_to_cstr_n(name, name_length).unwrap();
-            match ($e)($($arg), *) {
-                Ok(v) => ptr_to_ref_mut(user_type).set_option_by_name(name, v),
-                Err(e) => e,
-            }
-        }
-    };
-    (@multi $m_fn_by_idx:ident, $m_fn_by_name:ident, $m_fn_by_name_n:ident,
-        $e1:expr, [$($arg1:ident @ $t1:ty), *],
-        $e2:expr, [$($arg2:ident @ $t2:ty), *],
-        $e3:expr, [$($arg3:ident @ $t3:ty), *]) => {
-            make_binders!(@index $m_fn_by_idx, $e1, [$($arg1 @ $t1), *]);
-            make_binders!(@name $m_fn_by_name, $e2, [$($arg2 @ $t2), *]);
-            make_binders!(@name_n $m_fn_by_name_n, $e3, [$($arg3 @ $t3), *]);
-    };
-
-    ($fn_by_idx:ident, $fn_by_name:ident, $fn_by_name_n:ident, $e:expr, $($arg:ident @ $t:ty), *) => {
-        make_binders!(@multi $fn_by_idx, $fn_by_name, $fn_by_name_n, $e, [$($arg @ $t), *], $e, [$($arg @ $t), *], $e, [$($arg @ $t), *]);
-    }
-}
+prepare_binders_macro!(@index_and_name CassUserType, 
+    |udt: &mut CassUserType, index, v| udt.set_option_by_index(index, v), 
+    |udt: &mut CassUserType, name, v| udt.set_option_by_name(name, v));
 
 make_binders!(
+    null,
     cass_user_type_set_null,
     cass_user_type_set_null_by_name,
-    cass_user_type_set_null_by_name_n,
-    || Ok(None),
+    cass_user_type_set_null_by_name_n
 );
-
 make_binders!(
+    int8,
     cass_user_type_set_int8,
     cass_user_type_set_int8_by_name,
-    cass_user_type_set_int8_by_name_n,
-    |v| Ok(Some(TinyInt(v))),
-    v @ cass_int8_t
+    cass_user_type_set_int8_by_name_n
 );
-
 make_binders!(
+    int16,
     cass_user_type_set_int16,
     cass_user_type_set_int16_by_name,
-    cass_user_type_set_int16_by_name_n,
-    |v| Ok(Some(SmallInt(v))),
-    v @ cass_int16_t
+    cass_user_type_set_int16_by_name_n
 );
-
 make_binders!(
+    int32,
     cass_user_type_set_int32,
     cass_user_type_set_int32_by_name,
-    cass_user_type_set_int32_by_name_n,
-    |v| Ok(Some(Int(v))),
-    v @ cass_int32_t
+    cass_user_type_set_int32_by_name_n
 );
-
 make_binders!(
+    uint32,
     cass_user_type_set_uint32,
     cass_user_type_set_uint32_by_name,
-    cass_user_type_set_uint32_by_name_n,
-    |v| Ok(Some(Date(v))),
-    v @ cass_uint32_t
+    cass_user_type_set_uint32_by_name_n
 );
-
 make_binders!(
+    int64,
     cass_user_type_set_int64,
     cass_user_type_set_int64_by_name,
-    cass_user_type_set_int64_by_name_n,
-    |v| Ok(Some(BigInt(v))),
-    v @ cass_int64_t
+    cass_user_type_set_int64_by_name_n
 );
-
 make_binders!(
+    float,
     cass_user_type_set_float,
     cass_user_type_set_float_by_name,
-    cass_user_type_set_float_by_name_n,
-    |v| Ok(Some(Float(v))),
-    v @ cass_float_t
+    cass_user_type_set_float_by_name_n
 );
-
 make_binders!(
+    double,
     cass_user_type_set_double,
     cass_user_type_set_double_by_name,
-    cass_user_type_set_double_by_name_n,
-    |v| Ok(Some(Double(v))),
-    v @ cass_double_t
+    cass_user_type_set_double_by_name_n
 );
-
 make_binders!(
+    bool,
     cass_user_type_set_bool,
     cass_user_type_set_bool_by_name,
-    cass_user_type_set_bool_by_name_n,
-    |v| Ok(Some(Boolean(v != 0))),
-    v @ cass_bool_t
+    cass_user_type_set_bool_by_name_n
 );
-
-make_binders!(@multi
-    cass_user_type_set_string,
-    cass_user_type_set_string_by_name,
-    cass_user_type_set_string_by_name_n,
-    |v| Ok(Some(Text(ptr_to_cstr(v).unwrap().to_string()))),
-    [v @ *const c_char],
-    |v| Ok(Some(Text(ptr_to_cstr(v).unwrap().to_string()))),
-    [v @ *const c_char],
-    |v, n| Ok(Some(Text(ptr_to_cstr_n(v, n).unwrap().to_string()))),
-    [v @ *const c_char, n @ size_t]
-);
-
 make_binders!(
+    string,
+    cass_user_type_set_string,
+    string_n,
+    cass_user_type_set_string_by_name,
+    string_n,
+    cass_user_type_set_string_by_name_n
+);
+make_binders!(@index string_n, cass_user_type_set_string_n);
+make_binders!(
+    bytes,
     cass_user_type_set_bytes,
     cass_user_type_set_bytes_by_name,
-    cass_user_type_set_bytes_by_name_n,
-    |v, v_size| {
-        let v_vec = std::slice::from_raw_parts(v, v_size as usize).to_vec();
-        Ok(Some(Blob(v_vec)))
-    },
-    v @ *const cass_byte_t,
-    v_size @ size_t
+    cass_user_type_set_bytes_by_name_n
 );
-
 make_binders!(
+    uuid,
     cass_user_type_set_uuid,
     cass_user_type_set_uuid_by_name,
-    cass_user_type_set_uuid_by_name_n,
-    |v: CassUuid| Ok(Some(Uuid(v.into()))),
-    v @ CassUuid
+    cass_user_type_set_uuid_by_name_n
 );
-
 make_binders!(
+    inet,
     cass_user_type_set_inet,
     cass_user_type_set_inet_by_name,
-    cass_user_type_set_inet_by_name_n,
-    |v: CassInet| {
-        // Err if length in struct is invalid.
-        // cppdriver doesn't check this - it encodes any length given to it
-        // but it doesn't seem like something we wanna do. Also, rust driver can't
-        // really do it afaik.
-        match v.try_into() {
-            Ok(v) => Ok(Some(Inet(v))),
-            Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
-        }
-    },
-    v @ CassInet
+    cass_user_type_set_inet_by_name_n
 );
-
 make_binders!(
+    collection,
     cass_user_type_set_collection,
     cass_user_type_set_collection_by_name,
-    cass_user_type_set_collection_by_name_n,
-    |p: *const CassCollection| {
-        match ptr_to_ref(p).try_into() {
-            Ok(v) => Ok(Some(v)),
-            Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
-        }
-    },
-    p @ *const CassCollection
+    cass_user_type_set_collection_by_name_n
 );
-
 make_binders!(
+    tuple,
+    cass_user_type_set_tuple,
+    cass_user_type_set_tuple_by_name,
+    cass_user_type_set_tuple_by_name_n
+);
+make_binders!(
+    user_type,
     cass_user_type_set_user_type,
     cass_user_type_set_user_type_by_name,
-    cass_user_type_set_user_type_by_name_n,
-    |p: *const CassUserType| Ok(Some(ptr_to_ref(p).into())),
-    p @ *const CassUserType
+    cass_user_type_set_user_type_by_name_n
 );

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -293,7 +293,7 @@ make_binders!(
     cass_user_type_set_collection_by_name,
     cass_user_type_set_collection_by_name_n,
     |p: *const CassCollection| {
-        match ptr_to_ref(p).clone().try_into() {
+        match ptr_to_ref(p).try_into() {
             Ok(v) => Ok(Some(v)),
             Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
         }

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -1,4 +1,5 @@
 use crate::argconv::*;
+use crate::binding::is_compatible_type;
 use crate::cass_error::CassError;
 use crate::cass_types::CassDataType;
 use crate::cass_types::{CassDataTypeArc, UDTDataType};
@@ -18,12 +19,6 @@ pub struct CassUserType {
 
     // Vec to preserve the order of fields
     pub field_values: Vec<Option<CqlValue>>,
-}
-
-fn is_compatible_type(_data_type: &CassDataType, _value: &Option<CqlValue>) -> bool {
-    // TODO: cppdriver actually checks types.
-    // TODO: this function should probably somewhere else
-    true
 }
 
 impl CassUserType {
@@ -248,8 +243,8 @@ make_binders!(@multi
     cass_user_type_set_string,
     cass_user_type_set_string_by_name,
     cass_user_type_set_string_by_name_n,
-    |v, n| Ok(Some(Text(ptr_to_cstr_n(v, n).unwrap().to_string()))),
-    [v @ *const c_char, n @ size_t],
+    |v| Ok(Some(Text(ptr_to_cstr(v).unwrap().to_string()))),
+    [v @ *const c_char],
     |v| Ok(Some(Text(ptr_to_cstr(v).unwrap().to_string()))),
     [v @ *const c_char],
     |v, n| Ok(Some(Text(ptr_to_cstr_n(v, n).unwrap().to_string()))),


### PR DESCRIPTION
1. Implemented CassTuple and all associated functions.
2. Created new macros that replace old version of `make_binders` - with the new version we can be sure that binding to each structure works the same (there is no code repetition), the code is shorter and less error-prone. 