### PR TITLE
Fix `ConfigTests` tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
 :SslNoClusterTests*:SslNoSslOnClusterTests*\
 :SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator\
 :TracingTests.*\
+:ConfigTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*"

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -49,6 +49,7 @@ jobs:
 :SslClientAuthenticationTests*:SslNoClusterTests*:SslNoSslOnClusterTests*:SslTests*\
 :SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator\
 :TracingTests.*\
+:ConfigTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*\

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -25,10 +25,10 @@ enum CassClusterChildLoadBalancingPolicy {
 
 #[derive(Clone)]
 pub struct CassCluster {
-    session_builder: SessionBuilder,
+    pub session_builder: SessionBuilder,
 
-    contact_points: Vec<String>,
-    port: u16,
+    pub contact_points: Vec<String>,
+    pub port: u16,
 
     child_load_balancing_policy: CassClusterChildLoadBalancingPolicy,
     token_aware_policy_enabled: bool,
@@ -123,9 +123,10 @@ unsafe fn cluster_set_contact_points(
     let mut contact_points = ptr_to_cstr_n(contact_points_raw, contact_points_length)
         .ok_or(CassError::CASS_ERROR_LIB_BAD_PARAMS)?
         .split(',')
+        .filter(|s| !s.is_empty()) // Extra commas should be ignored
         .peekable();
 
-    if contact_points.peek().is_none() {
+    if contact_points.peek().is_none() || contact_points.peek().unwrap().is_empty() {
         // If cass_cluster_set_contact_points() is called with empty
         // set of contact points, the contact points should be cleared.
         cluster.contact_points.clear();

--- a/scylla-rust-wrapper/src/testing.rs
+++ b/scylla-rust-wrapper/src/testing.rs
@@ -1,1 +1,39 @@
+use crate::argconv::{free_boxed, ptr_to_ref, write_str_to_c};
+use crate::cluster::CassCluster;
+use crate::types::*;
+use std::os::raw::c_char;
 
+#[no_mangle]
+pub unsafe extern "C" fn testing_get_connect_timeout_from_cluster(
+    cluster: *mut CassCluster,
+) -> cass_uint16_t {
+    let cluster = ptr_to_ref(cluster);
+    cluster.session_builder.config.connect_timeout.as_millis() as cass_uint16_t
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn testing_get_contact_points_from_cluster(
+    cluster: *mut CassCluster,
+    contact_points: *mut *const c_char,
+    contact_points_length: *mut size_t,
+    contact_points_boxed: *mut *const String,
+) {
+    let cluster = ptr_to_ref(cluster);
+    let str = Box::new(cluster.contact_points.join(","));
+    let result = str.as_str();
+
+    write_str_to_c(result, contact_points, contact_points_length);
+    *contact_points_boxed = Box::into_raw(str);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn testing_free_contact_points_string(contact_points_boxed: *mut String) {
+    free_boxed(contact_points_boxed)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn testing_get_port_from_cluster(cluster: *mut CassCluster) -> cass_int32_t {
+    let cluster = ptr_to_ref(cluster);
+
+    cluster.port as cass_int32_t
+}

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -21,6 +21,11 @@
 #include "get_time.hpp"
 #include "logger.hpp"
 #include "murmur3.hpp"
+#include <iostream>
+
+extern "C" {
+  #include "testing_utils.h"
+}
 
 namespace datastax { namespace internal { namespace testing {
 
@@ -35,15 +40,26 @@ StringVec get_attempted_hosts_from_future(CassFuture* future) {
 }
 
 unsigned get_connect_timeout_from_cluster(CassCluster* cluster) {
-  throw std::runtime_error("Unimplemented 'get_connect_timeout_from_cluster'!");
+  return testing_get_connect_timeout_from_cluster(cluster);
 }
 
 int get_port_from_cluster(CassCluster* cluster) {
-  throw std::runtime_error("Unimplemented 'get_port_from_cluster'!");
+  return testing_get_port_from_cluster(cluster);
 }
 
 String get_contact_points_from_cluster(CassCluster* cluster) {
-  throw std::runtime_error("Unimplemented 'get_contact_points_from_cluster'!");
+  const char* contact_points;
+  size_t contact_points_length;
+  void *contact_points_boxed;
+  testing_get_contact_points_from_cluster(cluster, &contact_points, &contact_points_length, &contact_points_boxed);
+
+  std::string contact_points_str(contact_points, contact_points_length);
+  OStringStream ss;
+  ss << contact_points_str;
+
+  testing_free_contact_points_string(contact_points_boxed);
+
+  return ss.str();
 }
 
 int64_t create_murmur3_hash_from_string(const String& value) {

--- a/src/testing_utils.cpp
+++ b/src/testing_utils.cpp
@@ -1,0 +1,26 @@
+#include "testing_utils.h"
+#include <stdexcept>
+
+CASS_EXPORT CassConsistency testing_get_consistency(const CassStatement* statement) {
+  throw std::runtime_error("UNIMPLEMENTED testing_get_consistency\n");
+}
+
+CASS_EXPORT CassConsistency testing_get_serial_consistency(const CassStatement* statement) {
+  throw std::runtime_error("UNIMPLEMENTED testing_get_serial_consistency\n");
+}
+
+CASS_EXPORT cass_uint64_t testing_get_request_timeout_ms(const CassStatement* statement) {
+  throw std::runtime_error("UNIMPLEMENTED testing_get_request_timeout_ms\n");
+}
+
+CASS_EXPORT const CassRetryPolicy* testing_get_retry_policy(const CassStatement* statement) {
+  throw std::runtime_error("UNIMPLEMENTED testing_get_retry_policy\n");
+}
+
+CASS_EXPORT const char* testing_get_server_name(CassFuture* future) {
+  throw std::runtime_error("UNIMPLEMENTED testing_get_server_name\n");
+}
+
+CASS_EXPORT void testing_set_record_attempted_hosts(CassStatement* statement, cass_bool_t enable) {
+  throw std::runtime_error("UNIMPLEMENTED testing_set_record_attempted_hosts\n");
+}

--- a/src/testing_utils.h
+++ b/src/testing_utils.h
@@ -1,0 +1,34 @@
+#ifndef CPPDRIVERV2_TESTING_UTILS_H
+#define CPPDRIVERV2_TESTING_UTILS_H
+
+#include "cassandra.h"
+
+extern "C" {
+  CASS_EXPORT cass_uint16_t testing_get_connect_timeout_from_cluster(CassCluster* cluster);
+
+  CASS_EXPORT cass_int32_t testing_get_port_from_cluster(CassCluster* cluster);
+
+  CASS_EXPORT void
+  testing_get_contact_points_from_cluster(
+      CassCluster* cluster,
+      const char** contact_points,
+      size_t* contact_points_length,
+      void** contact_points_boxed
+  );
+
+  CASS_EXPORT void testing_free_contact_points_string(void* box);
+
+  CASS_EXPORT CassConsistency testing_get_consistency(const CassStatement* statement);
+
+  CASS_EXPORT CassConsistency testing_get_serial_consistency(const CassStatement* statement);
+
+  CASS_EXPORT cass_uint64_t testing_get_request_timeout_ms(const CassStatement* statement);
+
+  CASS_EXPORT const CassRetryPolicy* testing_get_retry_policy(const CassStatement* statement);
+
+  CASS_EXPORT const char* testing_get_server_name(CassFuture* future);
+
+  CASS_EXPORT void testing_set_record_attempted_hosts(CassStatement* statement, cass_bool_t enable);
+}
+
+#endif //CPPDRIVERV2_TESTING_UTILS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ set(CPP_DRIVER_SOURCE_FILES
     ${CASS_SRC_DIR}/testing.cpp
     ${CASS_SRC_DIR}/logger.cpp
     ${CASS_SRC_DIR}/testing_unimplemented.cpp
+    ${CASS_SRC_DIR}/testing_utils.cpp
     )
 if(APPLE)
   list(REMOVE_ITEM CPP_DRIVER_SOURCE_FILES ${CASS_SRC_DIR}/get_time-unix.cpp ${CASS_SRC_DIR}/get_time-win.cpp)


### PR DESCRIPTION
Added implementation for functions in `testing.cpp` used in `ConfigTests` tests:
 * get_connect_timeout_from_cluster
 * get_port_from_cluster
 * get_contact_points_from_cluster

To avoid generating bindings for functions that are directly under namespaces and may return objects of custom types, the `testing_utils` header is added as a median between the Rust implementation of those functions and the `testing.hpp` header.

Added `ConfigTests` tests to GitHub Actions for Cassandra and ScyllaDB.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.