### PR TITLE
Add workflow to Github actions to run tests on Cassandra

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,5 @@
 - [ ] I have split my patch into logically separate commits.
 - [ ] All commit messages clearly explain what they change and why.
 - [ ] PR description sums up the changes and reasons why they should be introduced.
-- [ ] I have enabled appropriate tests in `.github/workflows/build.yaml` in `gtest_filter`.
+- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
+- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,4 +43,4 @@ jobs:
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_UDT"
-      run: valgrind --error-exitcode=123 ./cassandra-integration-tests --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
+      run: valgrind --error-exitcode=123 ./cassandra-integration-tests --scylla --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -1,0 +1,52 @@
+name: Cassandra
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Setup Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Setup environment
+        run: |
+          sudo sh -c "echo 'deb http://security.ubuntu.com/ubuntu xenial-security main' >> /etc/apt/sources.list"
+          sudo apt-get update
+          sudo apt-get install libssl1.0.0 libuv1-dev libkrb5-dev libc6-dbg
+          sudo snap install valgrind --classic
+          pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
+          sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
+
+      - name: Build
+        run: cmake -DCASS_BUILD_INTEGRATION_TESTS=ON . && make
+
+      - name: Run integration tests on Cassandra 3.0.8
+        env:
+          #        Ignored tests are added in the end, after the "-" sign.
+          Tests: "ClusterTests.*\
+:BasicsTests.*\
+:PreparedTests.*\
+:CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
+:-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
+:*5.Integration_Cassandra_*\
+:*19.Integration_Cassandra_*\
+:CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_UDT"
+        run: valgrind --error-exitcode=123 ./cassandra-integration-tests --version=3.0.8 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"

--- a/tests/src/integration/ccm/bridge.hpp
+++ b/tests/src/integration/ccm/bridge.hpp
@@ -53,7 +53,7 @@ typedef struct _LIBSSH2_CHANNEL LIBSSH2_CHANNEL;
 #define DEFAULT_REMOTE_DEPLOYMENT_USERNAME "vagrant"
 #define DEFAULT_REMOTE_DEPLOYMENT_PASSWORD "vagrant"
 #define DEFAULT_IS_VERBOSE false
-#define DEFAULT_IS_SCYLLA true
+#define DEFAULT_IS_SCYLLA false
 #define DEFAULT_SMP 1
 #define DEFAULT_JVM_ARGUMENTS std::vector<std::string>()
 

--- a/tests/src/integration/options.cpp
+++ b/tests/src/integration/options.cpp
@@ -50,7 +50,7 @@ std::string Options::private_key_ = "private.key";
 bool Options::is_verbose_ccm_ = false;
 bool Options::is_verbose_integration_ = false;
 bool Options::is_beta_protocol_ = true;
-bool Options::is_scylla_ = true;
+bool Options::is_scylla_ = false;
 int Options::smp_ = 1;
 
 // Static initialization is not guaranteed for the following types


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yaml` in `gtest_filter`.

This PR adds a workflow to Github actions to run integration tests on a Cassandra cluster. There are some tests, e.g. SSL-related tests, that cannot be run on a Scylla cluster because of `scylla-ccm` but they can be tested on a Cassandra cluster. So, new tests that will be enabled in the Github actions, should also be added in `cassandra.yml`, unless the newly added features are not compatible with Cassandra.