### PR TITLE
Fix memory leak error afer adding schema metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,4 @@ jobs:
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*"
-      run: valgrind --error-exitcode=123 ./cassandra-integration-tests --scylla --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
+      run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --scylla --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -55,4 +55,4 @@ jobs:
 :*19.Integration_Cassandra_*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_UDT\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart"
-        run: valgrind --error-exitcode=123 ./cassandra-integration-tests --version=3.0.8 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
+        run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --version=3.0.8 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -486,9 +486,7 @@ pub unsafe extern "C" fn cass_iterator_get_user_type(
             .nth(iter_position);
 
         return match udt_to_type_entry_opt {
-            Some(udt_to_type_entry) => {
-                Arc::into_raw(udt_to_type_entry.1.clone()) as *const CassDataType
-            }
+            Some(udt_to_type_entry) => Arc::as_ptr(udt_to_type_entry.1),
             None => std::ptr::null(),
         };
     }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -586,7 +586,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
         .user_defined_type_data_type
         .get(user_type_name)
     {
-        Some(udt) => Arc::into_raw(udt.clone()) as *const CassDataType,
+        Some(udt) => Arc::as_ptr(udt) as *const CassDataType,
         None => std::ptr::null(),
     }
 }


### PR DESCRIPTION
`Build` and `Cassandra` workflows did not report definitely lost memory leaks as errors and support for fetching schema metadata was merged with memory leaks.

Fixed memory leaking error and added appropriate options to valgrind to report only definitely lost memory as error.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.