### PR TITLE
Allow bigger difference between timestamps in BasicsTests.Timestamps

### DIFF
--- a/tests/src/integration/tests/test_basics.cpp
+++ b/tests/src/integration/tests/test_basics.cpp
@@ -68,7 +68,7 @@ CASSANDRA_INTEGRATION_TEST_F(BasicsTests, Timestamps) {
 
   // Validate the timestamps
   ASSERT_NE(timestamp_1, timestamp_2);
-  ASSERT_LT(timestamp_2 - timestamp_1 - BigInteger(pause_duration * 1000), BigInteger(100000));
+  ASSERT_LT(timestamp_2 - timestamp_1 - BigInteger(pause_duration * 1000), BigInteger(150000));
 }
 
 /**


### PR DESCRIPTION
Increased the acceptable time difference between sequential inserts in
`BasicsTests.Timestamps` test, cause it happens to fail on very slow
machines like Github actions.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yaml` in `gtest_filter`.

Increased the acceptable time difference between sequential inserts in
`BasicsTests.Timestamps` test, cause it happens to fail on very slow
machines like Github actions.