### PR TITLE
Add batch support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
 :BasicsTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
+:BatchSingleNodeClusterTests*:BatchCounterSingleNodeClusterTests*:BatchCounterThreeNodeClusterTests*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*\

--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -71,6 +71,11 @@ fn main() {
         &out_path,
     );
     prepare_cppdriver_data(
+        "cppdriver_batch_types.rs",
+        &["CassBatchType_", "CassBatchType"],
+        &out_path,
+    );
+    prepare_cppdriver_data(
         "cppdriver_data_collection.rs",
         &["CassCollectionType_", "CassCollectionType"],
         &out_path,

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -1,0 +1,146 @@
+use crate::argconv::{free_boxed, ptr_to_ref, ptr_to_ref_mut};
+use crate::cass_error::CassError;
+use crate::cass_types::CassConsistency;
+use crate::cass_types::{make_batch_type, CassBatchType};
+use crate::statement::{CassStatement, Statement};
+use crate::types::*;
+use scylla::batch::Batch;
+use scylla::frame::response::result::CqlValue;
+use scylla::frame::value::MaybeUnset;
+use std::convert::TryInto;
+use std::sync::Arc;
+
+pub struct CassBatch {
+    pub state: Arc<CassBatchState>,
+    pub batch_request_timeout_ms: Option<cass_uint64_t>,
+}
+
+#[derive(Clone)]
+pub struct CassBatchState {
+    pub batch: Batch,
+    pub bound_values: Vec<Vec<MaybeUnset<Option<CqlValue>>>>,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_new(type_: CassBatchType) -> *mut CassBatch {
+    if let Some(batch_type) = make_batch_type(type_) {
+        Box::into_raw(Box::new(CassBatch {
+            state: Arc::new(CassBatchState {
+                batch: Batch::new(batch_type),
+                bound_values: Vec::new(),
+            }),
+            batch_request_timeout_ms: None,
+        }))
+    } else {
+        std::ptr::null_mut()
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_free(batch: *mut CassBatch) {
+    free_boxed(batch)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_set_consistency(
+    batch: *mut CassBatch,
+    consistency: CassConsistency,
+) -> CassError {
+    let batch = ptr_to_ref_mut(batch);
+    let consistency = match consistency.try_into().ok() {
+        Some(c) => c,
+        None => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
+    };
+    Arc::make_mut(&mut batch.state)
+        .batch
+        .set_consistency(consistency);
+
+    CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_set_serial_consistency(
+    batch: *mut CassBatch,
+    serial_consistency: CassConsistency,
+) -> CassError {
+    let batch = ptr_to_ref_mut(batch);
+    let serial_consistency = match serial_consistency.try_into().ok() {
+        Some(c) => c,
+        None => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
+    };
+    Arc::make_mut(&mut batch.state)
+        .batch
+        .set_serial_consistency(Some(serial_consistency));
+
+    CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_set_timestamp(
+    batch: *mut CassBatch,
+    timestamp: cass_int64_t,
+) -> CassError {
+    let batch = ptr_to_ref_mut(batch);
+
+    Arc::make_mut(&mut batch.state)
+        .batch
+        .set_timestamp(Some(timestamp));
+
+    CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_set_request_timeout(
+    batch: *mut CassBatch,
+    timeout_ms: cass_uint64_t,
+) -> CassError {
+    let batch = ptr_to_ref_mut(batch);
+    batch.batch_request_timeout_ms = Some(timeout_ms);
+
+    CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_set_is_idempotent(
+    batch: *mut CassBatch,
+    is_idempotent: cass_bool_t,
+) -> CassError {
+    let batch = ptr_to_ref_mut(batch);
+    Arc::make_mut(&mut batch.state)
+        .batch
+        .set_is_idempotent(is_idempotent != 0);
+
+    CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_set_tracing(
+    batch: *mut CassBatch,
+    enabled: cass_bool_t,
+) -> CassError {
+    let batch = ptr_to_ref_mut(batch);
+    Arc::make_mut(&mut batch.state)
+        .batch
+        .set_tracing(enabled != 0);
+
+    CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_add_statement(
+    batch: *mut CassBatch,
+    statement: *const CassStatement,
+) -> CassError {
+    let batch = ptr_to_ref_mut(batch);
+    let state = Arc::make_mut(&mut batch.state);
+    let statement = ptr_to_ref(statement);
+
+    match &statement.statement {
+        Statement::Simple(q) => state.batch.append_statement(q.query.clone()),
+        Statement::Prepared(p) => state.batch.append_statement((**p).clone()),
+    };
+
+    state.bound_values.push(statement.bound_values.clone());
+
+    CassError::CASS_OK
+}

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -5,6 +5,7 @@ use tokio::runtime::Runtime;
 #[macro_use]
 mod binding;
 mod argconv;
+pub mod batch;
 pub mod cass_error;
 pub mod cass_types;
 pub mod cluster;

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -53,19 +53,6 @@ cass_authenticator_set_error(CassAuthenticator* auth,
 	throw std::runtime_error("UNIMPLEMENTED cass_authenticator_set_error\n");
 }
 CASS_EXPORT CassError
-cass_batch_add_statement(CassBatch* batch,
-                         CassStatement* statement){
-	throw std::runtime_error("UNIMPLEMENTED cass_batch_add_statement\n");
-}
-CASS_EXPORT void
-cass_batch_free(CassBatch* batch){
-	throw std::runtime_error("UNIMPLEMENTED cass_batch_free\n");
-}
-CASS_EXPORT CassBatch*
-cass_batch_new(CassBatchType type){
-	throw std::runtime_error("UNIMPLEMENTED cass_batch_new\n");
-}
-CASS_EXPORT CassError
 cass_batch_set_execution_profile(CassBatch* batch,
                                  const char* name){
 	throw std::runtime_error("UNIMPLEMENTED cass_batch_set_execution_profile\n");
@@ -74,11 +61,6 @@ CASS_EXPORT CassError
 cass_batch_set_keyspace(CassBatch* batch,
                         const char* keyspace){
 	throw std::runtime_error("UNIMPLEMENTED cass_batch_set_keyspace\n");
-}
-CASS_EXPORT CassError
-cass_batch_set_timestamp(CassBatch* batch,
-                         cass_int64_t timestamp){
-	throw std::runtime_error("UNIMPLEMENTED cass_batch_set_timestamp\n");
 }
 CASS_EXPORT CassError
 cass_cluster_set_authenticator_callbacks(CassCluster* cluster,
@@ -495,11 +477,6 @@ cass_session_connect_keyspace(CassSession* session,
                               const CassCluster* cluster,
                               const char* keyspace){
 	throw std::runtime_error("UNIMPLEMENTED cass_session_connect_keyspace\n");
-}
-CASS_EXPORT CassFuture*
-cass_session_execute_batch(CassSession* session,
-                           const CassBatch* batch){
-	throw std::runtime_error("UNIMPLEMENTED cass_session_execute_batch\n");
 }
 CASS_EXPORT void
 cass_session_get_metrics(const CassSession* session,

--- a/tests/src/integration/ccm/bridge.cpp
+++ b/tests/src/integration/ccm/bridge.cpp
@@ -501,6 +501,9 @@ bool CCM::Bridge::start_cluster(
     oss << smp_;
     jvm_arguments.push_back(oss.str());
   }
+  if (is_scylla_) {
+    jvm_arguments.push_back("--skip-wait-for-gossip-to-settle=0");
+  }
   for (std::vector<std::string>::const_iterator iterator = jvm_arguments.begin();
        iterator != jvm_arguments.end(); ++iterator) {
     std::string jvm_argument = trim(*iterator);


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yaml` in `gtest_filter`.

This PR is dependent upon #69

Adds batch support to the driver.
As `BatchCounterThreeNodeClusterTests.Integration_Cassandra_MixedPreparedAndSimple` integration test creates a 3-node cluster which takes a lot of time, a special flag `--skip-wait-for-gossip-to-settle=0` is added to `ccm` to avoid unnecessary gossip delays.