### PR TITLE
Disable `uninlined_format_args` clippy lint

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,4 +16,4 @@ jobs:
     - uses: actions/checkout@v2
     - name: Clippy check
       working-directory: ./scylla-rust-wrapper
-      run: cargo clippy --verbose -- -D warnings
+      run: cargo clippy --verbose -- -D warnings -Aclippy::uninlined_format_args


### PR DESCRIPTION
The clippy style lint uninlined_format_args is temporarily downgraded to pedantic -- allowed by default. While the compiler has supported this format since Rust 1.58, rust-analyzer does not support it yet.

This commit disables the new lint in the CI. We can turn it on again when rust-analyzer supports it.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.