### PR TITLE
Add cluster schema metadata and UDT iterator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,5 @@ jobs:
 :SslNoClusterTests*:SslNoSslOnClusterTests*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
-:*19.Integration_Cassandra_*\
-:CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_UDT"
+:*19.Integration_Cassandra_*"
       run: valgrind --error-exitcode=123 ./cassandra-integration-tests --scylla --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
 :BatchSingleNodeClusterTests*:BatchCounterSingleNodeClusterTests*:BatchCounterThreeNodeClusterTests*\
 :ErrorTests.*\
 :SslNoClusterTests*:SslNoSslOnClusterTests*\
+:SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*"

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -47,6 +47,7 @@ jobs:
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :ErrorTests.*\
 :SslClientAuthenticationTests*:SslNoClusterTests*:SslNoSslOnClusterTests*:SslTests*\
+:SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*\

--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -81,6 +81,11 @@ fn main() {
         &out_path,
     );
     prepare_cppdriver_data(
+        "cppdriver_column_type.rs",
+        &["CassColumnType_", "CassColumnType"],
+        &out_path,
+    );
+    prepare_cppdriver_data(
         "cppdriver_data_inet.rs",
         &["CassInet_", "CassInet"],
         &out_path,

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -3,6 +3,8 @@ use crate::cass_error::CassError;
 use crate::types::*;
 use scylla::batch::{BatchType, Consistency, SerialConsistency};
 use scylla::frame::response::result::ColumnType;
+use scylla::transport::topology::{CollectionType, CqlType, NativeType};
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::os::raw::c_char;
 use std::ptr;
@@ -12,7 +14,7 @@ include!(concat!(env!("OUT_DIR"), "/cppdriver_data_types.rs"));
 include!(concat!(env!("OUT_DIR"), "/cppdriver_data_query_error.rs"));
 include!(concat!(env!("OUT_DIR"), "/cppdriver_batch_types.rs"));
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct UDTDataType {
     // Vec to preserve the order of types
     pub field_types: Vec<(String, CassDataTypeArc)>,
@@ -27,6 +29,32 @@ impl UDTDataType {
             field_types: Vec::new(),
             keyspace: "".to_string(),
             name: "".to_string(),
+        }
+    }
+
+    pub fn create_with_params(
+        user_defined_types: &HashMap<String, Vec<(String, CqlType)>>,
+        keyspace_name: &str,
+        name: &str,
+    ) -> UDTDataType {
+        UDTDataType {
+            field_types: user_defined_types
+                .get(name)
+                .unwrap_or(&vec![])
+                .iter()
+                .map(|(udt_field_name, udt_field_type)| {
+                    (
+                        udt_field_name.clone(),
+                        Arc::new(get_column_type_from_cql_type(
+                            udt_field_type,
+                            user_defined_types,
+                            keyspace_name,
+                        )),
+                    )
+                })
+                .collect(),
+            keyspace: keyspace_name.to_string(),
+            name: name.to_owned(),
         }
     }
 
@@ -60,7 +88,7 @@ impl Default for UDTDataType {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum CassDataType {
     Value(CassValueType),
     UDT(UDTDataType),
@@ -72,6 +100,78 @@ pub enum CassDataType {
 }
 
 pub type CassDataTypeArc = Arc<CassDataType>;
+
+impl From<NativeType> for CassValueType {
+    fn from(native_type: NativeType) -> CassValueType {
+        match native_type {
+            NativeType::Ascii => CassValueType::CASS_VALUE_TYPE_ASCII,
+            NativeType::Boolean => CassValueType::CASS_VALUE_TYPE_BOOLEAN,
+            NativeType::Blob => CassValueType::CASS_VALUE_TYPE_BLOB,
+            NativeType::Counter => CassValueType::CASS_VALUE_TYPE_COUNTER,
+            NativeType::Date => CassValueType::CASS_VALUE_TYPE_DATE,
+            NativeType::Decimal => CassValueType::CASS_VALUE_TYPE_DECIMAL,
+            NativeType::Double => CassValueType::CASS_VALUE_TYPE_DOUBLE,
+            NativeType::Duration => CassValueType::CASS_VALUE_TYPE_DURATION,
+            NativeType::Float => CassValueType::CASS_VALUE_TYPE_FLOAT,
+            NativeType::Int => CassValueType::CASS_VALUE_TYPE_INT,
+            NativeType::BigInt => CassValueType::CASS_VALUE_TYPE_BIGINT,
+            NativeType::Text => CassValueType::CASS_VALUE_TYPE_TEXT,
+            NativeType::Timestamp => CassValueType::CASS_VALUE_TYPE_TIMESTAMP,
+            NativeType::Inet => CassValueType::CASS_VALUE_TYPE_INET,
+            NativeType::SmallInt => CassValueType::CASS_VALUE_TYPE_SMALL_INT,
+            NativeType::TinyInt => CassValueType::CASS_VALUE_TYPE_TINY_INT,
+            NativeType::Time => CassValueType::CASS_VALUE_TYPE_TIME,
+            NativeType::Timeuuid => CassValueType::CASS_VALUE_TYPE_TIMEUUID,
+            NativeType::Uuid => CassValueType::CASS_VALUE_TYPE_UUID,
+            NativeType::Varint => CassValueType::CASS_VALUE_TYPE_VARINT,
+        }
+    }
+}
+
+pub fn get_column_type_from_cql_type(
+    cql_type: &CqlType,
+    user_defined_types: &HashMap<String, Vec<(String, CqlType)>>,
+    keyspace_name: &str,
+) -> CassDataType {
+    match cql_type {
+        CqlType::Native(native) => CassDataType::Value(native.clone().into()),
+        CqlType::Collection { type_, .. } => match type_ {
+            CollectionType::List(list) => CassDataType::List(Some(Arc::new(
+                get_column_type_from_cql_type(list, user_defined_types, keyspace_name),
+            ))),
+            CollectionType::Map(key, value) => CassDataType::Map(
+                Some(Arc::new(get_column_type_from_cql_type(
+                    key,
+                    user_defined_types,
+                    keyspace_name,
+                ))),
+                Some(Arc::new(get_column_type_from_cql_type(
+                    value,
+                    user_defined_types,
+                    keyspace_name,
+                ))),
+            ),
+            CollectionType::Set(set) => CassDataType::Set(Some(Arc::new(
+                get_column_type_from_cql_type(set, user_defined_types, keyspace_name),
+            ))),
+        },
+        CqlType::Tuple(tuple) => CassDataType::Tuple(
+            tuple
+                .iter()
+                .map(|field_type| {
+                    Arc::new(get_column_type_from_cql_type(
+                        field_type,
+                        user_defined_types,
+                        keyspace_name,
+                    ))
+                })
+                .collect(),
+        ),
+        CqlType::UserDefinedType { name, .. } => CassDataType::UDT(
+            UDTDataType::create_with_params(user_defined_types, keyspace_name, name),
+        ),
+    }
+}
 
 impl CassDataType {
     fn get_sub_data_type(&self, index: usize) -> Option<&CassDataTypeArc> {

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -2,7 +2,10 @@ use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::cass_types::{cass_data_type_type, CassDataType, CassDataTypeArc, CassValueType};
 use crate::inet::CassInet;
-use crate::session::{CassKeyspaceMeta, CassSchemaMeta, CassSchemaMeta_};
+use crate::session::{
+    CassColumnMeta, CassKeyspaceMeta, CassKeyspaceMeta_, CassSchemaMeta, CassSchemaMeta_,
+    CassTableMeta, CassTableMeta_,
+};
 use crate::statement::CassStatement;
 use crate::types::*;
 use crate::uuid::CassUuid;
@@ -93,6 +96,18 @@ pub struct CassSchemaMetaIterator {
     position: Option<usize>,
 }
 
+pub struct CassKeyspaceMetaIterator {
+    value: CassKeyspaceMeta_,
+    count: usize,
+    position: Option<usize>,
+}
+
+pub struct CassTableMetaIterator {
+    value: CassTableMeta_,
+    count: usize,
+    position: Option<usize>,
+}
+
 pub enum CassIterator {
     CassResultIterator(CassResultIterator),
     CassRowIterator(CassRowIterator),
@@ -100,6 +115,9 @@ pub enum CassIterator {
     CassMapIterator(CassMapIterator),
     CassUdtIterator(CassUdtIterator),
     CassSchemaMetaIterator(CassSchemaMetaIterator),
+    CassKeyspaceMetaTableIterator(CassKeyspaceMetaIterator),
+    CassKeyspaceMetaUserTypeIterator(CassKeyspaceMetaIterator),
+    CassTableMetaIterator(CassTableMetaIterator),
 }
 
 #[no_mangle]
@@ -161,6 +179,31 @@ pub unsafe extern "C" fn cass_iterator_next(iterator: *mut CassIterator) -> cass
             schema_meta_iterator.position = Some(new_pos);
 
             (new_pos < schema_meta_iterator.count) as cass_bool_t
+        }
+        CassIterator::CassKeyspaceMetaTableIterator(keyspace_meta_iterator) => {
+            let new_pos: usize = keyspace_meta_iterator
+                .position
+                .map_or(0, |prev_pos| prev_pos + 1);
+
+            keyspace_meta_iterator.position = Some(new_pos);
+
+            (new_pos < keyspace_meta_iterator.count) as cass_bool_t
+        }
+        CassIterator::CassKeyspaceMetaUserTypeIterator(keyspace_meta_iterator) => {
+            let new_pos: usize = keyspace_meta_iterator
+                .position
+                .map_or(0, |prev_pos| prev_pos + 1);
+
+            keyspace_meta_iterator.position = Some(new_pos);
+
+            (new_pos < keyspace_meta_iterator.count) as cass_bool_t
+        }
+        CassIterator::CassTableMetaIterator(table_iterator) => {
+            let new_pos: usize = table_iterator.position.map_or(0, |prev_pos| prev_pos + 1);
+
+            table_iterator.position = Some(new_pos);
+
+            (new_pos < table_iterator.count) as cass_bool_t
         }
     }
 }
@@ -396,6 +439,89 @@ pub unsafe extern "C" fn cass_iterator_get_keyspace_meta(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn cass_iterator_get_table_meta(
+    iterator: *const CassIterator,
+) -> *const CassTableMeta {
+    let iter = ptr_to_ref(iterator);
+
+    if let CassIterator::CassKeyspaceMetaTableIterator(keyspace_meta_iterator) = iter {
+        let iter_position = match keyspace_meta_iterator.position {
+            Some(pos) => pos,
+            None => return std::ptr::null(),
+        };
+
+        let table_meta_entry_opt = keyspace_meta_iterator
+            .value
+            .tables
+            .iter()
+            .nth(iter_position);
+
+        return match table_meta_entry_opt {
+            Some(table_meta_entry) => table_meta_entry.1 as *const CassTableMeta,
+            None => std::ptr::null(),
+        };
+    }
+
+    std::ptr::null()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_iterator_get_user_type(
+    iterator: *const CassIterator,
+) -> *const CassDataType {
+    let iter = ptr_to_ref(iterator);
+
+    if let CassIterator::CassKeyspaceMetaUserTypeIterator(keyspace_meta_iterator) = iter {
+        let iter_position = match keyspace_meta_iterator.position {
+            Some(pos) => pos,
+            None => return std::ptr::null(),
+        };
+
+        let udt_to_type_entry_opt = keyspace_meta_iterator
+            .value
+            .user_defined_type_data_type
+            .iter()
+            .nth(iter_position);
+
+        return match udt_to_type_entry_opt {
+            Some(udt_to_type_entry) => {
+                Arc::into_raw(udt_to_type_entry.1.clone()) as *const CassDataType
+            }
+            None => std::ptr::null(),
+        };
+    }
+
+    std::ptr::null()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_iterator_get_column_meta(
+    iterator: *const CassIterator,
+) -> *const CassColumnMeta {
+    let iter = ptr_to_ref(iterator);
+
+    if let CassIterator::CassTableMetaIterator(table_meta_iterator) = iter {
+        let iter_position = match table_meta_iterator.position {
+            Some(pos) => pos,
+            None => return std::ptr::null(),
+        };
+
+        let column_meta_entry_opt = table_meta_iterator
+            .value
+            .columns_metadata
+            .iter()
+            .nth(iter_position);
+
+        return match column_meta_entry_opt {
+            Some(column_meta_entry) => column_meta_entry.1 as *const CassColumnMeta,
+            None => std::ptr::null(),
+        };
+    }
+
+    std::ptr::null()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn cass_iterator_from_result(result: *const CassResult) -> *mut CassIterator {
     let result_from_raw: CassResult_ = clone_arced(result);
 
@@ -515,6 +641,55 @@ pub unsafe extern "C" fn cass_iterator_keyspaces_from_schema_meta(
     };
 
     Box::into_raw(Box::new(CassIterator::CassSchemaMetaIterator(iterator)))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_iterator_tables_from_keyspace_meta(
+    keyspace_meta: *const CassKeyspaceMeta,
+) -> *mut CassIterator {
+    let metadata = ptr_to_ref(keyspace_meta);
+
+    let iterator = CassKeyspaceMetaIterator {
+        value: metadata,
+        count: metadata.tables.len(),
+        position: None,
+    };
+
+    Box::into_raw(Box::new(CassIterator::CassKeyspaceMetaTableIterator(
+        iterator,
+    )))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_iterator_user_types_from_keyspace_meta(
+    keyspace_meta: *const CassKeyspaceMeta,
+) -> *mut CassIterator {
+    let metadata = ptr_to_ref(keyspace_meta);
+
+    let iterator = CassKeyspaceMetaIterator {
+        value: metadata,
+        count: metadata.user_defined_type_data_type.len(),
+        position: None,
+    };
+
+    Box::into_raw(Box::new(CassIterator::CassKeyspaceMetaUserTypeIterator(
+        iterator,
+    )))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_iterator_columns_from_table_meta(
+    table_meta: *const CassTableMeta,
+) -> *mut CassIterator {
+    let metadata = ptr_to_ref(table_meta);
+
+    let iterator = CassTableMetaIterator {
+        value: metadata,
+        count: metadata.columns_metadata.len(),
+        position: None,
+    };
+
+    Box::into_raw(Box::new(CassIterator::CassTableMetaIterator(iterator)))
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -32,6 +32,8 @@ include!(concat!(env!("OUT_DIR"), "/cppdriver_column_type.rs"));
 pub type CassSession = RwLock<Option<Session>>;
 type CassSession_ = Arc<CassSession>;
 
+pub type CassKeyspaceMeta_ = &'static CassKeyspaceMeta;
+
 pub struct CassKeyspaceMeta {
     name: String,
 
@@ -39,6 +41,8 @@ pub struct CassKeyspaceMeta {
     pub user_defined_type_data_type: HashMap<String, Arc<CassDataType>>,
     pub tables: HashMap<String, CassTableMeta>,
 }
+
+pub type CassTableMeta_ = &'static CassTableMeta;
 
 pub struct CassTableMeta {
     pub name: String,

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -585,3 +585,149 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
         None => std::ptr::null(),
     }
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_keyspace_meta_table_by_name(
+    keyspace_meta: *const CassKeyspaceMeta,
+    table: *const c_char,
+) -> *const CassTableMeta {
+    cass_keyspace_meta_table_by_name_n(keyspace_meta, table, strlen(table))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_keyspace_meta_table_by_name_n(
+    keyspace_meta: *const CassKeyspaceMeta,
+    table: *const c_char,
+    table_length: size_t,
+) -> *const CassTableMeta {
+    if table.is_null() {
+        return std::ptr::null();
+    }
+
+    let keyspace_meta = ptr_to_ref(keyspace_meta);
+    let table_name = ptr_to_cstr_n(table, table_length).unwrap();
+
+    let table_meta = keyspace_meta.tables.get(table_name);
+
+    match table_meta {
+        Some(meta) => meta as *const CassTableMeta,
+        None => std::ptr::null(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_table_meta_name(
+    table_meta: *const CassTableMeta,
+    name: *mut *const c_char,
+    name_length: *mut size_t,
+) {
+    let table_meta = ptr_to_ref(table_meta);
+    write_str_to_c(table_meta.name.as_str(), name, name_length)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_table_meta_column_count(table_meta: *const CassTableMeta) -> size_t {
+    let table_meta = ptr_to_ref(table_meta);
+    table_meta.columns_metadata.len() as size_t
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_table_meta_partition_key(
+    table_meta: *const CassTableMeta,
+    index: size_t,
+) -> *const CassColumnMeta {
+    let table_meta = ptr_to_ref(table_meta);
+
+    match table_meta.partition_keys.get(index as usize) {
+        Some(column_name) => match table_meta.columns_metadata.get(column_name) {
+            Some(column_meta) => column_meta as *const CassColumnMeta,
+            None => std::ptr::null(),
+        },
+        None => std::ptr::null(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_table_meta_partition_key_count(
+    table_meta: *const CassTableMeta,
+) -> size_t {
+    let table_meta = ptr_to_ref(table_meta);
+    table_meta.partition_keys.len() as size_t
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_table_meta_clustering_key(
+    table_meta: *const CassTableMeta,
+    index: size_t,
+) -> *const CassColumnMeta {
+    let table_meta = ptr_to_ref(table_meta);
+
+    match table_meta.clustering_keys.get(index as usize) {
+        Some(column_name) => match table_meta.columns_metadata.get(column_name) {
+            Some(column_meta) => column_meta as *const CassColumnMeta,
+            None => std::ptr::null(),
+        },
+        None => std::ptr::null(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_table_meta_clustering_key_count(
+    table_meta: *const CassTableMeta,
+) -> size_t {
+    let table_meta = ptr_to_ref(table_meta);
+    table_meta.clustering_keys.len() as size_t
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_table_meta_column_by_name(
+    table_meta: *const CassTableMeta,
+    column: *const c_char,
+) -> *const CassColumnMeta {
+    cass_table_meta_column_by_name_n(table_meta, column, strlen(column))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_table_meta_column_by_name_n(
+    table_meta: *const CassTableMeta,
+    column: *const c_char,
+    column_length: size_t,
+) -> *const CassColumnMeta {
+    if column.is_null() {
+        return std::ptr::null();
+    }
+
+    let table_meta = ptr_to_ref(table_meta);
+    let column_name = ptr_to_cstr_n(column, column_length).unwrap();
+
+    match table_meta.columns_metadata.get(column_name) {
+        Some(column_meta) => column_meta as *const CassColumnMeta,
+        None => std::ptr::null(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_column_meta_name(
+    column_meta: *const CassColumnMeta,
+    name: *mut *const c_char,
+    name_length: *mut size_t,
+) {
+    let column_meta = ptr_to_ref(column_meta);
+    write_str_to_c(column_meta.name.as_str(), name, name_length)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_column_meta_data_type(
+    column_meta: *const CassColumnMeta,
+) -> *const CassDataType {
+    let column_meta = ptr_to_ref(column_meta);
+    &column_meta.column_type as *const CassDataType
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_column_meta_type(
+    column_meta: *const CassColumnMeta,
+) -> CassColumnType {
+    let column_meta = ptr_to_ref(column_meta);
+    column_meta.column_kind
+}

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -31,7 +31,7 @@ pub struct CassKeyspaceMeta {
     name: String,
 
     // User defined type name to type
-    pub user_defined_type_data_type: HashMap<String, CassDataType>,
+    pub user_defined_type_data_type: HashMap<String, Arc<CassDataType>>,
 }
 
 pub struct CassSchemaMeta {
@@ -427,11 +427,11 @@ pub unsafe extern "C" fn cass_session_get_schema_meta(
         for udt_name in keyspace.user_defined_types.keys() {
             user_defined_type_data_type.insert(
                 udt_name.clone(),
-                CassDataType::UDT(UDTDataType::create_with_params(
+                Arc::new(CassDataType::UDT(UDTDataType::create_with_params(
                     &keyspace.user_defined_types,
                     keyspace_name,
                     udt_name,
-                )),
+                ))),
             );
         }
         keyspaces.insert(
@@ -515,7 +515,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
         .user_defined_type_data_type
         .get(user_type_name)
     {
-        Some(udt) => udt,
+        Some(udt) => Arc::into_raw(udt.clone()) as *const CassDataType,
         None => std::ptr::null(),
     }
 }

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -414,11 +414,6 @@ cass_keyspace_meta_table_by_name(const CassKeyspaceMeta* keyspace_meta,
                                  const char* table){
 	throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_table_by_name\n");
 }
-CASS_EXPORT const CassDataType*
-cass_keyspace_meta_user_type_by_name(const CassKeyspaceMeta* keyspace_meta,
-                                     const char* type){
-	throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_user_type_by_name\n");
-}
 CASS_EXPORT const char*
 cass_log_level_string(CassLogLevel log_level){
 	throw std::runtime_error("UNIMPLEMENTED cass_log_level_string\n");
@@ -446,15 +441,6 @@ CASS_EXPORT CassRetryPolicy*
 cass_retry_policy_logging_new(CassRetryPolicy* child_retry_policy){
 	throw std::runtime_error("UNIMPLEMENTED cass_retry_policy_logging_new\n");
 }
-CASS_EXPORT void
-cass_schema_meta_free(const CassSchemaMeta* schema_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_schema_meta_free\n");
-}
-CASS_EXPORT const CassKeyspaceMeta*
-cass_schema_meta_keyspace_by_name(const CassSchemaMeta* schema_meta,
-                                  const char* keyspace){
-	throw std::runtime_error("UNIMPLEMENTED cass_schema_meta_keyspace_by_name\n");
-}
 CASS_EXPORT CassVersion
 cass_schema_meta_version(const CassSchemaMeta* schema_meta){
 	throw std::runtime_error("UNIMPLEMENTED cass_schema_meta_version\n");
@@ -469,10 +455,6 @@ CASS_EXPORT void
 cass_session_get_metrics(const CassSession* session,
                          CassMetrics* output){
 	throw std::runtime_error("UNIMPLEMENTED cass_session_get_metrics\n");
-}
-CASS_EXPORT const CassSchemaMeta*
-cass_session_get_schema_meta(const CassSession* session){
-	throw std::runtime_error("UNIMPLEMENTED cass_session_get_schema_meta\n");
 }
 CASS_EXPORT void
 cass_session_get_speculative_execution_metrics(const CassSession* session,

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -369,20 +369,6 @@ cass_index_meta_field_by_name(const CassIndexMeta* index_meta,
                                const char* name){
 	throw std::runtime_error("UNIMPLEMENTED cass_index_meta_field_by_name\n");
 }
-CASS_EXPORT CassIterator*
-cass_iterator_fields_from_user_type(const CassValue* value){
-	throw std::runtime_error("UNIMPLEMENTED cass_iterator_fields_from_user_type\n");
-}
-CASS_EXPORT CassError
-cass_iterator_get_user_type_field_name(const CassIterator* iterator,
-                                       const char** name,
-                                       size_t* name_length){
-	throw std::runtime_error("UNIMPLEMENTED cass_iterator_get_user_type_field_name\n");
-}
-CASS_EXPORT const CassValue*
-cass_iterator_get_user_type_field_value(const CassIterator* iterator){
-	throw std::runtime_error("UNIMPLEMENTED cass_iterator_get_user_type_field_value\n");
-}
 CASS_EXPORT const CassAggregateMeta*
 cass_keyspace_meta_aggregate_by_name(const CassKeyspaceMeta* keyspace_meta,
                                      const char* name,

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -201,10 +201,6 @@ cass_collection_append_duration(CassCollection* collection,
                                 cass_int64_t nanos){
 	throw std::runtime_error("UNIMPLEMENTED cass_collection_append_duration\n");
 }
-CASS_EXPORT const CassDataType*
-cass_column_meta_data_type(const CassColumnMeta* column_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_column_meta_data_type\n");
-}
 CASS_EXPORT const CassValue*
 cass_column_meta_field_by_name(const CassColumnMeta* column_meta,
                                const char* name){
@@ -395,11 +391,6 @@ cass_keyspace_meta_materialized_view_by_name(const CassKeyspaceMeta* keyspace_me
                                              const char* view){
 	throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_materialized_view_by_name\n");
 }
-CASS_EXPORT const CassTableMeta*
-cass_keyspace_meta_table_by_name(const CassKeyspaceMeta* keyspace_meta,
-                                 const char* table){
-	throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_table_by_name\n");
-}
 CASS_EXPORT const char*
 cass_log_level_string(CassLogLevel log_level){
 	throw std::runtime_error("UNIMPLEMENTED cass_log_level_string\n");
@@ -532,23 +523,10 @@ cass_statement_set_node(CassStatement* statement,
                         const CassNode* node){
 	throw std::runtime_error("UNIMPLEMENTED cass_statement_set_node\n");
 }
-CASS_EXPORT size_t
-cass_table_meta_clustering_key_count(const CassTableMeta* table_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_clustering_key_count\n");
-}
 CASS_EXPORT CassClusteringOrder
 cass_table_meta_clustering_key_order(const CassTableMeta* table_meta,
                                      size_t index){
 	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_clustering_key_order\n");
-}
-CASS_EXPORT const CassColumnMeta*
-cass_table_meta_column_by_name(const CassTableMeta* table_meta,
-                               const char* column){
-	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_column_by_name\n");
-}
-CASS_EXPORT size_t
-cass_table_meta_column_count(const CassTableMeta* table_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_column_count\n");
 }
 CASS_EXPORT const CassValue*
 cass_table_meta_field_by_name(const CassTableMeta* table_meta,
@@ -576,10 +554,6 @@ cass_table_meta_materialized_view_by_name(const CassTableMeta* table_meta,
 CASS_EXPORT size_t
 cass_table_meta_materialized_view_count(const CassTableMeta* table_meta){
 	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_materialized_view_count\n");
-}
-CASS_EXPORT size_t
-cass_table_meta_partition_key_count(const CassTableMeta* table_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_partition_key_count\n");
 }
 CASS_EXPORT CassError
 cass_tuple_set_custom(CassTuple* tuple,

--- a/tests/src/integration/objects/session.hpp
+++ b/tests/src/integration/objects/session.hpp
@@ -256,6 +256,14 @@ public:
     return Schema(schema_meta);
   }
 
+  const CassSchemaMeta *schema_meta() {
+      const CassSchemaMeta* schema_meta = cass_session_get_schema_meta(get());
+      if (schema_meta == NULL) {
+          throw test::Exception("Unable to get schema metadata");
+      }
+      return schema_meta;
+  }
+
 protected:
   /**
    * Create a new session and establish a connection to the server;

--- a/tests/src/integration/tests/test_schema_metadata.cpp
+++ b/tests/src/integration/tests/test_schema_metadata.cpp
@@ -36,6 +36,11 @@ public:
                                    "PRIMARY KEY (key))",
                                    table_name_.c_str()));
 
+/*
+ * Support for UDF should be manually enabled to successfully execute the below code.
+ * These tests are also disabled for C++ driver. Additionally, Scylla does no support Java language in UDFs.
+ * It seems that the created aggregate and functions are not checked in these tests, so currently it is commented out.
+ *
     session_.execute("CREATE FUNCTION avg_state(state tuple<int, bigint>, val int) "
                      "CALLED ON NULL INPUT RETURNS tuple<int, bigint> "
                      "LANGUAGE java AS "
@@ -58,6 +63,7 @@ public:
     session_.execute("CREATE AGGREGATE average(int) "
                      "SFUNC avg_state STYPE tuple<int, bigint> FINALFUNC avg_final "
                      "INITCOND(0, 0);");
+*/
 
     if (server_version_ >= "3.0.0") {
       session_.execute(format_string("CREATE MATERIALIZED VIEW %s "
@@ -68,9 +74,12 @@ public:
                                      VIEW_NAME, table_name_.c_str()));
     }
     session_.execute("CREATE TYPE address (street text, city text)");
-
+/*
+ * The below part is commented out as the created index is not being checked in these tests.
+ *
     session_.execute(
         format_string("CREATE INDEX schema_meta_index ON %s (value)", table_name_.c_str()));
+*/
   }
 
 protected:
@@ -193,4 +202,140 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, VirtualMetadata) {
   column_meta = cass_table_meta_column_by_name(table_meta.get(), "unit");
   ASSERT_TRUE(column_meta);
   EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+}
+
+CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, KeyspaceMetadata) {
+  const CassSchemaMeta* schema_meta = session_.schema_meta();
+
+  // Schema Metadata
+  const CassKeyspaceMeta* keyspace_meta = cass_schema_meta_keyspace_by_name(schema_meta, keyspace_name_.c_str());
+  ASSERT_TRUE(keyspace_meta);
+
+  // Keyspace Metadata
+  const char* keyspace_name;
+  size_t keyspace_name_length;
+  cass_keyspace_meta_name(keyspace_meta, &keyspace_name, &keyspace_name_length);
+  std::string keyspace_meta_name(keyspace_name, keyspace_name_length);
+  ASSERT_EQ(keyspace_meta_name, keyspace_name_);
+
+  // User Type Metadata
+  const CassDataType* user_type_meta = cass_keyspace_meta_user_type_by_name(keyspace_meta, "address");
+  const char* user_type_name;
+  size_t user_type_name_length;
+  cass_data_type_type_name(user_type_meta, &user_type_name, &user_type_name_length);
+  std::string user_type_meta_name(user_type_name, user_type_name_length);
+  ASSERT_EQ(user_type_meta_name, "address");
+
+  const CassDataType* user_type_field1 = cass_data_type_sub_data_type_by_name(user_type_meta, "street");
+  ASSERT_EQ(cass_data_type_type(user_type_field1), CASS_VALUE_TYPE_TEXT);
+
+  const CassDataType* user_type_field2 = cass_data_type_sub_data_type_by_name(user_type_meta, "city");
+  ASSERT_EQ(cass_data_type_type(user_type_field2), CASS_VALUE_TYPE_TEXT);
+
+  // Table Metadata
+  const CassTableMeta* table_meta = cass_keyspace_meta_table_by_name(keyspace_meta, table_name_.c_str());
+  ASSERT_TRUE(table_meta);
+
+  EXPECT_EQ(cass_table_meta_column_count(table_meta), 2u);
+
+  EXPECT_EQ(cass_table_meta_partition_key_count(table_meta), 1u);
+  EXPECT_EQ(cass_table_meta_clustering_key_count(table_meta), 0u);
+
+  // Column Metadata
+  const CassColumnMeta* column_meta;
+  column_meta = cass_table_meta_column_by_name(table_meta, "key");
+  ASSERT_TRUE(column_meta);
+  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+
+  column_meta = cass_table_meta_column_by_name(table_meta, "value");
+  ASSERT_TRUE(column_meta);
+  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_BIGINT);
+
+  cass_schema_meta_free(schema_meta);
+}
+
+CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, MetadataIterator) {
+  const CassSchemaMeta* schema_meta = session_.schema_meta();
+
+  // Schema Metadata
+  const CassKeyspaceMeta* keyspace_meta = cass_schema_meta_keyspace_by_name(schema_meta, keyspace_name_.c_str());
+  ASSERT_TRUE(keyspace_meta);
+
+  // Keyspace Metadata
+  const char* keyspace_name;
+  size_t keyspace_name_length;
+  cass_keyspace_meta_name(keyspace_meta, &keyspace_name, &keyspace_name_length);
+  std::string keyspace_meta_name(keyspace_name, keyspace_name_length);
+  ASSERT_EQ(keyspace_meta_name, keyspace_name_);
+
+  // User Type Metadata
+  CassIterator* keyspace_user_types_iterator = cass_iterator_user_types_from_keyspace_meta(keyspace_meta);
+  cass_iterator_next(keyspace_user_types_iterator);
+  const CassDataType* user_type_meta = cass_iterator_get_user_type(keyspace_user_types_iterator);
+  const char* user_type_name;
+  size_t user_type_name_length;
+  cass_data_type_type_name(user_type_meta, &user_type_name, &user_type_name_length);
+  std::string user_type_meta_name(user_type_name, user_type_name_length);
+  ASSERT_EQ(user_type_meta_name, "address");
+
+  const CassDataType* user_type_field1 = cass_data_type_sub_data_type_by_name(user_type_meta, "street");
+  ASSERT_EQ(cass_data_type_type(user_type_field1), CASS_VALUE_TYPE_TEXT);
+
+  const CassDataType* user_type_field2 = cass_data_type_sub_data_type_by_name(user_type_meta, "city");
+  ASSERT_EQ(cass_data_type_type(user_type_field2), CASS_VALUE_TYPE_TEXT);
+
+  ASSERT_FALSE(cass_iterator_next(keyspace_user_types_iterator));
+
+  cass_iterator_free(keyspace_user_types_iterator);
+
+  // Table Metadata
+  CassIterator* keyspace_tables_iterator = cass_iterator_tables_from_keyspace_meta(keyspace_meta);
+  cass_iterator_next(keyspace_tables_iterator);
+  const CassTableMeta* table_meta = cass_iterator_get_table_meta(keyspace_tables_iterator);
+  ASSERT_TRUE(table_meta);
+
+  EXPECT_EQ(cass_table_meta_column_count(table_meta), 2u);
+
+  EXPECT_EQ(cass_table_meta_partition_key_count(table_meta), 1u);
+  EXPECT_EQ(cass_table_meta_clustering_key_count(table_meta), 0u);
+
+  ASSERT_FALSE(cass_iterator_next(keyspace_tables_iterator));
+
+  cass_iterator_free(keyspace_tables_iterator);
+
+  // Column Metadata
+  CassIterator* table_columns_iterator = cass_iterator_columns_from_table_meta(table_meta);
+  const CassColumnMeta* column_meta;
+  const char* column_meta_name;
+  size_t column_meta_name_length;
+
+  cass_iterator_next(table_columns_iterator);
+  column_meta = cass_iterator_get_column_meta(table_columns_iterator);
+  ASSERT_TRUE(column_meta);
+  cass_column_meta_name(column_meta, &column_meta_name, &column_meta_name_length);
+  std::string column1_name(column_meta_name, column_meta_name_length);
+
+  if (column1_name == "key") {
+    EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+  } else if (column1_name == "value") {
+    EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_BIGINT);
+  }
+
+  cass_iterator_next(table_columns_iterator);
+  column_meta = cass_iterator_get_column_meta(table_columns_iterator);
+  ASSERT_TRUE(column_meta);
+  cass_column_meta_name(column_meta, &column_meta_name, &column_meta_name_length);
+  std::string column2_name(column_meta_name, column_meta_name_length);
+
+  if (column2_name == "key") {
+    EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+  } else if (column2_name == "value") {
+    EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_BIGINT);
+  }
+
+  ASSERT_FALSE(cass_iterator_next(table_columns_iterator));
+
+  cass_iterator_free(table_columns_iterator);
+
+  cass_schema_meta_free(schema_meta);
 }


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yaml` in `gtest_filter`.

This PR is dependent upon #69

This PR adds a possibility to fetch cluster schema metadata and adds an implementation of `UDT` iterator and functions to get `UDT` field names and values.
The cluster metadata is refreshed automatically in the Rust driver immediately after successfully reaching schema agreement.