### PR TITLE
Increment Cassandra version in CI tests

### DIFF
--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: cmake -DCASS_BUILD_INTEGRATION_TESTS=ON . && make
 
-      - name: Run integration tests on Cassandra 3.0.8
+      - name: Run integration tests on Cassandra 3.0.9
         env:
           #        Ignored tests are added in the end, after the "-" sign.
           Tests: "ClusterTests.*\
@@ -55,4 +55,4 @@ jobs:
 :*19.Integration_Cassandra_*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_UDT\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart"
-        run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --version=3.0.8 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
+        run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --version=3.0.9 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"


### PR DESCRIPTION
The `TracingTests.Simple` test was flaky, supposedly because of
Cassandra version 3.0.8. A select all query from
`system_traces.sessions` sometimes returned an empty result, however,
a manual check showed that the table was not empty during the execution
of the query. The issue is fixed in 3.0.9 which waits for the tracing
events before returning response and queries at the same consistency level
client side.

Ref to the changelog: https://raw.githubusercontent.com/apache/cassandra/cassandra-3.0.9/CHANGES.txt

The version is incremented to 3.0.9 for now, as it allows to
avoid the issue and not introduce new tests which were skipped
previously because of the version.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.