### PR TITLE
Fix binding by name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
 :SslNoClusterTests*:SslNoSslOnClusterTests*\
 :SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator\
 :TracingTests.*\
+:ByNameTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*"

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -49,6 +49,7 @@ jobs:
 :SslClientAuthenticationTests*:SslNoClusterTests*:SslNoSslOnClusterTests*:SslTests*\
 :SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator\
 :TracingTests.*\
+:ByNameTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*\


### PR DESCRIPTION
Fixes case sensitive binding by name:
 * binding by name inside double quotes is case sensitive
 * binding by name without quotes should bind the value to multiple columns

Enabled `ByNameTests` tests for both ScyllaDB and Cassandra

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.