### PR TITLE
Update rust driver rev in Cargo.toml

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -800,8 +800,8 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scylla"
-version = "0.6.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=358eabbbb71c112bf1b19b0e8b4eafd169146cdc#358eabbbb71c112bf1b19b0e8b4eafd169146cdc"
+version = "0.7.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db#9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -854,9 +854,10 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.0.2"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=358eabbbb71c112bf1b19b0e8b4eafd169146cdc#358eabbbb71c112bf1b19b0e8b4eafd169146cdc"
+version = "0.0.3"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db#9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db"
 dependencies = [
+ "async-trait",
  "bigdecimal",
  "byteorder",
  "bytes",
@@ -873,9 +874,10 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.1.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=358eabbbb71c112bf1b19b0e8b4eafd169146cdc#358eabbbb71c112bf1b19b0e8b4eafd169146cdc"
+version = "0.1.2"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db#9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -1189,6 +1191,9 @@ name = "uuid"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "358eabbbb71c112bf1b19b0e8b4eafd169146cdc", features = ["ssl"]}
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db", features = ["ssl"]}
 tokio = { version = "1.1.0", features = ["full"] }
 lazy_static = "1.4.0"
 uuid = "1.1.2"

--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -54,7 +54,6 @@ impl From<&BadQuery> for CassError {
             BadQuery::SerializeValuesError(_serialize_values_error) => {
                 CassError::CASS_ERROR_LAST_ENTRY
             }
-            BadQuery::ValueLenMismatch(_usize, _usize2) => CassError::CASS_ERROR_LAST_ENTRY,
             BadQuery::ValuesTooLongForKey(_usize, _usize2) => CassError::CASS_ERROR_LAST_ENTRY,
             BadQuery::BadKeyspaceName(_bad_keyspace_name) => CassError::CASS_ERROR_LAST_ENTRY,
             BadQuery::Other(_other_query) => CassError::CASS_ERROR_LAST_ENTRY,


### PR DESCRIPTION
Imported scylla-rust-driver by commit hash 9dc6f4871f2. This will include all pre-execution-profile changes in the Rust driver and will resolve the following conflicts:

* Removed `BadQuery::ValueLenMismatch` error, as it was also removed from the Rust driver to allow removing `len` from `BatchValues`.

* Resolved conflicts after custom authentication feature was added to the Rust driver.

It was requested by @wprzytula and it aims to make the addition of execution profiles easier.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.