### PR TITLE
Cassandra types tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,14 @@ jobs:
       run: cmake -DCASS_BUILD_INTEGRATION_TESTS=ON . && make
 
     - name: Run integration tests on Scylla 5.0.0
-      run: valgrind --error-exitcode=123 ./cassandra-integration-tests --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="ClusterTests.*:BasicsTests.*:PreparedTests.*:-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare"
+      env:
+#        Ignored tests are added in the end, after the "-" sign.
+        Tests: "ClusterTests.*\
+:BasicsTests.*\
+:PreparedTests.*\
+:CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
+:-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
+:*5.Integration_Cassandra_*\
+:*19.Integration_Cassandra_*\
+:CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_UDT"
+      run: valgrind --error-exitcode=123 ./cassandra-integration-tests --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -127,6 +127,18 @@ impl CassDataType {
             _ => panic!("Can get UDT out of non-UDT data type"),
         }
     }
+
+    pub fn get_value_type(&self) -> CassValueType {
+        match &self {
+            CassDataType::Value(value_data_type) => *value_data_type,
+            CassDataType::UDT { .. } => CassValueType::CASS_VALUE_TYPE_UDT,
+            CassDataType::List(..) => CassValueType::CASS_VALUE_TYPE_LIST,
+            CassDataType::Set(..) => CassValueType::CASS_VALUE_TYPE_SET,
+            CassDataType::Map(..) => CassValueType::CASS_VALUE_TYPE_MAP,
+            CassDataType::Tuple(..) => CassValueType::CASS_VALUE_TYPE_TUPLE,
+            CassDataType::Custom(..) => CassValueType::CASS_VALUE_TYPE_CUSTOM,
+        }
+    }
 }
 
 pub fn get_column_type(column_type: &ColumnType) -> CassDataType {
@@ -232,15 +244,7 @@ pub unsafe extern "C" fn cass_data_type_free(data_type: *mut CassDataType) {
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_type(data_type: *const CassDataType) -> CassValueType {
     let data_type = ptr_to_ref(data_type);
-    match data_type {
-        CassDataType::Value(value_data_type) => *value_data_type,
-        CassDataType::UDT { .. } => CassValueType::CASS_VALUE_TYPE_UDT,
-        CassDataType::List(..) => CassValueType::CASS_VALUE_TYPE_LIST,
-        CassDataType::Set(..) => CassValueType::CASS_VALUE_TYPE_SET,
-        CassDataType::Map(..) => CassValueType::CASS_VALUE_TYPE_MAP,
-        CassDataType::Tuple(..) => CassValueType::CASS_VALUE_TYPE_TUPLE,
-        CassDataType::Custom(..) => CassValueType::CASS_VALUE_TYPE_CUSTOM,
-    }
+    data_type.get_value_type()
 }
 
 // #[no_mangle]

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -84,7 +84,9 @@ pub unsafe extern "C" fn cass_session_execute(
 
         let query_res: Result<QueryResult, QueryError> = match statement {
             Statement::Simple(query) => {
-                session.query_paged(query, bound_values, paging_state).await
+                session
+                    .query_paged(query.query, bound_values, paging_state)
+                    .await
             }
             Statement::Prepared(prepared) => {
                 session
@@ -268,7 +270,7 @@ pub unsafe extern "C" fn cass_session_prepare_from_existing(
         }
         let session = session_guard.as_ref().unwrap();
         let prepared = session
-            .prepare(query.clone())
+            .prepare(query.query.clone())
             .await
             .map_err(|err| (CassError::from(&err), err.msg()))?;
 

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -396,14 +396,6 @@ CASS_EXPORT CassIterator*
 cass_iterator_fields_from_user_type(const CassValue* value){
 	throw std::runtime_error("UNIMPLEMENTED cass_iterator_fields_from_user_type\n");
 }
-CASS_EXPORT CassIterator*
-cass_iterator_from_collection(const CassValue* value){
-	throw std::runtime_error("UNIMPLEMENTED cass_iterator_from_collection\n");
-}
-CASS_EXPORT CassIterator*
-cass_iterator_from_tuple(const CassValue* value){
-	throw std::runtime_error("UNIMPLEMENTED cass_iterator_from_tuple\n");
-}
 CASS_EXPORT CassError
 cass_iterator_get_user_type_field_name(const CassIterator* iterator,
                                        const char** name,
@@ -413,10 +405,6 @@ cass_iterator_get_user_type_field_name(const CassIterator* iterator,
 CASS_EXPORT const CassValue*
 cass_iterator_get_user_type_field_value(const CassIterator* iterator){
 	throw std::runtime_error("UNIMPLEMENTED cass_iterator_get_user_type_field_value\n");
-}
-CASS_EXPORT const CassValue*
-cass_iterator_get_value(const CassIterator* iterator){
-	throw std::runtime_error("UNIMPLEMENTED cass_iterator_get_value\n");
 }
 CASS_EXPORT const CassAggregateMeta*
 cass_keyspace_meta_aggregate_by_name(const CassKeyspaceMeta* keyspace_meta,

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -760,19 +760,3 @@ cass_value_get_duration(const CassValue* value,
                         cass_int64_t* nanos){
 	throw std::runtime_error("UNIMPLEMENTED cass_value_get_duration\n");
 }
-CASS_EXPORT cass_bool_t
-cass_value_is_collection(const CassValue* value){
-	throw std::runtime_error("UNIMPLEMENTED cass_value_is_collection\n");
-}
-CASS_EXPORT size_t
-cass_value_item_count(const CassValue* collection){
-	throw std::runtime_error("UNIMPLEMENTED cass_value_item_count\n");
-}
-CASS_EXPORT CassValueType
-cass_value_primary_sub_type(const CassValue* collection){
-	throw std::runtime_error("UNIMPLEMENTED cass_value_primary_sub_type\n");
-}
-CASS_EXPORT CassValueType
-cass_value_secondary_sub_type(const CassValue* collection){
-	throw std::runtime_error("UNIMPLEMENTED cass_value_secondary_sub_type\n");
-}

--- a/tests/src/integration/objects/result.hpp
+++ b/tests/src/integration/objects/result.hpp
@@ -258,6 +258,9 @@ public:
     return T(value_);
   }
 
+  CassValue const* get_value() const {
+    return value_;
+  }
 private:
   /**
    * The value held by this column

--- a/tests/src/integration/values/varchar.hpp
+++ b/tests/src/integration/values/varchar.hpp
@@ -89,7 +89,7 @@ public:
 
   ValueType value() const { return varchar_; }
 
-  CassValueType value_type() const { return CASS_VALUE_TYPE_VARCHAR; }
+  CassValueType value_type() const { return CASS_VALUE_TYPE_TEXT; }
 
 protected:
   /**
@@ -111,7 +111,7 @@ public:
   std::string cql_type() const { return "text"; }
 
   CassValueType value_type() const {
-    return CASS_VALUE_TYPE_VARCHAR; // Text (alias is returned as varchar from server)
+    return CASS_VALUE_TYPE_TEXT; // Text (alias is returned as varchar from server)
   }
 };
 


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yaml` in `gtest_filter`.

This PR is dependent on #68.

Adds necessary implementation to pass all `CassandraTypesTests` excluding `UDT` tests as it requires an implementation to get cluster schema metadata, so it will be done in another PR.
Tests are modified to properly iterate over collections to check their values and size.
As `CassandraTypesTests` tests collections with all possible types, overall `208` tests are enabled. Only tests for `Decimal` and `Varint` types are disabled, as `invoke_binder_maker_macro_with_type` is not yet implemented for `Decimal` type and `cass_value_get_bytes` is not implemented for `Varint`. The latter should be implemented for all types, however, it requires the rust driver to return raw bytes of values instead of `CqlValue`. 