### PR TITLE
Add running integration tests to GitHub actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Pre-review checklist
+
+<!--
+    Make sure you took care of the issues on the list.
+    Put 'x' into those boxes which apply.
+    You can also create the PR now and click on all relevant checkboxes.
+-->
+
+- [ ] I have split my patch into logically separate commits.
+- [ ] All commit messages clearly explain what they change and why.
+- [ ] PR description sums up the changes and reasons why they should be introduced.
+- [ ] I have enabled appropriate tests in `.github/workflows/build.yaml` in `gtest_filter`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,5 +14,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Setup Python 3
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Setup environment
+      run: |
+        sudo sh -c "echo 'deb http://security.ubuntu.com/ubuntu xenial-security main' >> /etc/apt/sources.list"
+        sudo apt-get update
+        sudo apt-get install libssl1.0.0 libuv1-dev libkrb5-dev libc6-dbg
+        sudo snap install valgrind --classic
+        pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
+        sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
+
     - name: Build
-      run: cmake . && make
+      run: cmake -DCASS_BUILD_INTEGRATION_TESTS=ON . && make
+
+    - name: Run integration tests on Scylla 5.0.0
+      run: valgrind --error-exitcode=123 ./cassandra-integration-tests --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="ClusterTests.*"


### PR DESCRIPTION
This PR adds running integration tests to GitHub actions. `scylla-ccm` is used for managing clusters and tests are run on `Scylla 5.0.0`. Tests are run with `Valgrind` which will detect memory corruption and will not show details of leaked memory. For now, only `ClusterTests` are enabled to be tested on GitHub actions.