### PR TITLE
Remove unnecessary types, stylistic fixes

### DIFF
--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -174,10 +174,9 @@ pub fn get_column_type_from_cql_type(
 impl CassDataType {
     fn get_sub_data_type(&self, index: usize) -> Option<&Arc<CassDataType>> {
         match self {
-            CassDataType::UDT(udt_data_type) => udt_data_type
-                .field_types
-                .get(index as usize)
-                .map(|(_, b)| b),
+            CassDataType::UDT(udt_data_type) => {
+                udt_data_type.field_types.get(index).map(|(_, b)| b)
+            }
             CassDataType::List(t) | CassDataType::Set(t) => {
                 if index > 0 {
                     None
@@ -190,7 +189,7 @@ impl CassDataType {
                 1 => t2.as_ref(),
                 _ => None,
             },
-            CassDataType::Tuple(v) => v.get(index as usize),
+            CassDataType::Tuple(v) => v.get(index),
             _ => None,
         }
     }

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -2,8 +2,8 @@ use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::cass_error::CassErrorMessage;
 use crate::prepared::CassPrepared;
-use crate::query_error::{CassErrorResult, CassErrorResult_};
-use crate::query_result::{CassResult, CassResult_};
+use crate::query_error::CassErrorResult;
+use crate::query_result::CassResult;
 use crate::types::*;
 use crate::uuid::CassUuid;
 use crate::RUNTIME;
@@ -14,8 +14,8 @@ use std::sync::{Arc, Condvar, Mutex};
 
 pub enum CassResultValue {
     Empty,
-    QueryResult(CassResult_),
-    QueryError(CassErrorResult_),
+    QueryResult(Arc<CassResult>),
+    QueryError(Arc<CassErrorResult>),
     Prepared(Arc<PreparedStatement>),
 }
 
@@ -193,7 +193,7 @@ pub unsafe extern "C" fn cass_future_get_result(
     future_raw: *const CassFuture,
 ) -> *const CassResult {
     ptr_to_ref(future_raw)
-        .with_waited_result(|r: &mut CassFutureResult| -> Option<CassResult_> {
+        .with_waited_result(|r: &mut CassFutureResult| -> Option<Arc<CassResult>> {
             match r.as_ref().ok()? {
                 CassResultValue::QueryResult(qr) => Some(qr.clone()),
                 _ => None,
@@ -207,7 +207,7 @@ pub unsafe extern "C" fn cass_future_get_error_result(
     future_raw: *const CassFuture,
 ) -> *const CassErrorResult {
     ptr_to_ref(future_raw)
-        .with_waited_result(|r: &mut CassFutureResult| -> Option<CassErrorResult_> {
+        .with_waited_result(|r: &mut CassFutureResult| -> Option<Arc<CassErrorResult>> {
             match r.as_ref().ok()? {
                 CassResultValue::QueryError(qr) => Some(qr.clone()),
                 _ => None,

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn stderr_log_callback(message: *const CassLogMessage, _da
 
     eprintln!(
         "{} [{}] ({}:{}) {}",
-        message.time_ms as u64,
+        message.time_ms,
         ptr_to_cstr(cass_log_level_string(message.severity)).unwrap(),
         ptr_to_cstr(message.file).unwrap(),
         message.line,

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -1,12 +1,7 @@
-mod cass_log {
-    #![allow(non_camel_case_types)]
-    include!(concat!(env!("OUT_DIR"), "/cppdriver_log.rs"));
-}
 use crate::argconv::{arr_to_cstr, ptr_to_cstr, ptr_to_ref, str_to_arr};
 use crate::types::size_t;
 use crate::LOG;
 use crate::LOGGER;
-use cass_log::*;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::fmt::Write;
@@ -19,6 +14,12 @@ use tracing::Level;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::Layer;
+
+mod cass_log {
+    #![allow(non_camel_case_types)]
+    include!(concat!(env!("OUT_DIR"), "/cppdriver_log.rs"));
+}
+use cass_log::*;
 
 pub type CassLogCallback =
     Option<unsafe extern "C" fn(message: *const CassLogMessage, data: *mut c_void)>;

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -10,13 +10,9 @@ use std::sync::Weak;
 
 include!(concat!(env!("OUT_DIR"), "/cppdriver_column_type.rs"));
 
-pub type CassSchemaMeta_ = &'static CassSchemaMeta;
-
 pub struct CassSchemaMeta {
     pub keyspaces: HashMap<String, CassKeyspaceMeta>,
 }
-
-pub type CassKeyspaceMeta_ = &'static CassKeyspaceMeta;
 
 pub struct CassKeyspaceMeta {
     pub name: String,
@@ -27,8 +23,6 @@ pub struct CassKeyspaceMeta {
     pub views: HashMap<String, Arc<CassMaterializedViewMeta>>,
 }
 
-pub type CassTableMeta_ = &'static CassTableMeta;
-
 pub struct CassTableMeta {
     pub name: String,
     pub columns_metadata: HashMap<String, CassColumnMeta>,
@@ -36,8 +30,6 @@ pub struct CassTableMeta {
     pub clustering_keys: Vec<String>,
     pub views: HashMap<String, Arc<CassMaterializedViewMeta>>,
 }
-
-pub type CassMaterializedViewMeta_ = &'static CassMaterializedViewMeta;
 
 pub struct CassMaterializedViewMeta {
     pub name: String,

--- a/scylla-rust-wrapper/src/query_error.rs
+++ b/scylla-rust-wrapper/src/query_error.rs
@@ -5,12 +5,10 @@ use scylla::batch::SerialConsistency;
 use scylla::frame::types::LegacyConsistency;
 use scylla::statement::Consistency;
 use scylla::transport::errors::*;
-use std::sync::Arc;
 
 include!(concat!(env!("OUT_DIR"), "/cppdriver_data_query_error.rs"));
 
 pub type CassErrorResult = QueryError;
-pub type CassErrorResult_ = Arc<CassErrorResult>;
 
 impl From<Consistency> for CassConsistency {
     fn from(c: Consistency) -> CassConsistency {

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -40,7 +40,7 @@ pub struct CassStatement {
 
 impl CassStatement {
     fn bind_cql_value(&mut self, index: usize, value: Option<CqlValue>) -> CassError {
-        if index as usize >= self.bound_values.len() {
+        if index >= self.bound_values.len() {
             CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS
         } else {
             self.bound_values[index] = Set(value);
@@ -332,7 +332,7 @@ pub unsafe extern "C" fn cass_statement_set_request_timeout(
     // The maximum duration for a sleep is 68719476734 milliseconds (approximately 2.2 years).
     // Note: this is limited by tokio::time:timout
     // https://github.com/tokio-rs/tokio/blob/4b1c4801b1383800932141d0f6508d5b3003323e/tokio/src/time/driver/wheel/mod.rs#L44-L50
-    let request_timeout_limit = (2_u64.pow(36) - 1) as u64;
+    let request_timeout_limit = 2_u64.pow(36) - 1;
     if timeout_ms >= request_timeout_limit {
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -2,7 +2,6 @@ use crate::argconv::*;
 use crate::binding;
 use crate::cass_error::CassError;
 use crate::cass_types::CassDataType;
-use crate::cass_types::CassDataTypeArc;
 use crate::types::*;
 use scylla::frame::response::result::CqlValue;
 use std::convert::TryFrom;
@@ -12,12 +11,12 @@ static EMPTY_TUPLE_TYPE: CassDataType = CassDataType::Tuple(Vec::new());
 
 #[derive(Clone)]
 pub struct CassTuple {
-    pub data_type: Option<CassDataTypeArc>,
+    pub data_type: Option<Arc<CassDataType>>,
     pub items: Vec<Option<CqlValue>>,
 }
 
 impl CassTuple {
-    fn get_types(&self) -> Option<&Vec<CassDataTypeArc>> {
+    fn get_types(&self) -> Option<&Vec<Arc<CassDataType>>> {
         match &self.data_type {
             Some(t) => match &**t {
                 CassDataType::Tuple(v) => Some(v),

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -2,7 +2,6 @@ use crate::argconv::*;
 use crate::binding::is_compatible_type;
 use crate::cass_error::CassError;
 use crate::cass_types::CassDataType;
-use crate::cass_types::CassDataTypeArc;
 use crate::types::*;
 use scylla::frame::response::result::CqlValue;
 use std::os::raw::c_char;
@@ -10,7 +9,7 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct CassUserType {
-    pub data_type: CassDataTypeArc,
+    pub data_type: Arc<CassDataType>,
 
     // Vec to preserve the order of fields
     pub field_values: Vec<Option<CqlValue>>,


### PR DESCRIPTION
This PR is part of a larger series of change (previous PRs: #97 #98 ) that leads to FFI safety refactor.
It includes 3 commits that didn't fit anywhere else.

Commit 1 removes unnecessary type aliases.
Commit 2 fixes Clippy warnings.
Commit 3 has small code style changes.

For more information please see commit messages.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.