### PR TITLE
Put content of CassDataType into UnsafeCell

### DIFF
--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -1,6 +1,6 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
-use crate::cass_types::{cass_data_type_type, CassDataType, CassValueType};
+use crate::cass_types::{cass_data_type_type, CassDataType, CassDataTypeInner, CassValueType};
 use crate::inet::CassInet;
 use crate::metadata::{
     CassColumnMeta, CassKeyspaceMeta, CassMaterializedViewMeta, CassSchemaMeta, CassTableMeta,
@@ -1173,10 +1173,10 @@ pub unsafe extern "C" fn cass_value_primary_sub_type(
 ) -> CassValueType {
     let val = ptr_to_ref(collection);
 
-    match val.value_type.as_ref() {
-        CassDataType::List(Some(list)) => list.get_value_type(),
-        CassDataType::Set(Some(set)) => set.get_value_type(),
-        CassDataType::Map(Some(key), _) => key.get_value_type(),
+    match val.value_type.as_ref().get_unchecked() {
+        CassDataTypeInner::List(Some(list)) => list.get_unchecked().get_value_type(),
+        CassDataTypeInner::Set(Some(set)) => set.get_unchecked().get_value_type(),
+        CassDataTypeInner::Map(Some(key), _) => key.get_unchecked().get_value_type(),
         _ => CassValueType::CASS_VALUE_TYPE_UNKNOWN,
     }
 }
@@ -1187,8 +1187,8 @@ pub unsafe extern "C" fn cass_value_secondary_sub_type(
 ) -> CassValueType {
     let val = ptr_to_ref(collection);
 
-    match val.value_type.as_ref() {
-        CassDataType::Map(_, Some(value)) => value.get_value_type(),
+    match val.value_type.as_ref().get_unchecked() {
+        CassDataTypeInner::Map(_, Some(value)) => value.get_unchecked().get_value_type(),
         _ => CassValueType::CASS_VALUE_TYPE_UNKNOWN,
     }
 }


### PR DESCRIPTION
Previously `CassDataType` was just an enum, held inside `Arc`. User was given a pointer to `CassDataType` using `Arc::as_ptr` or `Arc::into_ptr`. There are however some functions that mutate the data - and they were given the very same pointers.
Current code was most likely sound - but I'm not completely sure, Rust reference is very confusing in this aspect.
It was however very confusing - when a programmer reads or writes a function that that *mut CassDataType it is not obivious that this data lies inside Arc and so has shared ownership.

To make this more explicit this commit puts `CassDataType` inside UnsafeCell. Now each access needs to use `.get_unchecked()` and `.get_mut_unchecked()` methods and an unsafe block / function, so it will be easier to spot aliasing ^ mutability problems in the future.

In the future we can use `Arc::get_mut_unchecked()` for this purpose, but it's not yet stabilised.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.