### PR TITLE
Implement CassDataType, CassUserType, CassTuple

### DIFF
--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -95,4 +95,9 @@ fn main() {
         &["CassUuid_", "CassUuid"],
         &out_path,
     );
+    prepare_cppdriver_data(
+        "cppdriver_data_types.rs",
+        &["CassValueType_", "CassValueType"],
+        &out_path,
+    );
 }

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -141,7 +141,6 @@ macro_rules! make_appender {
 // custom - Not implemented in Rust driver?
 // decimal
 // duration - DURATION not implemented in Rust Driver
-// tuple - not implemented yet
 
 macro_rules! invoke_binder_maker_macro_with_type {
     (null, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
@@ -288,6 +287,17 @@ macro_rules! invoke_binder_maker_macro_with_type {
                 }
             },
             [p @ *const crate::collection::CassCollection]
+        );
+    };
+    (tuple, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |p: *const crate::tuple::CassTuple| {
+                std::convert::TryInto::try_into(ptr_to_ref(p)).map(Some)
+            },
+            [p @ *const crate::tuple::CassTuple]
         );
     };
     (user_type, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -47,6 +47,13 @@
 //!     It can be used for binding named parameter in CassStatement or field by name in CassUserType.
 //!  * Functions from make_appender don't take any extra argument, as they are for use by CassCollection
 //!     functions - values are appended to collection.
+use crate::cass_types::CassDataType;
+use scylla::frame::response::result::CqlValue;
+
+pub fn is_compatible_type(_data_type: &CassDataType, _value: &Option<CqlValue>) -> bool {
+    // TODO: cppdriver actually checks types.
+    true
+}
 
 macro_rules! make_index_binder {
     ($this:ty, $consume_v:expr, $fn_by_idx:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -142,7 +142,6 @@ macro_rules! make_appender {
 // decimal
 // duration - DURATION not implemented in Rust Driver
 // tuple - not implemented yet
-// UDT - not implemented yet
 
 macro_rules! invoke_binder_maker_macro_with_type {
     (null, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
@@ -289,6 +288,15 @@ macro_rules! invoke_binder_maker_macro_with_type {
                 }
             },
             [p @ *const crate::collection::CassCollection]
+        );
+    };
+    (user_type, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |p: *const crate::user_type::CassUserType| Ok(Some(ptr_to_ref(p).into())),
+            [p @ *const crate::user_type::CassUserType]
         );
     };
 }

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -1,0 +1,468 @@
+use crate::argconv::*;
+use crate::cass_error::CassError;
+use crate::types::*;
+use std::os::raw::c_char;
+use std::ptr;
+use std::sync::Arc;
+
+include!(concat!(env!("OUT_DIR"), "/cppdriver_data_types.rs"));
+
+#[derive(Clone)]
+pub struct UDTDataType {
+    // Vec to preserve the order of types
+    pub field_types: Vec<(String, CassDataTypeArc)>,
+
+    pub keyspace: String,
+    pub name: String,
+}
+
+impl UDTDataType {
+    pub fn new() -> UDTDataType {
+        UDTDataType {
+            field_types: Vec::new(),
+            keyspace: "".to_string(),
+            name: "".to_string(),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> UDTDataType {
+        UDTDataType {
+            field_types: Vec::with_capacity(capacity),
+            keyspace: "".to_string(),
+            name: "".to_string(),
+        }
+    }
+
+    pub fn add_field(&mut self, name: String, field_type: CassDataTypeArc) {
+        self.field_types.push((name, field_type));
+    }
+
+    pub fn get_field_by_name(&self, name: &str) -> Option<&CassDataTypeArc> {
+        self.field_types
+            .iter()
+            .find(|(field_name, _)| field_name == name)
+            .map(|(_, t)| t)
+    }
+
+    pub fn get_field_by_index(&self, index: usize) -> Option<&CassDataTypeArc> {
+        self.field_types.get(index).map(|(_, b)| b)
+    }
+}
+
+impl Default for UDTDataType {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone)]
+pub enum CassDataType {
+    Value(CassValueType),
+    UDT(UDTDataType),
+    List(Option<CassDataTypeArc>),
+    Set(Option<CassDataTypeArc>),
+    Map(Option<CassDataTypeArc>, Option<CassDataTypeArc>),
+    Tuple(Vec<CassDataTypeArc>),
+    Custom(String),
+}
+
+pub type CassDataTypeArc = Arc<CassDataType>;
+
+impl CassDataType {
+    fn get_sub_data_type(&self, index: usize) -> Option<&CassDataTypeArc> {
+        match self {
+            CassDataType::UDT(udt_data_type) => udt_data_type
+                .field_types
+                .get(index as usize)
+                .map(|(_, b)| b),
+            CassDataType::List(t) | CassDataType::Set(t) => {
+                if index > 0 {
+                    None
+                } else {
+                    t.as_ref()
+                }
+            }
+            CassDataType::Map(t1, t2) => match index {
+                0 => t1.as_ref(),
+                1 => t2.as_ref(),
+                _ => None,
+            },
+            CassDataType::Tuple(v) => v.get(index as usize),
+            _ => None,
+        }
+    }
+
+    fn add_sub_data_type(&mut self, sub_type: CassDataTypeArc) -> Result<(), CassError> {
+        match self {
+            CassDataType::List(t) | CassDataType::Set(t) => match t {
+                Some(_) => Err(CassError::CASS_ERROR_LIB_BAD_PARAMS),
+                None => {
+                    *t = Some(sub_type);
+                    Ok(())
+                }
+            },
+            CassDataType::Map(t1, t2) => {
+                if t1.is_some() && t2.is_some() {
+                    Err(CassError::CASS_ERROR_LIB_BAD_PARAMS)
+                } else if t1.is_none() {
+                    *t1 = Some(sub_type);
+                    Ok(())
+                } else {
+                    *t2 = Some(sub_type);
+                    Ok(())
+                }
+            }
+            CassDataType::Tuple(types) => {
+                types.push(sub_type);
+                Ok(())
+            }
+            _ => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
+        }
+    }
+}
+
+// Changed return type to const ptr - Arc::into_raw is const.
+// It's probably not a good idea - but cppdriver doesn't guarantee
+// thread safety apart from CassSession and CassFuture.
+// This comment also applies to other functions that create CassDataType.
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new(value_type: CassValueType) -> *const CassDataType {
+    let data_type = match value_type {
+        CassValueType::CASS_VALUE_TYPE_LIST => CassDataType::List(None),
+        CassValueType::CASS_VALUE_TYPE_SET => CassDataType::Set(None),
+        CassValueType::CASS_VALUE_TYPE_TUPLE => CassDataType::Tuple(Vec::new()),
+        CassValueType::CASS_VALUE_TYPE_MAP => CassDataType::Map(None, None),
+        CassValueType::CASS_VALUE_TYPE_UDT => CassDataType::UDT(UDTDataType::new()),
+        CassValueType::CASS_VALUE_TYPE_CUSTOM => CassDataType::Custom("".to_string()),
+        CassValueType::CASS_VALUE_TYPE_UNKNOWN => return ptr::null_mut(),
+        t if t < CassValueType::CASS_VALUE_TYPE_LAST_ENTRY => CassDataType::Value(t),
+        _ => return ptr::null_mut(),
+    };
+    Arc::into_raw(Arc::new(data_type))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new_from_existing(
+    data_type: *const CassDataType,
+) -> *const CassDataType {
+    let data_type = ptr_to_ref(data_type);
+    Arc::into_raw(Arc::new(data_type.clone()))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new_tuple(item_count: size_t) -> *const CassDataType {
+    Arc::into_raw(Arc::new(CassDataType::Tuple(Vec::with_capacity(
+        item_count as usize,
+    ))))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_new_udt(field_count: size_t) -> *const CassDataType {
+    Arc::into_raw(Arc::new(CassDataType::UDT(UDTDataType::with_capacity(
+        field_count as usize,
+    ))))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_free(data_type: *mut CassDataType) {
+    free_arced(data_type);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_type(data_type: *const CassDataType) -> CassValueType {
+    let data_type = ptr_to_ref(data_type);
+    match data_type {
+        CassDataType::Value(value_data_type) => *value_data_type,
+        CassDataType::UDT { .. } => CassValueType::CASS_VALUE_TYPE_UDT,
+        CassDataType::List(..) => CassValueType::CASS_VALUE_TYPE_LIST,
+        CassDataType::Set(..) => CassValueType::CASS_VALUE_TYPE_SET,
+        CassDataType::Map(..) => CassValueType::CASS_VALUE_TYPE_MAP,
+        CassDataType::Tuple(..) => CassValueType::CASS_VALUE_TYPE_TUPLE,
+        CassDataType::Custom(..) => CassValueType::CASS_VALUE_TYPE_CUSTOM,
+    }
+}
+
+// #[no_mangle]
+// pub unsafe extern "C" fn cass_data_type_is_frozen(data_type: *const CassDataType) -> cass_bool_t {}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_type_name(
+    data_type: *const CassDataType,
+    type_name: *mut *const c_char,
+    type_name_length: *mut size_t,
+) -> CassError {
+    let data_type = ptr_to_ref(data_type);
+    match data_type {
+        CassDataType::UDT(UDTDataType { name, .. }) => {
+            write_str_to_c(name, type_name, type_name_length);
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_type_name(
+    data_type: *mut CassDataType,
+    type_name: *const c_char,
+) -> CassError {
+    cass_data_type_set_type_name_n(data_type, type_name, strlen(type_name))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_type_name_n(
+    data_type_raw: *mut CassDataType,
+    type_name: *const c_char,
+    type_name_length: size_t,
+) -> CassError {
+    let data_type = ptr_to_ref_mut(data_type_raw);
+    let type_name_string = ptr_to_cstr_n(type_name, type_name_length)
+        .unwrap()
+        .to_string();
+
+    match data_type {
+        CassDataType::UDT(udt_data_type) => {
+            udt_data_type.name = type_name_string;
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_keyspace(
+    data_type: *const CassDataType,
+    keyspace: *mut *const c_char,
+    keyspace_length: *mut size_t,
+) -> CassError {
+    let data_type = ptr_to_ref(data_type);
+    match data_type {
+        CassDataType::UDT(UDTDataType { name, .. }) => {
+            write_str_to_c(name, keyspace, keyspace_length);
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_keyspace(
+    data_type: *mut CassDataType,
+    keyspace: *const c_char,
+) -> CassError {
+    cass_data_type_set_keyspace_n(data_type, keyspace, strlen(keyspace))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
+    data_type: *mut CassDataType,
+    keyspace: *const c_char,
+    keyspace_length: size_t,
+) -> CassError {
+    let data_type = ptr_to_ref_mut(data_type);
+    let keyspace_string = ptr_to_cstr_n(keyspace, keyspace_length)
+        .unwrap()
+        .to_string();
+
+    match data_type {
+        CassDataType::UDT(udt_data_type) => {
+            udt_data_type.keyspace = keyspace_string;
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_class_name(
+    data_type: *const CassDataType,
+    class_name: *mut *const ::std::os::raw::c_char,
+    class_name_length: *mut size_t,
+) -> CassError {
+    let data_type = ptr_to_ref(data_type);
+    match data_type {
+        CassDataType::Custom(name) => {
+            write_str_to_c(name, class_name, class_name_length);
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_class_name(
+    data_type: *mut CassDataType,
+    class_name: *const ::std::os::raw::c_char,
+) -> CassError {
+    cass_data_type_set_class_name_n(data_type, class_name, strlen(class_name))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_set_class_name_n(
+    data_type: *mut CassDataType,
+    class_name: *const ::std::os::raw::c_char,
+    class_name_length: size_t,
+) -> CassError {
+    let data_type = ptr_to_ref_mut(data_type);
+    let class_string = ptr_to_cstr_n(class_name, class_name_length)
+        .unwrap()
+        .to_string();
+    match data_type {
+        CassDataType::Custom(name) => {
+            *name = class_string;
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_type_count(data_type: *const CassDataType) -> size_t {
+    let data_type = ptr_to_ref(data_type);
+    match data_type {
+        CassDataType::Value(..) => 0,
+        CassDataType::UDT(udt_data_type) => udt_data_type.field_types.len() as size_t,
+        CassDataType::List(t) | CassDataType::Set(t) => t.is_some() as size_t,
+        CassDataType::Map(t1, t2) => t1.is_some() as size_t + t2.is_some() as size_t,
+        CassDataType::Tuple(v) => v.len() as size_t,
+        CassDataType::Custom(..) => 0,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_sub_type_count(data_type: *const CassDataType) -> size_t {
+    cass_data_type_sub_type_count(data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_data_type(
+    data_type: *const CassDataType,
+    index: size_t,
+) -> *const CassDataType {
+    let data_type = ptr_to_ref(data_type);
+    let sub_type: Option<&CassDataTypeArc> = data_type.get_sub_data_type(index as usize);
+
+    match sub_type {
+        None => std::ptr::null(),
+        // Semantic from cppdriver which also returns non-owning pointer
+        Some(arc) => Arc::as_ptr(arc),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name(
+    data_type: *const CassDataType,
+    name: *const ::std::os::raw::c_char,
+) -> *const CassDataType {
+    cass_data_type_sub_data_type_by_name_n(data_type, name, strlen(name))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n(
+    data_type: *const CassDataType,
+    name: *const ::std::os::raw::c_char,
+    name_length: size_t,
+) -> *const CassDataType {
+    let data_type = ptr_to_ref(data_type);
+    let name_str = ptr_to_cstr_n(name, name_length).unwrap();
+    match data_type {
+        CassDataType::UDT(udt) => match udt.get_field_by_name(name_str) {
+            None => std::ptr::null(),
+            Some(t) => Arc::as_ptr(t),
+        },
+        _ => std::ptr::null(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_sub_type_name(
+    data_type: *const CassDataType,
+    index: size_t,
+    name: *mut *const ::std::os::raw::c_char,
+    name_length: *mut size_t,
+) -> CassError {
+    let data_type = ptr_to_ref(data_type);
+    match data_type {
+        CassDataType::UDT(udt) => match udt.field_types.get(index as usize) {
+            None => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
+            Some((field_name, _)) => {
+                write_str_to_c(field_name, name, name_length);
+                CassError::CASS_OK
+            }
+        },
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_type(
+    data_type: *mut CassDataType,
+    sub_data_type: *const CassDataType,
+) -> CassError {
+    let data_type = ptr_to_ref_mut(data_type);
+    match data_type.add_sub_data_type(clone_arced(sub_data_type)) {
+        Ok(()) => CassError::CASS_OK,
+        Err(e) => e,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    sub_data_type: *const CassDataType,
+) -> CassError {
+    cass_data_type_add_sub_type_by_name_n(data_type, name, strlen(name), sub_data_type)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
+    data_type_raw: *mut CassDataType,
+    name: *const c_char,
+    name_length: size_t,
+    sub_data_type_raw: *const CassDataType,
+) -> CassError {
+    let name_string = ptr_to_cstr_n(name, name_length).unwrap().to_string();
+    let sub_data_type = clone_arced(sub_data_type_raw);
+
+    let data_type = ptr_to_ref_mut(data_type_raw);
+    match data_type {
+        CassDataType::UDT(udt_data_type) => {
+            // The Cpp Driver does not check whether field_types size
+            // exceeded field_count.
+            udt_data_type.field_types.push((name_string, sub_data_type));
+            CassError::CASS_OK
+        }
+        _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_value_type(
+    data_type: *mut CassDataType,
+    sub_value_type: CassValueType,
+) -> CassError {
+    let sub_data_type = Arc::new(CassDataType::Value(sub_value_type));
+    cass_data_type_add_sub_type(data_type, Arc::as_ptr(&sub_data_type))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    sub_value_type: CassValueType,
+) -> CassError {
+    let sub_data_type = Arc::new(CassDataType::Value(sub_value_type));
+    cass_data_type_add_sub_type_by_name(data_type, name, Arc::as_ptr(&sub_data_type))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
+    data_type: *mut CassDataType,
+    name: *const c_char,
+    name_length: size_t,
+    sub_value_type: CassValueType,
+) -> CassError {
+    let sub_data_type = Arc::new(CassDataType::Value(sub_value_type));
+    cass_data_type_add_sub_type_by_name_n(data_type, name, name_length, Arc::as_ptr(&sub_data_type))
+}

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -119,6 +119,13 @@ impl CassDataType {
             _ => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
         }
     }
+
+    pub fn get_udt_type(&self) -> &UDTDataType {
+        match self {
+            CassDataType::UDT(udt) => udt,
+            _ => panic!("Can get UDT out of non-UDT data type"),
+        }
+    }
 }
 
 // Changed return type to const ptr - Arc::into_raw is const.

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -88,3 +88,4 @@ make_binders!(bytes, cass_collection_append_bytes);
 make_binders!(uuid, cass_collection_append_uuid);
 make_binders!(inet, cass_collection_append_inet);
 make_binders!(collection, cass_collection_append_collection);
+make_binders!(user_type, cass_collection_append_user_type);

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -88,4 +88,5 @@ make_binders!(bytes, cass_collection_append_bytes);
 make_binders!(uuid, cass_collection_append_uuid);
 make_binders!(inet, cass_collection_append_inet);
 make_binders!(collection, cass_collection_append_collection);
+make_binders!(tuple, cass_collection_append_tuple);
 make_binders!(user_type, cass_collection_append_user_type);

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -16,6 +16,7 @@ pub mod query_error;
 pub mod query_result;
 pub mod session;
 pub mod statement;
+pub mod tuple;
 pub mod types;
 pub mod user_type;
 pub mod uuid;

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -17,6 +17,7 @@ pub mod query_result;
 pub mod session;
 pub mod statement;
 pub mod types;
+pub mod user_type;
 pub mod uuid;
 
 lazy_static! {

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -6,6 +6,7 @@ use tokio::runtime::Runtime;
 mod binding;
 mod argconv;
 pub mod cass_error;
+pub mod cass_types;
 pub mod cluster;
 pub mod collection;
 pub mod future;

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -242,6 +242,12 @@ make_binders!(
     cass_statement_bind_collection_by_name_n
 );
 make_binders!(
+    tuple,
+    cass_statement_bind_tuple,
+    cass_statement_bind_tuple_by_name,
+    cass_statement_bind_tuple_by_name_n
+);
+make_binders!(
     user_type,
     cass_statement_bind_user_type,
     cass_statement_bind_user_type_by_name,

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -241,3 +241,9 @@ make_binders!(
     cass_statement_bind_collection_by_name,
     cass_statement_bind_collection_by_name_n
 );
+make_binders!(
+    user_type,
+    cass_statement_bind_user_type,
+    cass_statement_bind_user_type_by_name,
+    cass_statement_bind_user_type_by_name_n
+);

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -5,6 +5,7 @@ use crate::cass_types::CassDataType;
 use crate::cass_types::CassDataTypeArc;
 use crate::types::*;
 use scylla::frame::response::result::CqlValue;
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 static EMPTY_TUPLE_TYPE: CassDataType = CassDataType::Tuple(Vec::new());
@@ -46,6 +47,13 @@ impl CassTuple {
         self.items[index] = v;
 
         CassError::CASS_OK
+    }
+}
+
+impl TryFrom<&CassTuple> for CqlValue {
+    type Error = CassError;
+    fn try_from(tuple: &CassTuple) -> Result<Self, Self::Error> {
+        Ok(CqlValue::Tuple(tuple.items.clone()))
     }
 }
 
@@ -101,4 +109,5 @@ make_binders!(bytes, cass_tuple_set_bytes);
 make_binders!(uuid, cass_tuple_set_uuid);
 make_binders!(inet, cass_tuple_set_inet);
 make_binders!(collection, cass_tuple_set_collection);
+make_binders!(tuple, cass_tuple_set_tuple);
 make_binders!(user_type, cass_tuple_set_user_type);

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -1,0 +1,104 @@
+use crate::argconv::*;
+use crate::binding;
+use crate::cass_error::CassError;
+use crate::cass_types::CassDataType;
+use crate::cass_types::CassDataTypeArc;
+use crate::types::*;
+use scylla::frame::response::result::CqlValue;
+use std::sync::Arc;
+
+static EMPTY_TUPLE_TYPE: CassDataType = CassDataType::Tuple(Vec::new());
+
+#[derive(Clone)]
+pub struct CassTuple {
+    pub data_type: Option<CassDataTypeArc>,
+    pub items: Vec<Option<CqlValue>>,
+}
+
+impl CassTuple {
+    fn get_types(&self) -> Option<&Vec<CassDataTypeArc>> {
+        match &self.data_type {
+            Some(t) => match &**t {
+                CassDataType::Tuple(v) => Some(v),
+                _ => unreachable!(),
+            },
+            None => None,
+        }
+    }
+
+    // Logic in this function is adapted from cppdriver.
+    // https://github.com/scylladb/cpp-driver/blob/81ac12845bdb02f43bbf0384107334e37ae57cde/src/tuple.hpp#L87-L99
+    // If the tuple was created without type (`cass_tuple_new`) we'll only make sure to
+    // not bind items with too high index.
+    // If it was created using `cass_tuple_new_from_data_type` we additionally check if
+    // value has correct type.
+    fn bind_value(&mut self, index: usize, v: Option<CqlValue>) -> CassError {
+        if index >= self.items.len() {
+            return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
+        }
+
+        if let Some(inner_types) = self.get_types() {
+            if !binding::is_compatible_type(&inner_types[index], &v) {
+                return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
+            }
+        }
+
+        self.items[index] = v;
+
+        CassError::CASS_OK
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_tuple_new(item_count: size_t) -> *mut CassTuple {
+    Box::into_raw(Box::new(CassTuple {
+        data_type: None,
+        items: vec![None; item_count as usize],
+    }))
+}
+
+#[no_mangle]
+unsafe extern "C" fn cass_tuple_new_from_data_type(
+    data_type: *const CassDataType,
+) -> *mut CassTuple {
+    let data_type = clone_arced(data_type);
+    let item_count = match &*data_type {
+        CassDataType::Tuple(v) => v.len(),
+        _ => return std::ptr::null_mut(),
+    };
+    Box::into_raw(Box::new(CassTuple {
+        data_type: Some(data_type),
+        items: vec![None; item_count],
+    }))
+}
+
+#[no_mangle]
+unsafe extern "C" fn cass_tuple_free(tuple: *mut CassTuple) {
+    free_boxed(tuple)
+}
+
+#[no_mangle]
+unsafe extern "C" fn cass_tuple_data_type(tuple: *const CassTuple) -> *const CassDataType {
+    match &ptr_to_ref(tuple).data_type {
+        Some(t) => Arc::as_ptr(t),
+        None => &EMPTY_TUPLE_TYPE,
+    }
+}
+
+prepare_binders_macro!(@only_index CassTuple, |tuple: &mut CassTuple, index, v| tuple.bind_value(index, v));
+make_binders!(null, cass_tuple_set_null);
+make_binders!(int8, cass_tuple_set_int8);
+make_binders!(int16, cass_tuple_set_int16);
+make_binders!(int32, cass_tuple_set_int32);
+make_binders!(uint32, cass_tuple_set_uint32);
+make_binders!(int64, cass_tuple_set_int64);
+make_binders!(float, cass_tuple_set_float);
+make_binders!(double, cass_tuple_set_double);
+make_binders!(bool, cass_tuple_set_bool);
+make_binders!(string, cass_tuple_set_string);
+make_binders!(string_n, cass_tuple_set_string_n);
+make_binders!(bytes, cass_tuple_set_bytes);
+make_binders!(uuid, cass_tuple_set_uuid);
+make_binders!(inet, cass_tuple_set_inet);
+make_binders!(collection, cass_tuple_set_collection);
+make_binders!(user_type, cass_tuple_set_user_type);

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -189,3 +189,9 @@ make_binders!(
     cass_user_type_set_collection_by_name,
     cass_user_type_set_collection_by_name_n
 );
+make_binders!(
+    user_type,
+    cass_user_type_set_user_type,
+    cass_user_type_set_user_type_by_name,
+    cass_user_type_set_user_type_by_name_n
+);

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -190,6 +190,12 @@ make_binders!(
     cass_user_type_set_collection_by_name_n
 );
 make_binders!(
+    tuple,
+    cass_user_type_set_tuple,
+    cass_user_type_set_tuple_by_name,
+    cass_user_type_set_tuple_by_name_n
+);
+make_binders!(
     user_type,
     cass_user_type_set_user_type,
     cass_user_type_set_user_type_by_name,

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -1,0 +1,191 @@
+use crate::argconv::*;
+use crate::binding::is_compatible_type;
+use crate::cass_error::CassError;
+use crate::cass_types::CassDataType;
+use crate::cass_types::CassDataTypeArc;
+use crate::types::*;
+use scylla::frame::response::result::CqlValue;
+use std::os::raw::c_char;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct CassUserType {
+    pub data_type: CassDataTypeArc,
+
+    // Vec to preserve the order of fields
+    pub field_values: Vec<Option<CqlValue>>,
+}
+
+impl CassUserType {
+    fn set_option_by_index(&mut self, index: usize, value: Option<CqlValue>) -> CassError {
+        if index >= self.field_values.len() {
+            return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
+        }
+        if !is_compatible_type(&self.data_type.get_udt_type().field_types[index].1, &value) {
+            return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
+        }
+        self.field_values[index] = value;
+        CassError::CASS_OK
+    }
+
+    //TODO: some hashtable for name lookup?
+    fn set_option_by_name(&mut self, name: &str, value: Option<CqlValue>) -> CassError {
+        let mut found_field: bool = false;
+        for (index, (field_name, field_type)) in
+            self.data_type.get_udt_type().field_types.iter().enumerate()
+        {
+            if *field_name == name {
+                found_field = true;
+                if index >= self.field_values.len() {
+                    return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
+                }
+                if !is_compatible_type(field_type, &value) {
+                    return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
+                }
+                self.field_values[index] = value.clone();
+            }
+        }
+
+        if found_field {
+            CassError::CASS_OK
+        } else {
+            CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST
+        }
+    }
+}
+
+impl From<&CassUserType> for CqlValue {
+    fn from(user_type: &CassUserType) -> Self {
+        CqlValue::UserDefinedType {
+            keyspace: user_type.data_type.get_udt_type().keyspace.clone(),
+            type_name: user_type.data_type.get_udt_type().name.clone(),
+            fields: user_type
+                .field_values
+                .iter()
+                .zip(user_type.data_type.get_udt_type().field_types.iter())
+                .map(|(v, (name, _))| (name.clone(), v.clone()))
+                .collect(),
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_new_from_data_type(
+    data_type_raw: *const CassDataType,
+) -> *mut CassUserType {
+    let data_type = clone_arced(data_type_raw);
+
+    match &*data_type {
+        CassDataType::UDT(udt_data_type) => {
+            let field_values = vec![None; udt_data_type.field_types.len()];
+            Box::into_raw(Box::new(CassUserType {
+                data_type,
+                field_values,
+            }))
+        }
+        _ => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_free(user_type: *mut CassUserType) {
+    free_boxed(user_type);
+}
+#[no_mangle]
+pub unsafe extern "C" fn cass_user_type_data_type(
+    user_type: *const CassUserType,
+) -> *const CassDataType {
+    Arc::as_ptr(&ptr_to_ref(user_type).data_type)
+}
+
+prepare_binders_macro!(@index_and_name CassUserType,
+    |udt: &mut CassUserType, index, v| udt.set_option_by_index(index, v),
+    |udt: &mut CassUserType, name, v| udt.set_option_by_name(name, v));
+
+make_binders!(
+    null,
+    cass_user_type_set_null,
+    cass_user_type_set_null_by_name,
+    cass_user_type_set_null_by_name_n
+);
+make_binders!(
+    int8,
+    cass_user_type_set_int8,
+    cass_user_type_set_int8_by_name,
+    cass_user_type_set_int8_by_name_n
+);
+make_binders!(
+    int16,
+    cass_user_type_set_int16,
+    cass_user_type_set_int16_by_name,
+    cass_user_type_set_int16_by_name_n
+);
+make_binders!(
+    int32,
+    cass_user_type_set_int32,
+    cass_user_type_set_int32_by_name,
+    cass_user_type_set_int32_by_name_n
+);
+make_binders!(
+    uint32,
+    cass_user_type_set_uint32,
+    cass_user_type_set_uint32_by_name,
+    cass_user_type_set_uint32_by_name_n
+);
+make_binders!(
+    int64,
+    cass_user_type_set_int64,
+    cass_user_type_set_int64_by_name,
+    cass_user_type_set_int64_by_name_n
+);
+make_binders!(
+    float,
+    cass_user_type_set_float,
+    cass_user_type_set_float_by_name,
+    cass_user_type_set_float_by_name_n
+);
+make_binders!(
+    double,
+    cass_user_type_set_double,
+    cass_user_type_set_double_by_name,
+    cass_user_type_set_double_by_name_n
+);
+make_binders!(
+    bool,
+    cass_user_type_set_bool,
+    cass_user_type_set_bool_by_name,
+    cass_user_type_set_bool_by_name_n
+);
+make_binders!(
+    string,
+    cass_user_type_set_string,
+    string,
+    cass_user_type_set_string_by_name,
+    string_n,
+    cass_user_type_set_string_by_name_n
+);
+make_binders!(@index string_n, cass_user_type_set_string_n);
+make_binders!(
+    bytes,
+    cass_user_type_set_bytes,
+    cass_user_type_set_bytes_by_name,
+    cass_user_type_set_bytes_by_name_n
+);
+make_binders!(
+    uuid,
+    cass_user_type_set_uuid,
+    cass_user_type_set_uuid_by_name,
+    cass_user_type_set_uuid_by_name_n
+);
+make_binders!(
+    inet,
+    cass_user_type_set_inet,
+    cass_user_type_set_inet_by_name,
+    cass_user_type_set_inet_by_name_n
+);
+make_binders!(
+    collection,
+    cass_user_type_set_collection,
+    cass_user_type_set_collection_by_name,
+    cass_user_type_set_collection_by_name_n
+);


### PR DESCRIPTION
Based on https://github.com/hackathon-rust-cpp/cpp-rust-driver/pull/58
Implements CassDataType
Implements CassUserType, CassTuple and all bindings related to them, using new macros.