### PR TITLE
Avoid creating references to uninitialized data

### DIFF
--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -170,8 +170,6 @@ pub unsafe extern "C" fn cass_future_error_message(
     message: *mut *const ::std::os::raw::c_char,
     message_length: *mut size_t,
 ) {
-    let message = ptr_to_ref_mut(message);
-    let message_length = ptr_to_ref_mut(message_length);
     ptr_to_ref(future).with_waited_state(|state: &mut CassFutureState| {
         let value = &state.value;
         let msg = state

--- a/scylla-rust-wrapper/src/inet.rs
+++ b/scylla-rust-wrapper/src/inet.rs
@@ -75,8 +75,6 @@ pub unsafe extern "C" fn cass_inet_from_string_n(
     input_length: size_t,
     inet_raw: *mut CassInet,
 ) -> CassError {
-    let inet = ptr_to_ref_mut(inet_raw);
-
     let input = ptr_to_cstr_n(input_raw, input_length);
     if input.is_none() {
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
@@ -87,7 +85,7 @@ pub unsafe extern "C" fn cass_inet_from_string_n(
 
     match ip_addr {
         Ok(ip_addr) => {
-            *inet = ip_addr.into();
+            std::ptr::write(inet_raw, ip_addr.into());
             CassError::CASS_OK
         }
         Err(_) => CassError::CASS_ERROR_LIB_BAD_PARAMS,

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -933,9 +933,8 @@ pub unsafe extern "C" fn cass_value_get_float(
     output: *mut cass_float_t,
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
-    let out: &mut cass_float_t = ptr_to_ref_mut(output);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Float(f))) => *out = f,
+        Some(Value::RegularValue(CqlValue::Float(f))) => std::ptr::write(output, f),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -949,9 +948,8 @@ pub unsafe extern "C" fn cass_value_get_double(
     output: *mut cass_double_t,
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
-    let out: &mut cass_double_t = ptr_to_ref_mut(output);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Double(d))) => *out = d,
+        Some(Value::RegularValue(CqlValue::Double(d))) => std::ptr::write(output, d),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -965,9 +963,10 @@ pub unsafe extern "C" fn cass_value_get_bool(
     output: *mut cass_bool_t,
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
-    let out: &mut cass_bool_t = ptr_to_ref_mut(output);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Boolean(b))) => *out = b as cass_bool_t,
+        Some(Value::RegularValue(CqlValue::Boolean(b))) => {
+            std::ptr::write(output, b as cass_bool_t)
+        }
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -981,9 +980,8 @@ pub unsafe extern "C" fn cass_value_get_int8(
     output: *mut cass_int8_t,
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
-    let out: &mut cass_int8_t = ptr_to_ref_mut(output);
     match val.value {
-        Some(Value::RegularValue(CqlValue::TinyInt(i))) => *out = i,
+        Some(Value::RegularValue(CqlValue::TinyInt(i))) => std::ptr::write(output, i),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -997,9 +995,8 @@ pub unsafe extern "C" fn cass_value_get_int16(
     output: *mut cass_int16_t,
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
-    let out: &mut cass_int16_t = ptr_to_ref_mut(output);
     match val.value {
-        Some(Value::RegularValue(CqlValue::SmallInt(i))) => *out = i,
+        Some(Value::RegularValue(CqlValue::SmallInt(i))) => std::ptr::write(output, i),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -1013,9 +1010,8 @@ pub unsafe extern "C" fn cass_value_get_uint32(
     output: *mut cass_uint32_t,
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
-    let out: &mut cass_uint32_t = ptr_to_ref_mut(output);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Date(u))) => *out = u, // FIXME: hack
+        Some(Value::RegularValue(CqlValue::Date(u))) => std::ptr::write(output, u), // FIXME: hack
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -1029,9 +1025,8 @@ pub unsafe extern "C" fn cass_value_get_int32(
     output: *mut cass_int32_t,
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
-    let out: &mut cass_int32_t = ptr_to_ref_mut(output);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Int(i))) => *out = i,
+        Some(Value::RegularValue(CqlValue::Int(i))) => std::ptr::write(output, i),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -1045,16 +1040,17 @@ pub unsafe extern "C" fn cass_value_get_int64(
     output: *mut cass_int64_t,
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
-    let out: &mut cass_int64_t = ptr_to_ref_mut(output);
     match val.value {
-        Some(Value::RegularValue(CqlValue::BigInt(i))) => *out = i,
-        Some(Value::RegularValue(CqlValue::Counter(i))) => *out = i.0 as cass_int64_t,
+        Some(Value::RegularValue(CqlValue::BigInt(i))) => std::ptr::write(output, i),
+        Some(Value::RegularValue(CqlValue::Counter(i))) => {
+            std::ptr::write(output, i.0 as cass_int64_t)
+        }
         Some(Value::RegularValue(CqlValue::Time(d))) => match d.num_nanoseconds() {
-            Some(nanos) => *out = nanos as cass_int64_t,
+            Some(nanos) => std::ptr::write(output, nanos as cass_int64_t),
             None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
         },
         Some(Value::RegularValue(CqlValue::Timestamp(d))) => {
-            *out = d.num_milliseconds() as cass_int64_t
+            std::ptr::write(output, d.num_milliseconds() as cass_int64_t)
         }
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
@@ -1069,10 +1065,9 @@ pub unsafe extern "C" fn cass_value_get_uuid(
     output: *mut CassUuid,
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
-    let out: &mut CassUuid = ptr_to_ref_mut(output);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Uuid(uuid))) => *out = uuid.into(),
-        Some(Value::RegularValue(CqlValue::Timeuuid(uuid))) => *out = uuid.into(),
+        Some(Value::RegularValue(CqlValue::Uuid(uuid))) => std::ptr::write(output, uuid.into()),
+        Some(Value::RegularValue(CqlValue::Timeuuid(uuid))) => std::ptr::write(output, uuid.into()),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -1086,9 +1081,8 @@ pub unsafe extern "C" fn cass_value_get_inet(
     output: *mut CassInet,
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
-    let out: &mut CassInet = ptr_to_ref_mut(output);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Inet(inet))) => *out = inet.into(),
+        Some(Value::RegularValue(CqlValue::Inet(inet))) => std::ptr::write(output, inet.into()),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };


### PR DESCRIPTION
Creating a reference to uninitialized data is most of the time undefined behaviour in Rust - even if data under this reference is never read.

This commit removes all occurences of this problem (in accordance with cpp-driver's semantics), instead using `std::ptr::write` - safer and more explicit way to achieve the same goal.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.