### PR TITLE
Add install capabilities to top-level CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ ExternalProject_Add(
     scylla-rust-cpp-driver
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND ./build-cmake-compat.sh $<IF:$<CONFIG:Debug>,DEBUG,RELEASE>
+    BUILD_COMMAND ./build-cmake-compat.sh $<IF:$<CONFIG:Debug>,DEBUG,RELEASE> $<IF:$<BOOL:${CASS_BUILD_STATIC}>,STATIC,NO_STATIC>
     BINARY_DIR "${CMAKE_SOURCE_DIR}/scylla-rust-wrapper"
     INSTALL_COMMAND ""
     LOG_BUILD ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,3 +272,28 @@ endif()
 if(CASS_BUILD_INTEGRATION_TESTS OR CASS_BUILD_TESTS)
   add_subdirectory(tests)
 endif()
+
+#-------------------------------------
+# Installation
+#-------------------------------------
+
+# Determine if the library directory needs to be determined
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr" OR
+    "${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local"))
+    if(EXISTS "/etc/debian_version")
+      set (CMAKE_INSTALL_LIBDIR "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+    elseif(EXISTS "/etc/redhat-release" OR EXISTS "/etc/fedora-release" OR
+        EXISTS "/etc/slackware-version" OR EXISTS "/etc/gentoo-release")
+      if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set (CMAKE_INSTALL_LIBDIR "lib64")
+      else()
+        set (CMAKE_INSTALL_LIBDIR "lib")
+      endif()
+    else()
+      set (CMAKE_INSTALL_LIBDIR "lib")
+    endif()
+  else()
+    set (CMAKE_INSTALL_LIBDIR "lib")
+  endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ ExternalProject_Add(
     scylla-rust-cpp-driver
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND cargo build $<IF:$<CONFIG:Debug>,,--release>
+    BUILD_COMMAND ./build-cmake-compat.sh $<IF:$<CONFIG:Debug>,DEBUG,RELEASE>
     BINARY_DIR "${CMAKE_SOURCE_DIR}/scylla-rust-wrapper"
     INSTALL_COMMAND ""
     LOG_BUILD ON
@@ -250,11 +250,11 @@ add_library(scylla-cpp-driver SHARED IMPORTED)
 set_target_properties(scylla-cpp-driver PROPERTIES IMPORTED_NO_SONAME TRUE)
 set_property(TARGET scylla-cpp-driver APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
 set_target_properties(scylla-cpp-driver PROPERTIES
-  IMPORTED_LOCATION_DEBUG "${CMAKE_SOURCE_DIR}/scylla-rust-wrapper/target/debug/libscylla_cpp_driver.so"
+  IMPORTED_LOCATION_DEBUG "${CMAKE_SOURCE_DIR}/scylla-rust-wrapper/target/debug/cmake-compat/libscylla-cpp-driver.so"
 )
 set_property(TARGET scylla-cpp-driver APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
 set_target_properties(scylla-cpp-driver PROPERTIES
-  IMPORTED_LOCATION_RELEASE "${CMAKE_SOURCE_DIR}/scylla-rust-wrapper/target/release/libscylla_cpp_driver.so"
+  IMPORTED_LOCATION_RELEASE "${CMAKE_SOURCE_DIR}/scylla-rust-wrapper/target/release/cmake-compat/libscylla-cpp-driver.so"
 )
 set_target_properties(scylla-cpp-driver PROPERTIES
   MAP_IMPORTED_CONFIG_MINSIZEREL Release
@@ -297,3 +297,8 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
     set (CMAKE_INSTALL_LIBDIR "lib")
   endif()
 endif()
+
+file(GLOB CASS_API_HEADER_FILES ${CASS_INCLUDE_DIR}/*.h)
+install(FILES ${CASS_API_HEADER_FILES} DESTINATION "include")
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/scylla-rust-wrapper/target/$<IF:$<CONFIG:Debug>,debug,release>/cmake-compat/ DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/scylla-rust-wrapper/build-cmake-compat.sh
+++ b/scylla-rust-wrapper/build-cmake-compat.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# The version number should be in the third line
+# of Cargo.toml file (e.g. version = "0.0.1")
+VERSION_NUMBER=$(sed -n '3p' < Cargo.toml)
+REGEX="version = \"([0-9]+)\.([0-9]+)\.([0-9]+)\""
+if [[ $VERSION_NUMBER =~ $REGEX ]]
+then
+  MAJOR=${BASH_REMATCH[1]}
+  MINOR=${BASH_REMATCH[2]}
+  PATCH=${BASH_REMATCH[3]}
+else
+  echo "Could not parse the version number in Cargo.toml"
+  echo "Tried to parse a third line of Cargo.toml: $VERSION_NUMBER"
+  echo 'but it did not contain a valid version number (e.g. version = "0.0.1").'
+  exit 1
+fi
+
+create_symlinks() {
+  rm -rf target/$1/cmake-compat/
+  mkdir target/$1/cmake-compat/
+
+  cp target/$1/libscylla_cpp_driver.so target/$1/cmake-compat/libscylla-cpp-driver.so.$MAJOR.$MINOR.$PATCH
+  ln -s libscylla-cpp-driver.so.$MAJOR.$MINOR.$PATCH target/$1/cmake-compat/libscylla-cpp-driver.so.$MAJOR
+  ln -s libscylla-cpp-driver.so.$MAJOR target/$1/cmake-compat/libscylla-cpp-driver.so
+}
+
+if [[ $1 == "DEBUG" ]]
+then
+  cargo build
+  create_symlinks "debug"
+elif [[ $1 == "RELEASE" ]]
+then
+  cargo build --release
+  create_symlinks "release"
+else
+  echo 'Invalid build mode: $1 (only DEBUG or RELEASE permitted)'
+  exit 1
+fi

--- a/scylla-rust-wrapper/build-cmake-compat.sh
+++ b/scylla-rust-wrapper/build-cmake-compat.sh
@@ -17,11 +17,31 @@ else
   exit 1
 fi
 
+COPY_STATIC=false
+
+if [[ $2 == "STATIC" ]]
+then
+  COPY_STATIC=true
+elif [[ $2 == "NO_STATIC" ]]
+then
+  COPY_STATIC=false
+else
+  echo 'Invalid static build configuration: $2 (only STATIC or NO_STATIC permitted)'
+  exit 1
+fi
+
+
 create_symlinks() {
   rm -rf target/$1/cmake-compat/
   mkdir target/$1/cmake-compat/
 
   cp target/$1/libscylla_cpp_driver.so target/$1/cmake-compat/libscylla-cpp-driver.so.$MAJOR.$MINOR.$PATCH
+  
+  if [[ "$COPY_STATIC" == true ]]
+  then
+    cp target/$1/libscylla_cpp_driver.a target/$1/cmake-compat/libscylla-cpp-driver_static.a
+  fi
+
   ln -s libscylla-cpp-driver.so.$MAJOR.$MINOR.$PATCH target/$1/cmake-compat/libscylla-cpp-driver.so.$MAJOR
   ln -s libscylla-cpp-driver.so.$MAJOR target/$1/cmake-compat/libscylla-cpp-driver.so
 }


### PR DESCRIPTION
Before this change, the generated Makefile by CMake lacked the capability to run `make install`. This PR makes it possible
to run `make install`, for example:

```bash
mkdir build
cd build
cmake -DCMAKE_BUILD_TYPE=RELEASE -DCASS_INSTALL_PKG_CONFIG=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib64 ..
make DESTDIR=/tmp/example install
```

The names and contents of installed files try to mimic the original C++ Driver files. For example, installation of C++ Driver generates the following `.so` files/symlinks:

```
usr/lib64/libscylla-cpp-driver.so -> libscylla-cpp-driver.so.2
usr/lib64/libscylla-cpp-driver.so.2 -> libscylla-cpp-driver.so.2.16.2
usr/lib64/libscylla-cpp-driver.so.2.16.2
```

This particular behavior is replicated in a new `build-cmake-compat.sh` script, which is executed as a `BUILD_COMMAND` in the Rust external project in the top-level `CMakeLists.txt`.

Unfortunately, I have not been able to configure CMake to create such symlinks on its own. One of the reasons is an unfixed bug in CMake: https://gitlab.kitware.com/cmake/cmake/-/issues/23249#note_1277271. Therefore, the `build-cmake-compat.sh` is introduced to create the necessary files in a way it's easy to install for CMake.

The third commit includes the static library in the installed files. 

Those are the contents of `DESTDIR` (as in `make DESTDIR=... install`) in the original C++ driver:
```
DESTDIR
└── usr
    ├── include
    │   ├── cassandra.h
    │   └── dse.h
    └── lib64
        ├── libscylla-cpp-driver.so -> libscylla-cpp-driver.so.2
        ├── libscylla-cpp-driver.so.2 -> libscylla-cpp-driver.so.2.16.2
        ├── libscylla-cpp-driver.so.2.16.2
        └── libscylla-cpp-driver_static.a
```

and after this PR in the bindings:
```
DESTDIR
└── usr
    ├── include
    │   └── cassandra.h
    └── lib64
        ├── libscylla-cpp-driver.so -> libscylla-cpp-driver.so.0
        ├── libscylla-cpp-driver.so.0 -> libscylla-cpp-driver.so.0.0.1
        ├── libscylla-cpp-driver.so.0.0.1
        └── libscylla-cpp-driver_static.a
```

This PR is a prerequisite for a follow-up PR reworking #88.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.