### PR TITLE
Add fetching tracing ID associated with a request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
 :ErrorTests.*\
 :SslNoClusterTests*:SslNoSslOnClusterTests*\
 :SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator\
+:TracingTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*"

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -48,6 +48,7 @@ jobs:
 :ErrorTests.*\
 :SslClientAuthenticationTests*:SslNoClusterTests*:SslNoSslOnClusterTests*:SslTests*\
 :SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator\
+:TracingTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*\

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -15,6 +15,7 @@ use std::convert::TryInto;
 use std::os::raw::c_char;
 use std::slice;
 use std::sync::Arc;
+use uuid::Uuid;
 
 pub struct CassResult {
     pub rows: Option<Vec<CassRow>>,
@@ -24,6 +25,7 @@ pub struct CassResult {
 pub struct CassResultData {
     pub paging_state: Option<Bytes>,
     pub col_specs: Vec<ColumnSpec>,
+    pub tracing_id: Option<Uuid>,
 }
 
 pub type CassResult_ = Arc<CassResult>;

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -125,6 +125,7 @@ pub unsafe extern "C" fn cass_session_execute_batch(
                 metadata: Arc::new(CassResultData {
                     paging_state: None,
                     col_specs: vec![],
+                    tracing_id: None,
                 }),
             }))),
             Err(err) => Ok(CassResultValue::QueryError(Arc::new(err))),
@@ -192,6 +193,7 @@ pub unsafe extern "C" fn cass_session_execute(
                 let metadata = Arc::new(CassResultData {
                     paging_state: result.paging_state,
                     col_specs: result.col_specs,
+                    tracing_id: result.tracing_id,
                 });
                 let cass_rows = create_cass_rows_from_rows(result.rows, &metadata);
                 let cass_result: CassResult_ = Arc::new(CassResult {

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -350,11 +350,6 @@ CASS_EXPORT const CassNode*
 cass_future_coordinator(CassFuture* future){
 	throw std::runtime_error("UNIMPLEMENTED cass_future_coordinator\n");
 }
-CASS_EXPORT CassError
-cass_future_tracing_id(CassFuture* future,
-                       CassUuid* tracing_id){
-	throw std::runtime_error("UNIMPLEMENTED cass_future_tracing_id\n");
-}
 CASS_EXPORT cass_bool_t
 cass_future_wait_timed(CassFuture* future,
                        cass_duration_t timeout_us){


### PR DESCRIPTION
Added implementation for `cass_future_tracing_id`

Enabled `TracingTests` in GitHub actions for ScyllaDB and Cassandra

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.