### PR TITLE
Fix setup step in Build and Cassandra workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,7 @@ jobs:
 
     - name: Setup environment
       run: |
-        sudo sh -c "echo 'deb http://security.ubuntu.com/ubuntu xenial-security main' >> /etc/apt/sources.list"
-        sudo apt-get update
-        sudo apt-get install libssl1.0.0 libuv1-dev libkrb5-dev libc6-dbg
+        sudo apt-get install libssl1.1 libuv1-dev libkrb5-dev libc6-dbg
         sudo snap install valgrind --classic
         pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
         sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -28,9 +28,7 @@ jobs:
 
       - name: Setup environment
         run: |
-          sudo sh -c "echo 'deb http://security.ubuntu.com/ubuntu xenial-security main' >> /etc/apt/sources.list"
-          sudo apt-get update
-          sudo apt-get install libssl1.0.0 libuv1-dev libkrb5-dev libc6-dbg
+          sudo apt-get install libssl1.1 libuv1-dev libkrb5-dev libc6-dbg
           sudo snap install valgrind --classic
           pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
           sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"


### PR DESCRIPTION
The workflows fail for current pull requests:

```
Err:6 http://security.ubuntu.com/ubuntu xenial-security InRelease
The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 40976EAF437D05B5 NO_PUBKEY 3B4FE6ACC0B21F32
Reading package lists...
W: GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 40976EAF437D05B5 NO_PUBKEY 3B4FE6ACC0B21F32
E: The repository 'http://security.ubuntu.com/ubuntu xenial-security InRelease' is not signed.
```

It seems that xenial-security does not maintain keys for the Ubuntu keyserver.
This PR will manually add the keys to the system.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.