### PR TITLE
Refactor binding

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -367,9 +367,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "libloading"
@@ -821,6 +821,7 @@ version = "0.0.1"
 dependencies = [
  "bindgen",
  "lazy_static",
+ "libc",
  "machine-uid",
  "num-derive",
  "num-traits",

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -4,27 +4,27 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "arc-swap"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6df5aef5c5830360ce5218cecb8f018af3438af5686ae945094affc86fdec63"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "atty"
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -84,18 +84,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,9 +97,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cexpr"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
@@ -137,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
+checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
 dependencies = [
  "glob",
  "libc",
@@ -148,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -192,9 +180,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -204,16 +192,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -226,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -236,15 +218,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -253,18 +235,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -272,23 +252,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -298,8 +277,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -396,9 +373,9 @@ checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "libloading"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -433,9 +410,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -461,13 +444,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
- "bitvec",
- "funty",
  "memchr",
+ "minimal-lexical",
  "version_check",
 ]
 
@@ -650,9 +632,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-crate"
@@ -665,22 +647,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -693,12 +663,6 @@ checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -792,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -815,9 +779,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 
 [[package]]
 name = "scopeguard"
@@ -828,7 +792,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "scylla"
 version = "0.2.1"
-source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#73be705ad10f7edf7b54983eb7a18a61b3fd05af"
+source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#47d0d02e5df4c0dbe949a0f06f93689e423c5987"
 dependencies = [
  "arc-swap",
  "bigdecimal",
@@ -869,7 +833,7 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "0.1.1"
-source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#73be705ad10f7edf7b54983eb7a18a61b3fd05af"
+source = "git+https://github.com/hackathon-rust-cpp/scylla-rust-driver.git?branch=main#47d0d02e5df4c0dbe949a0f06f93689e423c5987"
 dependencies = [
  "quote",
  "syn",
@@ -883,9 +847,9 @@ checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "itoa",
  "ryu",
@@ -933,20 +897,14 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -998,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1018,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1112,10 +1070,12 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
 dependencies = [
+ "either",
+ "lazy_static",
  "libc",
 ]
 
@@ -1158,9 +1118,3 @@ checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -19,6 +19,7 @@ machine-uid = "0.2.0"
 rand = "0.8.4"
 num-traits = "0.2"
 num-derive = "0.3"
+libc = "0.2.108"
 
 [build-dependencies]
 bindgen = "0.59.1"

--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -39,7 +39,9 @@ fn prepare_cppdriver_data(outfile: &str, allowed_types: &[&str], out_path: &Path
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .layout_tests(true)
         .generate_comments(false)
-        .default_enum_style(bindgen::EnumVariation::NewType { is_bitfield: false });
+        .default_enum_style(bindgen::EnumVariation::NewType { is_bitfield: false })
+        .derive_eq(true)
+        .derive_ord(true);
     for t in allowed_types {
         type_bindings = type_bindings.allowlist_type(t);
     }

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -42,3 +42,10 @@ pub unsafe fn write_str_to_c(s: &str, c_str: *mut *const c_char, c_strlen: *mut 
     *c_str = s.as_ptr() as *const i8;
     *c_strlen = s.len() as u64;
 }
+
+pub unsafe fn strlen(ptr: *const c_char) -> size_t {
+    if ptr.is_null() {
+        return 0;
+    }
+    libc::strlen(ptr) as size_t
+}

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -1,0 +1,379 @@
+//! This module implements macros that generate functions used to
+//! bind/append data to driver's structures (statement, UDT, tuple, collection)
+//!
+//! For examples on how to use this module, see documentation of `prepare_binders_macro`
+//!
+//! This module is a bit complicated, mostly because we can't concatenate identifiers
+//! in macros, but wanted to avoid code duplication anyway (so for instance having code
+//! that converts function arguments to CqlValue in only one place).
+//! `make_*_binder` and `make_appender` are macros that directly declare new functions.
+//! `invoke_binder_maker_macro_with_type` is responsible for converting function arguments to `Result<Option<CqlValue>, CassError>`.
+//! It basically takes a macro name (`make_*_binder` / `make_appender`), some arguments,
+//! and forwards those arguments to the macro, along with the description of additional arguments
+//! and a function that converts them to `Result<Option<CqlValue>, CassError>`.
+//! `prepare_binders_macro` declares `make_binders` macro, that is then directly called
+//! by module user (more on `make_binders` in documentation of `prepare_binders_macro`).
+//! Generally, `make_binders` will just use `invoke_binder_maker_macro_with_type` underneath,
+//! which in turn uses `make_*_binder` / `make_appender`, which declare desired function.
+
+//! # make_*_binder
+//! make_*_binder and make_appender generate target function.
+//! They should not be used directly, and are present only for internal usage by other macros.
+//!
+//! ## Arguments for make_*_binder and make_appender
+//!
+//! * `$this:ty` - type to which we are going to bind (e.g. `CassTuple`)
+//! * `$consume_v:expr` - function that accepts structure reference (`&mut $this`),
+//!     then optionally some flavour-specific arguments (described futher down),
+//!     value (`Option<CqlValue>`), and binds value to the structure.
+//! * `$fn_by_*` - name of the generated function.
+//! * `$e:expr` - takes remaining function arguments and produces `Result<Option<CqlValue>, CassError>`
+//! * `[$($arg:ident @ $t:ty), *]` - list of remaining function arguments and their types.
+//!     Example: `[v @ *const cass_byte_t, v_size @ size_t]`
+//!
+//! ## Differences between make_*_binder variants
+//!
+//! The variants differ by arguments accepted by generated function, and directly correlate to
+//! 4 types of data-binding functions encountered in cpp-driver.
+//! They all take raw pointer to `mut $this`, then some arguments that tell
+//! where should the value be bound (that's the part differing between them), and then
+//! rest of the arguments, dictated by `[$($arg:ident @ $t:ty), *]`, that are later
+//! passed to `$e`.
+//!  * Function from make_index_binder takes size_t, which is and index of field
+//!     where value should be bound (index of parameter in CassStatement, index of
+//!     field in CassUserType, index of element in CassTuple).
+//!  * Functions from make_name_binder and make_name_n_binder take a string, either
+//!     as a `*const c_char` (_name version), or `*const c_char` and `size_t` (_name_n version).
+//!     It can be used for binding named parameter in CassStatement or field by name in CassUserType.
+//!  * Functions from make_appender don't take any extra argument, as they are for use by CassCollection
+//!     functions - values are appended to collection.
+
+macro_rules! make_index_binder {
+    ($this:ty, $consume_v:expr, $fn_by_idx:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
+        #[no_mangle]
+        #[allow(clippy::redundant_closure_call)]
+        pub unsafe extern "C" fn $fn_by_idx(
+            this: *mut $this,
+            index: size_t,
+            $($arg: $t), *
+        ) -> CassError {
+            // For some reason detected as unused, which is not true
+            #[allow(unused_imports)]
+            use scylla::frame::response::result::CqlValue::*;
+            match ($e)($($arg), *) {
+                Ok(v) => $consume_v(ptr_to_ref_mut(this), index as usize, v),
+                Err(e) => e,
+            }
+        }
+    }
+}
+
+macro_rules! make_name_binder {
+    ($this:ty, $consume_v:expr, $fn_by_name:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
+        #[no_mangle]
+        #[allow(clippy::redundant_closure_call)]
+        pub unsafe extern "C" fn $fn_by_name(
+            this: *mut $this,
+            name: *const c_char,
+            $($arg: $t), *
+        ) -> CassError {
+            // For some reason detected as unused, which is not true
+            #[allow(unused_imports)]
+            use scylla::frame::response::result::CqlValue::*;
+            let name = ptr_to_cstr(name).unwrap();
+            match ($e)($($arg), *) {
+                Ok(v) => $consume_v(ptr_to_ref_mut(this), name, v),
+                Err(e) => e,
+            }
+        }
+    }
+}
+
+macro_rules! make_name_n_binder {
+    ($this:ty, $consume_v:expr, $fn_by_name_n:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
+        #[no_mangle]
+        #[allow(clippy::redundant_closure_call)]
+        pub unsafe extern "C" fn $fn_by_name_n(
+            this: *mut $this,
+            name: *const c_char,
+            name_length: size_t,
+            $($arg: $t), *
+        ) -> CassError {
+            // For some reason detected as unused, which is not true
+            #[allow(unused_imports)]
+            use scylla::frame::response::result::CqlValue::*;
+            let name = ptr_to_cstr_n(name, name_length).unwrap();
+            match ($e)($($arg), *) {
+                Ok(v) => $consume_v(ptr_to_ref_mut(this), name, v),
+                Err(e) => e,
+            }
+        }
+    }
+}
+
+macro_rules! make_appender {
+    ($this:ty, $consume_v:expr, $fn_append:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
+        #[no_mangle]
+        #[allow(clippy::redundant_closure_call)]
+        pub unsafe extern "C" fn $fn_append(
+            this: *mut $this,
+            $($arg: $t), *
+        ) -> CassError {
+            // For some reason detected as unused, which is not true
+            #[allow(unused_imports)]
+            use scylla::frame::response::result::CqlValue::*;
+            match ($e)($($arg), *) {
+                Ok(v) => $consume_v(ptr_to_ref_mut(this), v),
+                Err(e) => e,
+            }
+        }
+    }
+}
+
+macro_rules! invoke_binder_maker_macro_with_type {
+    (null, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!($this, $consume_v, $fn, || Ok(None), []);
+    };
+    (int8, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(TinyInt(v))),
+            [v @ cass_int8_t]
+        );
+    };
+    (int16, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(SmallInt(v))),
+            [v @ cass_int16_t]
+        );
+    };
+    (int32, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Int(v))),
+            [v @ cass_int32_t]
+        );
+    };
+    (uint32, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Date(v))),
+            [v @ cass_uint32_t]
+        );
+    };
+    (int64, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(BigInt(v))),
+            [v @ cass_int64_t]
+        );
+    };
+    (float, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Float(v))),
+            [v @ cass_float_t]
+        );
+    };
+    (double, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Double(v))),
+            [v @ cass_double_t]
+        );
+    };
+    (bool, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Boolean(v != 0))),
+            [v @ cass_bool_t]
+        );
+    };
+    (string, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v| Ok(Some(Text(ptr_to_cstr(v).unwrap().to_string()))),
+            [v @ *const std::os::raw::c_char]
+        );
+    };
+    (string_n, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v, n| Ok(Some(Text(ptr_to_cstr_n(v, n).unwrap().to_string()))),
+            [v @ *const std::os::raw::c_char, n @ size_t]
+        );
+    };
+    (bytes, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v, v_size| {
+                let v_vec = std::slice::from_raw_parts(v, v_size as usize).to_vec();
+                Ok(Some(Blob(v_vec)))
+            },
+            [v @ *const cass_byte_t, v_size @ size_t]
+        );
+    };
+    (uuid, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v: crate::uuid::CassUuid| Ok(Some(Uuid(v.into()))),
+            [v @ crate::uuid::CassUuid]
+        );
+    };
+    (inet, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v: crate::inet::CassInet| {
+                // Err if length in struct is invalid.
+                // cppdriver doesn't check this - it encodes any length given to it
+                // but it doesn't seem like something we wanna do. Also, rust driver can't
+                // really do it afaik.
+                match std::convert::TryInto::try_into(v) {
+                    Ok(v) => Ok(Some(Inet(v))),
+                    Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
+                }
+            },
+            [v @ crate::inet::CassInet]
+        );
+    };
+    (collection, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |p: *const crate::collection::CassCollection| {
+                match std::convert::TryInto::try_into(ptr_to_ref(p)) {
+                    Ok(v) => Ok(Some(v)),
+                    Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
+                }
+            },
+            [p @ *const crate::collection::CassCollection]
+        );
+    };
+}
+
+/// Usage of this macro declares a new macro - make_binders, which is then used to declare
+/// functions that bind data to driver structures.
+/// This macro has 3 variants - `@only_index`, `@index_and_name`, `@append`, to accomodate
+/// each use case from cppdriver.
+///
+/// # `@only_index`
+///
+/// `@only_index` is used if values can only be bound to a structure by index of the field,
+/// like in CassTuple. You need to pass it 2 arguments - type of the structure, and a function,
+/// which accepts mut ref to the structure, index (`size_t`), value (`Option<CqlValue>`), and
+/// binds the value to the structure at a given index.
+///
+/// After that, you can now create binders. For each supported type write: `make_binders!(type, fn_name)`.
+/// For a list of supported types see `invoke_binder_maker_macro_with_type`. `fn_name` is name of created function.
+/// Each function will be created using `make_index_binder` macro.
+///
+/// # `@index_and_name`
+///
+/// Use `@index_and_name` if the type supports binding both by index and by name, like CassUserType,
+/// or CassStatement.
+/// This version is slightly more complicated than others, and needs 3 arguments:
+///  * Name of the type
+///  * `$consume_v_idx:expr` - function that binds value by index - just like the one in `@only_index`
+///  * `$consume_v_name:expr` - function that binds value by name.
+///         Accepts mut ref to the structure, name (`str`) and value (`Option<CqlValue>`)
+///
+/// After that, you can again start generating functions using make_binders macro, but here it has 5 variants.
+/// 3 variants are the basic ones, resembling the one from `@only_index`:
+///  * `@index` - works the same as `make_binders` in `@only_index` variant - takes type and function name,
+///         declares this function using `make_index_binder` macro.
+///         In the function, value will be consumed using `$consume_v_idx`.
+///  * `@name` - accepts type and function name, declares this function using `make_name_binder` macro.
+///         In the function, value will be consumed using `$consume_v_name`.
+///  * `@name_n` - accepts type and function name, declares this function using `make_name_n_binder` macro.
+///         In the function, value will be consumed using `$consume_v_name`.
+/// There are also 2 helper variants, to accomodate scenarios often encountered in cppdriver (sets of 3 functions,
+/// binding the same type by index, name and name_n):
+///  * `make_binders!(type, fn_idx, fn_name, fn_name_n)` - is equivalent to:
+///     ```
+///     make_binders!(@index type, fn_idx);
+///     make_binders!(@name type, fn_name);
+///     make_binders!(@name_n type, fn_name_n);
+///     ```
+///  * `make_binders!(t1, fn_idx, t2, fn_name, t3, fn_name_n)` - is equivalent to:
+///     ```
+///     make_binders!(@index t1, fn_idx);
+///     make_binders!(@name t2, fn_name);
+///     make_binders!(@name_n t3, fn_name_n);
+///     ```
+/// # `@append`
+///
+/// `@append` is used, when values can only be appended to structure (like in CassCollection),
+/// not bound at specific index/name. You need to pass it 2 arguments - type of the structure, and a function,
+/// which accepts mut ref to the structure and a value (`Option<CqlValue>`), and appends value to the structure.
+///
+/// After that, you can now create binders. For each supported type write: `make_binders!(type, fn_name)`.
+/// For a list of supported types see `invoke_binder_maker_macro_with_type`. `fn_name` is name of created function.
+/// Each function will be created using `make_appender` macro.
+macro_rules! prepare_binders_macro {
+    (@only_index $this:ty, $consume_v:expr) => {
+        macro_rules! make_binders {
+            ($t:ident, $fn:ident) => {
+                invoke_binder_maker_macro_with_type!($t, make_index_binder, $this, $consume_v, $fn);
+            };
+        }
+    };
+    (@index_and_name $this:ty, $consume_v_idx:expr, $consume_v_name:expr) => {
+        macro_rules! make_binders {
+            ($t:ident, $fn_idx:ident, $fn_name:ident, $fn_name_n:ident) => {
+                invoke_binder_maker_macro_with_type!($t, make_index_binder, $this, $consume_v_idx, $fn_idx);
+                invoke_binder_maker_macro_with_type!($t, make_name_binder, $this, $consume_v_name, $fn_name);
+                invoke_binder_maker_macro_with_type!($t, make_name_n_binder, $this, $consume_v_name, $fn_name_n);
+            };
+            ($t_idx:ident, $fn_idx:ident, $t_name:ident, $fn_name:ident, $t_name_n:ident, $fn_name_n:ident) => {
+                invoke_binder_maker_macro_with_type!($t_idx, make_index_binder, $this, $consume_v_idx, $fn_idx);
+                invoke_binder_maker_macro_with_type!($t_name, make_name_binder, $this, $consume_v_name, $fn_name);
+                invoke_binder_maker_macro_with_type!($t_name_n, make_name_n_binder, $this, $consume_v_name, $fn_name_n);
+            };
+            (@index $t:ident, $fn_idx:ident) => {
+                invoke_binder_maker_macro_with_type!($t, make_index_binder, $this, $consume_v_idx, $fn_idx);
+            };
+            (@name $t:ident, $fn_name:ident) => {
+                invoke_binder_maker_macro_with_type!($t, make_name_binder, $this, $consume_v_name, $fn_name);
+            };
+            (@name_n $t:ident, $fn_name_n:ident) => {
+                invoke_binder_maker_macro_with_type!($t, make_name_n_binder, $this, $consume_v_name, $fn_name_n);
+            };
+        }
+    };
+
+    (@append $this:ty, $consume_v:expr) => {
+        macro_rules! make_binders {
+            ($t:ident, $fn:ident) => {
+                invoke_binder_maker_macro_with_type!($t, make_appender, $this, $consume_v, $fn);
+            };
+        }
+    };
+}

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -130,6 +130,13 @@ macro_rules! make_appender {
     }
 }
 
