### PR TITLE
Add support for compression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
 :SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator\
 :TracingTests.*\
 :ByNameTests.*\
+:CompressionTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*"

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -48,6 +48,7 @@ jobs:
 :SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator\
 :TracingTests.*\
 :ByNameTests.*\
+:CompressionTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*\

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -913,6 +913,12 @@ typedef void(*CassHostListenerCallback)(CassHostListenerEvent event,
                                         const CassInet address,
                                         void* data);
 
+typedef enum CassCompressionType_ {
+  CASS_COMPRESSION_LZ4,
+  CASS_COMPRESSION_SNAPPY,
+  CASS_COMPRESSION_NONE
+} CassCompressionType;
+
 /***********************************************************************************
  *
  * Execution Profile
@@ -2950,6 +2956,20 @@ cass_cluster_set_client_id(CassCluster* cluster, CassUuid client_id);
 CASS_EXPORT void
 cass_cluster_set_monitor_reporting_interval(CassCluster* cluster,
                                             unsigned interval_secs);
+
+/**
+ * Sets the preferred compression algorithm.
+ * <b>Default:</b> no compression.
+ * If it is not supported by database server Session will fall back to no compression.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] compression_type
+ */
+CASS_EXPORT void
+cass_cluster_set_compression(CassCluster* cluster,
+                             CassCompressionType compression_type);
 
 /***********************************************************************************
  *

--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -110,4 +110,9 @@ fn main() {
         &["CassValueType_", "CassValueType"],
         &out_path,
     );
+    prepare_cppdriver_data(
+        "cppdriver_compression_types.rs",
+        &["CassCompressionType_", "CassCompressionType"],
+        &out_path,
+    );
 }

--- a/scylla-rust-wrapper/extern/cassandra.h
+++ b/scylla-rust-wrapper/extern/cassandra.h
@@ -913,6 +913,12 @@ typedef void(*CassHostListenerCallback)(CassHostListenerEvent event,
                                         const CassInet address,
                                         void* data);
 
+typedef enum CassCompressionType_ {
+  CASS_COMPRESSION_LZ4,
+  CASS_COMPRESSION_SNAPPY,
+  CASS_COMPRESSION_NONE
+} CassCompressionType;
+
 /***********************************************************************************
  *
  * Execution Profile
@@ -2950,6 +2956,20 @@ cass_cluster_set_client_id(CassCluster* cluster, CassUuid client_id);
 CASS_EXPORT void
 cass_cluster_set_monitor_reporting_interval(CassCluster* cluster,
                                             unsigned interval_secs);
+
+/**
+ * Sets the preferred compression algorithm.
+ * <b>Default:</b> no compression.
+ * If it is not supported by database server Session will fall back to no compression.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] compression_type
+ */
+CASS_EXPORT void
+cass_cluster_set_compression(CassCluster* cluster,
+                             CassCompressionType compression_type);
 
 /***********************************************************************************
  *

--- a/tests/src/integration/tests/test_compression.cpp
+++ b/tests/src/integration/tests/test_compression.cpp
@@ -1,0 +1,27 @@
+#include "cassandra.h"
+#include "integration.hpp"
+
+class CompressionTests : public Integration {
+public:
+  CompressionTests() { is_ccm_requested_ = true; }
+
+  void SetUp() {
+    Integration::SetUp();
+    cluster_ = default_cluster();
+  }
+};
+
+CASSANDRA_INTEGRATION_TEST_F(CompressionTests, SetCompressionLZ4) {
+  cass_cluster_set_compression(cluster_.get(), CASS_COMPRESSION_LZ4);
+  ASSERT_EQ(CASS_OK, cluster_.connect("", false).connect_error_code());
+}
+
+CASSANDRA_INTEGRATION_TEST_F(CompressionTests, SetCompressionSnappy) {
+  cass_cluster_set_compression(cluster_.get(), CASS_COMPRESSION_SNAPPY);
+  ASSERT_EQ(CASS_OK, cluster_.connect("", false).connect_error_code());
+}
+
+CASSANDRA_INTEGRATION_TEST_F(CompressionTests, SetCompressionNone) {
+  cass_cluster_set_compression(cluster_.get(), CASS_COMPRESSION_NONE);
+  ASSERT_EQ(CASS_OK, cluster_.connect("", false).connect_error_code());
+}


### PR DESCRIPTION
The original C++ driver does not support compression, so new APIs are introduced. `CassCompressionType` enum is added with values `CASS_COMPRESSION_LZ4` and `CASS_COMPRESSION_SNAPPY`, those are the only compression algorithms that Rust driver supports currently.

Added `cass_cluster_set_compression` that sets the preferred compression type in the SessionBuilder object of the cluster.

Fixes #91

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.