### PR TITLE
Update README about fetching tracing id

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
             <td rowspan="3">Unimplemented</td>
         </tr>
         <tr>
-            <td>cass_future_tracing_id</td>
-        </tr>
-        <tr>
             <td>cass_future_coordinator</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Pre-review checklist

After merging fetching tracing id associated with a request (see https://github.com/scylladb/cpp-rust-driver/pull/86)
`cass_future_tracing_id` should be removed from README as it is already
implemented.

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.