+// TODO: Types for which binding is not implemented yet:
+// custom - Not implemented in Rust driver?
+// decimal
+// duration - DURATION not implemented in Rust Driver
+// tuple - not implemented yet
+// UDT - not implemented yet
+
 macro_rules! invoke_binder_maker_macro_with_type {
     (null, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
         $macro_name!($this, $consume_v, $fn, || Ok(None), []);

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -84,10 +84,7 @@ pub unsafe extern "C" fn cass_cluster_set_contact_points(
     cluster: *mut CassCluster,
     contact_points: *const c_char,
 ) -> CassError {
-    let contact_points_str = ptr_to_cstr(contact_points).unwrap();
-    let contact_points_length = contact_points_str.len();
-
-    cass_cluster_set_contact_points_n(cluster, contact_points, contact_points_length as size_t)
+    cass_cluster_set_contact_points_n(cluster, contact_points, strlen(contact_points))
 }
 
 #[no_mangle]
@@ -164,19 +161,12 @@ pub unsafe extern "C" fn cass_cluster_set_credentials(
     username: *const c_char,
     password: *const c_char,
 ) {
-    // TODO: string error handling
-    let username_str = ptr_to_cstr(username).unwrap();
-    let username_length = username_str.len();
-
-    let password_str = ptr_to_cstr(password).unwrap();
-    let password_length = password_str.len();
-
     cass_cluster_set_credentials_n(
         cluster,
         username,
-        username_length as size_t,
+        strlen(username),
         password,
-        password_length as size_t,
+        strlen(password),
     )
 }
 
@@ -211,14 +201,10 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware(
     used_hosts_per_remote_dc: c_uint,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
-    // TODO: string error handling
-    let local_dc_str = ptr_to_cstr(local_dc).unwrap();
-    let local_dc_length = local_dc_str.len();
-
     cass_cluster_set_load_balance_dc_aware_n(
         cluster,
         local_dc,
-        local_dc_length as size_t,
+        strlen(local_dc),
         used_hosts_per_remote_dc,
         allow_remote_dcs_for_local_cl,
     )

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -4,7 +4,6 @@ use crate::types::*;
 use scylla::frame::response::result::CqlValue;
 use scylla::frame::response::result::CqlValue::*;
 use std::convert::TryFrom;
-use std::os::raw::c_char;
 
 include!(concat!(env!("OUT_DIR"), "/cppdriver_data_collection.rs"));
 
@@ -15,136 +14,13 @@ pub struct CassCollection {
     pub items: Vec<CqlValue>,
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_new(
-    collection_type: CassCollectionType,
-    item_count: size_t,
-) -> *mut CassCollection {
-    let capacity = match collection_type {
-        // Maps consist of a key and a value, so twice
-        // the number of CqlValue will be stored.
-        CassCollectionType::CASS_COLLECTION_TYPE_MAP => item_count * 2,
-        _ => item_count,
-    } as usize;
-
-    Box::into_raw(Box::new(CassCollection {
-        collection_type,
-        capacity,
-        items: Vec::with_capacity(capacity),
-    }))
-}
-
-unsafe fn cass_collection_append_cql_value(
-    collection_raw: *mut CassCollection,
-    value: CqlValue,
-) -> CassError {
-    // FIXME: Bounds check
-    let collection = ptr_to_ref_mut(collection_raw);
-    collection.items.push(value);
-
-    CassError::CASS_OK
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_int8(
-    collection: *mut CassCollection,
-    value: cass_int8_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, TinyInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_int16(
-    collection: *mut CassCollection,
-    value: cass_int16_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, SmallInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_int32(
-    collection: *mut CassCollection,
-    value: cass_int32_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, Int(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_uint32(
-    collection: *mut CassCollection,
-    value: cass_uint32_t,
-) -> CassError {
-    // cass_collection_append_uint32 is only used to set a DATE.
-    cass_collection_append_cql_value(collection, Date(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_int64(
-    collection: *mut CassCollection,
-    value: cass_int64_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, BigInt(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_float(
-    collection: *mut CassCollection,
-    value: cass_float_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, Float(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_double(
-    collection: *mut CassCollection,
-    value: cass_double_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, Double(value))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_bool(
-    collection: *mut CassCollection,
-    value: cass_bool_t,
-) -> CassError {
-    cass_collection_append_cql_value(collection, Boolean(value != 0))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_string(
-    collection: *mut CassCollection,
-    value: *const c_char,
-) -> CassError {
-    let value_str = ptr_to_cstr(value).unwrap();
-    let value_length = value_str.len();
-
-    cass_collection_append_string_n(collection, value, value_length as size_t)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_string_n(
-    collection: *mut CassCollection,
-    value: *const c_char,
-    value_length: size_t,
-) -> CassError {
-    // TODO: Error handling
-    let value_string = ptr_to_cstr_n(value, value_length).unwrap().to_string();
-    cass_collection_append_cql_value(collection, Text(value_string))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_append_bytes(
-    collection: *mut CassCollection,
-    value: *const cass_byte_t,
-    value_size: size_t,
-) -> CassError {
-    let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
-    cass_collection_append_cql_value(collection, Blob(value_vec))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_collection_free(collection: *mut CassCollection) {
-    free_boxed(collection);
+impl CassCollection {
+    pub fn append_cql_value(&mut self, value: Option<CqlValue>) -> CassError {
+        // FIXME: Bounds check, type check
+        // There is no API to append null, so unwrap is safe
+        self.items.push(value.unwrap());
+        CassError::CASS_OK
+    }
 }
 
 impl TryFrom<&CassCollection> for CqlValue {
@@ -172,3 +48,43 @@ impl TryFrom<&CassCollection> for CqlValue {
         }
     }
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_collection_new(
+    collection_type: CassCollectionType,
+    item_count: size_t,
+) -> *mut CassCollection {
+    let capacity = match collection_type {
+        // Maps consist of a key and a value, so twice
+        // the number of CqlValue will be stored.
+        CassCollectionType::CASS_COLLECTION_TYPE_MAP => item_count * 2,
+        _ => item_count,
+    } as usize;
+
+    Box::into_raw(Box::new(CassCollection {
+        collection_type,
+        capacity,
+        items: Vec::with_capacity(capacity),
+    }))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_collection_free(collection: *mut CassCollection) {
+    free_boxed(collection);
+}
+
+prepare_binders_macro!(@append CassCollection, |collection: &mut CassCollection, v| collection.append_cql_value(v));
+make_binders!(int8, cass_collection_append_int8);
+make_binders!(int16, cass_collection_append_int16);
+make_binders!(int32, cass_collection_append_int32);
+make_binders!(uint32, cass_collection_append_uint32);
+make_binders!(int64, cass_collection_append_int64);
+make_binders!(float, cass_collection_append_float);
+make_binders!(double, cass_collection_append_double);
+make_binders!(bool, cass_collection_append_bool);
+make_binders!(string, cass_collection_append_string);
+make_binders!(string_n, cass_collection_append_string_n);
+make_binders!(bytes, cass_collection_append_bytes);
+make_binders!(uuid, cass_collection_append_uuid);
+make_binders!(inet, cass_collection_append_inet);
+make_binders!(collection, cass_collection_append_collection);

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -147,12 +147,12 @@ pub unsafe extern "C" fn cass_collection_free(collection: *mut CassCollection) {
     free_boxed(collection);
 }
 
-impl TryFrom<CassCollection> for CqlValue {
+impl TryFrom<&CassCollection> for CqlValue {
     type Error = ();
-    fn try_from(collection: CassCollection) -> Result<Self, Self::Error> {
+    fn try_from(collection: &CassCollection) -> Result<Self, Self::Error> {
         // FIXME: validate that collection items are correct
         match collection.collection_type {
-            CassCollectionType::CASS_COLLECTION_TYPE_LIST => Ok(List(collection.items)),
+            CassCollectionType::CASS_COLLECTION_TYPE_LIST => Ok(List(collection.items.clone())),
             CassCollectionType::CASS_COLLECTION_TYPE_MAP => {
                 let mut grouped_items = Vec::new();
                 // FIXME: validate even number of items
@@ -165,7 +165,9 @@ impl TryFrom<CassCollection> for CqlValue {
 
                 Ok(Map(grouped_items))
             }
-            CassCollectionType::CASS_COLLECTION_TYPE_SET => Ok(CqlValue::Set(collection.items)),
+            CassCollectionType::CASS_COLLECTION_TYPE_SET => {
+                Ok(CqlValue::Set(collection.items.clone()))
+            }
             _ => Err(()),
         }
     }

--- a/scylla-rust-wrapper/src/inet.rs
+++ b/scylla-rust-wrapper/src/inet.rs
@@ -66,10 +66,7 @@ pub unsafe extern "C" fn cass_inet_from_string(
     input: *const c_char,
     inet: *mut CassInet,
 ) -> CassError {
-    let input_str = ptr_to_cstr(input).unwrap();
-    let input_length = input_str.len();
-
-    cass_inet_from_string_n(input, input_length as size_t, inet)
+    cass_inet_from_string_n(input, strlen(input), inet)
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -2,6 +2,8 @@
 use lazy_static::lazy_static;
 use tokio::runtime::Runtime;
 
+#[macro_use]
+mod binding;
 mod argconv;
 pub mod cass_error;
 pub mod cluster;

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -97,14 +97,7 @@ pub unsafe extern "C" fn cass_session_prepare(
     session: *mut CassSession,
     query: *const c_char,
 ) -> *const CassFuture {
-    // TODO: error handling
-    let query_str = match ptr_to_cstr(query) {
-        Some(v) => v,
-        None => return std::ptr::null(),
-    };
-    let query_length = query_str.len();
-
-    cass_session_prepare_n(session, query, query_length as size_t)
+    cass_session_prepare_n(session, query, strlen(query))
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -35,13 +35,7 @@ pub unsafe extern "C" fn cass_statement_new(
     query: *const c_char,
     parameter_count: size_t,
 ) -> *mut CassStatement {
-    let query_str = match ptr_to_cstr(query) {
-        Some(v) => v,
-        None => return std::ptr::null_mut(),
-    };
-    let query_length = query_str.len();
-
-    cass_statement_new_n(query, query_length as size_t, parameter_count)
+    cass_statement_new_n(query, strlen(query), parameter_count)
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -311,7 +311,7 @@ make_binders!(
     cass_statement_bind_collection_by_name_n,
     *const CassCollection,
     |p: *const CassCollection| {
-        match ptr_to_ref(p).clone().try_into() {
+        match ptr_to_ref(p).try_into() {
             Ok(v) => Ok(v),
             Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
         }

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -62,6 +62,75 @@ pub unsafe extern "C" fn cass_statement_new_n(
     }))
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn cass_statement_free(statement_raw: *mut CassStatement) {
+    free_boxed(statement_raw);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_statement_set_paging_size(
+    statement_raw: *mut CassStatement,
+    page_size: c_int,
+) -> CassError {
+    // TODO: validate page_size
+    match &mut ptr_to_ref_mut(statement_raw).statement {
+        Statement::Simple(inner) => {
+            if page_size == -1 {
+                inner.disable_paging()
+            } else {
+                inner.set_page_size(page_size)
+            }
+        }
+        Statement::Prepared(inner) => {
+            if page_size == -1 {
+                Arc::make_mut(inner).disable_paging()
+            } else {
+                Arc::make_mut(inner).set_page_size(page_size)
+            }
+        }
+    }
+
+    CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_statement_set_paging_state(
+    statement: *mut CassStatement,
+    result: *const CassResult,
+) -> CassError {
+    let statement = ptr_to_ref_mut(statement);
+    let result = ptr_to_ref(result);
+
+    statement.paging_state = result.paging_state.clone();
+    CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_statement_set_is_idempotent(
+    statement_raw: *mut CassStatement,
+    is_idempotent: cass_bool_t,
+) -> CassError {
+    match &mut ptr_to_ref_mut(statement_raw).statement {
+        Statement::Simple(inner) => inner.set_is_idempotent(is_idempotent != 0),
+        Statement::Prepared(inner) => Arc::make_mut(inner).set_is_idempotent(is_idempotent != 0),
+    }
+
+    CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_statement_set_tracing(
+    statement_raw: *mut CassStatement,
+    enabled: cass_bool_t,
+) -> CassError {
+    match &mut ptr_to_ref_mut(statement_raw).statement {
+        Statement::Simple(inner) => inner.set_tracing(enabled != 0),
+        Statement::Prepared(inner) => Arc::make_mut(inner).set_tracing(enabled != 0),
+    }
+
+    CassError::CASS_OK
+}
+
 // TODO: Bind methods currently not implemented:
 // cass_statement_bind_decimal
 //
@@ -414,73 +483,4 @@ pub unsafe extern "C" fn cass_statement_bind_bytes_by_name_n(
 ) -> CassError {
     let value_vec = std::slice::from_raw_parts(value, value_size as usize).to_vec();
     cass_statement_bind_cql_value_by_name_n(statement, name, name_length, Blob(value_vec))
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_set_tracing(
-    statement_raw: *mut CassStatement,
-    enabled: cass_bool_t,
-) -> CassError {
-    match &mut ptr_to_ref_mut(statement_raw).statement {
-        Statement::Simple(inner) => inner.set_tracing(enabled != 0),
-        Statement::Prepared(inner) => Arc::make_mut(inner).set_tracing(enabled != 0),
-    }
-
-    CassError::CASS_OK
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_set_paging_size(
-    statement_raw: *mut CassStatement,
-    page_size: c_int,
-) -> CassError {
-    // TODO: validate page_size
-    match &mut ptr_to_ref_mut(statement_raw).statement {
-        Statement::Simple(inner) => {
-            if page_size == -1 {
-                inner.disable_paging()
-            } else {
-                inner.set_page_size(page_size)
-            }
-        }
-        Statement::Prepared(inner) => {
-            if page_size == -1 {
-                Arc::make_mut(inner).disable_paging()
-            } else {
-                Arc::make_mut(inner).set_page_size(page_size)
-            }
-        }
-    }
-
-    CassError::CASS_OK
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_set_paging_state(
-    statement: *mut CassStatement,
-    result: *const CassResult,
-) -> CassError {
-    let statement = ptr_to_ref_mut(statement);
-    let result = ptr_to_ref(result);
-
-    statement.paging_state = result.paging_state.clone();
-    CassError::CASS_OK
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_set_is_idempotent(
-    statement_raw: *mut CassStatement,
-    is_idempotent: cass_bool_t,
-) -> CassError {
-    match &mut ptr_to_ref_mut(statement_raw).statement {
-        Statement::Simple(inner) => inner.set_is_idempotent(is_idempotent != 0),
-        Statement::Prepared(inner) => Arc::make_mut(inner).set_is_idempotent(is_idempotent != 0),
-    }
-
-    CassError::CASS_OK
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_statement_free(statement_raw: *mut CassStatement) {
-    free_boxed(statement_raw);
 }

--- a/scylla-rust-wrapper/src/uuid.rs
+++ b/scylla-rust-wrapper/src/uuid.rs
@@ -220,10 +220,7 @@ pub unsafe extern "C" fn cass_uuid_from_string(
     value: *const c_char,
     output: *mut CassUuid,
 ) -> CassError {
-    let value_str = ptr_to_cstr(value).unwrap();
-    let value_length = value_str.len();
-
-    cass_uuid_from_string_n(value, value_length as size_t, output)
+    cass_uuid_from_string_n(value, strlen(value), output)
 }
 
 #[no_mangle]


### PR DESCRIPTION
This PR introduces macros to create binder functions that work with each use case from cpp-driver and allow to reduce code-duplication and amount of code.
Apart from that, there are few small fixes:
 - updating Cargo.lock to use current version of our Rust-driver fork
 - replacing unnecessary string decodings with strlen calls
 - Changed TryFrom in CassCollection to avoid unnecessary copies