### PR TITLE
Execution profiles support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
     - name: Build
       run: cmake -DCASS_BUILD_INTEGRATION_TESTS=ON . && make
 
+    - name: Run unit and proxy tests
+      working-directory: ./scylla-rust-wrapper
+      run: cargo test
+
     - name: Run integration tests on Scylla 5.0.0
       env:
 #        Ignored tests are added in the end, after the "-" sign.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,5 +51,6 @@ jobs:
 :LoggingTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :*5.Integration_Cassandra_*\
-:*19.Integration_Cassandra_*"
+:*19.Integration_Cassandra_*\
+:ExecutionProfileTest.InvalidName"
       run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --scylla --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -54,5 +54,6 @@ jobs:
 :*5.Integration_Cassandra_*\
 :*19.Integration_Cassandra_*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_UDT\
-:SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart"
+:SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
+:ExecutionProfileTest.InvalidName"
         run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --version=3.0.9 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,4 +16,4 @@ jobs:
     - uses: actions/checkout@v2
     - name: Clippy check
       working-directory: ./scylla-rust-wrapper
-      run: cargo clippy --verbose -- -D warnings -Aclippy::uninlined_format_args
+      run: cargo clippy --verbose --all-targets -- -D warnings -Aclippy::uninlined_format_args

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ build/
 scylla-rust-wrapper/target/
 .idea/
 cmake-build-debug/
+.cache/
 

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -179,6 +179,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +383,26 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -375,9 +437,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libloading"
@@ -388,6 +450,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "lock_api"
@@ -456,7 +524,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -549,7 +617,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -637,9 +705,9 @@ checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -702,6 +770,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +833,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,10 +872,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.37.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "scopeguard"
@@ -850,6 +959,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "rand",
+ "rusty-fork",
  "scylla",
  "scylla-proxy",
  "tokio",
@@ -1014,6 +1124,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1215,6 +1338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,12 +1451,72 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1333,10 +1525,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1345,16 +1561,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,18 +34,7 @@ checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -76,24 +56,24 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
- "env_logger",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.15",
  "which",
 ]
 
@@ -169,21 +149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,19 +171,6 @@ name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
-
-[[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "foreign-types"
@@ -291,7 +243,7 @@ checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -370,12 +322,6 @@ name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -536,7 +482,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -586,7 +532,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -618,7 +564,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -688,6 +634,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,18 +655,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.42"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -760,8 +716,6 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -879,7 +833,7 @@ source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9dc6f4871f2
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -950,12 +904,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
 name = "strum"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,7 +919,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -986,21 +934,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
+name = "syn"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1020,7 +961,7 @@ checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1072,7 +1013,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1116,7 +1057,7 @@ checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1181,12 +1122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "uuid"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,12 +1141,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wasi"
@@ -1246,7 +1175,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -1268,7 +1197,7 @@ checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1305,15 +1234,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +470,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da8ec6d2b73d45307e926f5af46809768581044384637af6b3f3fe7c3c88f512"
+dependencies = [
+ "ntest_test_cases",
+ "ntest_timeout",
+]
+
+[[package]]
+name = "ntest_test_cases"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be7d33be719c6f4d09e64e27c1ef4e73485dc4cc1f4d22201f89860a7fe22e22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "ntest_timeout"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "066b468120587a402f0b47d8f80035c921f6a46f8209efd0632a89a16f5188a4"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +741,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,8 +802,8 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scylla"
-version = "0.7.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db#9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db"
+version = "0.8.1"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=1a913a19#1a913a191fef6ba1ad05d4f4260037609d6fc64e"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -772,6 +820,7 @@ dependencies = [
  "num_enum",
  "openssl",
  "rand",
+ "rand_pcg",
  "scylla-cql",
  "scylla-macros",
  "smallvec",
@@ -789,17 +838,20 @@ dependencies = [
 name = "scylla-cpp-driver-rust"
 version = "0.0.1"
 dependencies = [
+ "assert_matches",
  "bindgen",
  "chrono",
  "lazy_static",
  "libc",
  "machine-uid",
+ "ntest",
  "num-derive",
  "num-traits",
  "openssl",
  "openssl-sys",
  "rand",
  "scylla",
+ "scylla-proxy",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -808,8 +860,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.0.3"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db#9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db"
+version = "0.0.6"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=1a913a19#1a913a191fef6ba1ad05d4f4260037609d6fc64e"
 dependencies = [
  "async-trait",
  "bigdecimal",
@@ -828,12 +880,32 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.1.2"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db#9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db"
+version = "0.2.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=1a913a19#1a913a191fef6ba1ad05d4f4260037609d6fc64e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.98",
+]
+
+[[package]]
+name = "scylla-proxy"
+version = "0.0.2"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=1a913a19#1a913a191fef6ba1ad05d4f4260037609d6fc64e"
+dependencies = [
+ "bigdecimal",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "futures",
+ "num-bigint",
+ "num_enum",
+ "rand",
+ "scylla-cql",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -946,22 +1018,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.98",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1039,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1051,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1062,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -9,9 +9,8 @@ keywords = ["database", "scylla", "cql", "cassandra"]
 categories = ["database"]
 license = "MIT OR Apache-2.0"
 
-
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9dc6f4871f2477c8ebb5bd911a0ce8ddc05ba8db", features = ["ssl"]}
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "1a913a19", features = ["ssl"]}
 tokio = { version = "1.1.0", features = ["full"] }
 lazy_static = "1.4.0"
 uuid = "1.1.2"
@@ -23,11 +22,16 @@ libc = "0.2.108"
 openssl-sys = "0.9.75"
 openssl = "0.10.32"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
-tracing = "0.1.25"
+tracing = "0.1.37"
 
 [build-dependencies]
 bindgen = "0.65"
 chrono = "0.4.20"
+
+[dev-dependencies]
+assert_matches = "1.5.0"
+ntest = "0.9.0"
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "1a913a19"}
 
 [lib]
 name = "scylla_cpp_driver"

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -26,7 +26,7 @@ tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing = "0.1.25"
 
 [build-dependencies]
-bindgen = "0.59.1"
+bindgen = "0.65"
 chrono = "0.4.20"
 
 [lib]

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -31,6 +31,7 @@ chrono = "0.4.20"
 [dev-dependencies]
 assert_matches = "1.5.0"
 ntest = "0.9.0"
+rusty-fork = "0.3.0"
 scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "1a913a19"}
 
 [lib]

--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -9,7 +9,10 @@ fn prepare_full_bindings(out_path: &Path) {
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .layout_tests(false)
         .generate_comments(false)
-        .default_enum_style(bindgen::EnumVariation::NewType { is_bitfield: false })
+        .default_enum_style(bindgen::EnumVariation::NewType {
+            is_bitfield: false,
+            is_global: false,
+        })
         .generate()
         .expect("Unable to generate bindings");
 
@@ -39,7 +42,10 @@ fn prepare_cppdriver_data(outfile: &str, allowed_types: &[&str], out_path: &Path
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .layout_tests(true)
         .generate_comments(false)
-        .default_enum_style(bindgen::EnumVariation::NewType { is_bitfield: false })
+        .default_enum_style(bindgen::EnumVariation::NewType {
+            is_bitfield: false,
+            is_global: false,
+        })
         .derive_eq(true)
         .derive_ord(true);
     for t in allowed_types {

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -73,3 +73,24 @@ pub unsafe fn strlen(ptr: *const c_char) -> size_t {
     }
     libc::strlen(ptr) as size_t
 }
+
+#[cfg(test)]
+pub fn str_to_c_str_n(s: &str) -> (*const c_char, size_t) {
+    let mut c_str = std::ptr::null();
+    let mut c_strlen = size_t::default();
+
+    // SAFETY: The pointers that are passed to `write_str_to_c` are compile-checked references.
+    unsafe { write_str_to_c(s, &mut c_str, &mut c_strlen) };
+
+    (c_str, c_strlen)
+}
+
+#[cfg(test)]
+macro_rules! make_c_str {
+    ($str:literal) => {
+        concat!($str, "\0").as_ptr() as *const c_char
+    };
+}
+
+#[cfg(test)]
+pub(crate) use make_c_str;

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -2,6 +2,7 @@ use crate::argconv::{free_boxed, ptr_to_ref, ptr_to_ref_mut};
 use crate::cass_error::CassError;
 use crate::cass_types::CassConsistency;
 use crate::cass_types::{make_batch_type, CassBatchType};
+use crate::exec_profile::PerStatementExecProfile;
 use crate::retry_policy::CassRetryPolicy;
 use crate::statement::{CassStatement, Statement};
 use crate::types::*;
@@ -14,6 +15,8 @@ use std::sync::Arc;
 pub struct CassBatch {
     pub state: Arc<CassBatchState>,
     pub batch_request_timeout_ms: Option<cass_uint64_t>,
+
+    pub(crate) exec_profile: Option<PerStatementExecProfile>,
 }
 
 #[derive(Clone)]
@@ -31,6 +34,7 @@ pub unsafe extern "C" fn cass_batch_new(type_: CassBatchType) -> *mut CassBatch 
                 bound_values: Vec::new(),
             }),
             batch_request_timeout_ms: None,
+            exec_profile: None,
         }))
     } else {
         std::ptr::null_mut()

--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -14,6 +14,7 @@ impl From<&QueryError> for CassError {
             QueryError::TooManyOrphanedStreamIds(_) => CassError::CASS_ERROR_LIB_INVALID_STATE,
             QueryError::UnableToAllocStreamId => CassError::CASS_ERROR_LIB_NO_STREAMS,
             QueryError::RequestTimeout(_) => CassError::CASS_ERROR_LIB_REQUEST_TIMED_OUT,
+            QueryError::TranslationError(_) => CassError::CASS_ERROR_LIB_HOST_RESOLUTION,
         }
     }
 }
@@ -79,6 +80,7 @@ impl From<&NewSessionError> for CassError {
             NewSessionError::TooManyOrphanedStreamIds(_) => CassError::CASS_ERROR_LAST_ENTRY,
             NewSessionError::UnableToAllocStreamId => CassError::CASS_ERROR_LAST_ENTRY,
             NewSessionError::RequestTimeout(_) => CassError::CASS_ERROR_LIB_REQUEST_TIMED_OUT,
+            NewSessionError::TranslationError(_) => CassError::CASS_ERROR_LIB_HOST_RESOLUTION,
         }
     }
 }

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -8,36 +8,60 @@ use crate::types::*;
 use core::time::Duration;
 use openssl::ssl::SslContextBuilder;
 use openssl_sys::SSL_CTX_up_ref;
+use scylla::execution_profile::ExecutionProfileBuilder;
 use scylla::frame::Compression;
-use scylla::load_balancing::{
-    DcAwareRoundRobinPolicy, LoadBalancingPolicy, RoundRobinPolicy, TokenAwarePolicy,
-};
+use scylla::load_balancing::{DefaultPolicyBuilder, LoadBalancingPolicy};
 use scylla::retry_policy::RetryPolicy;
 use scylla::speculative_execution::SimpleSpeculativeExecutionPolicy;
 use scylla::SessionBuilder;
+use std::future::Future;
 use std::os::raw::{c_char, c_int, c_uint};
 use std::sync::Arc;
 
 include!(concat!(env!("OUT_DIR"), "/cppdriver_compression_types.rs"));
 
-#[derive(Clone)]
-enum CassClusterChildLoadBalancingPolicy {
-    RoundRobinPolicy,
-    DcAwareRoundRobinPolicy {
-        local_dc: String,
-        include_remote_nodes: bool,
-    },
+#[derive(Clone, Debug)]
+pub(crate) struct LoadBalancingConfig {
+    pub(crate) token_awareness_enabled: bool,
+    pub(crate) dc_awareness: Option<DcAwareness>,
+}
+impl LoadBalancingConfig {
+    // This is `async` to prevent running this function from beyond tokio context,
+    // as it results in panic due to DefaultPolicyBuilder::build() spawning a tokio task.
+    pub(crate) async fn build(self) -> Arc<dyn LoadBalancingPolicy> {
+        let mut builder = DefaultPolicyBuilder::new().token_aware(self.token_awareness_enabled);
+        if let Some(dc_awareness) = self.dc_awareness.as_ref() {
+            builder = builder
+                .prefer_datacenter(dc_awareness.local_dc.clone())
+                .permit_dc_failover(true)
+        }
+        builder.build()
+    }
+}
+impl Default for LoadBalancingConfig {
+    fn default() -> Self {
+        Self {
+            token_awareness_enabled: true,
+            dc_awareness: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DcAwareness {
+    pub(crate) local_dc: String,
 }
 
 #[derive(Clone)]
 pub struct CassCluster {
     session_builder: SessionBuilder,
+    default_execution_profile_builder: ExecutionProfileBuilder,
 
     contact_points: Vec<String>,
     port: u16,
 
-    child_load_balancing_policy: CassClusterChildLoadBalancingPolicy,
-    token_aware_policy_enabled: bool,
+    load_balancing_config: LoadBalancingConfig,
+
     use_beta_protocol_version: bool,
     auth_username: Option<String>,
     auth_password: Option<String>,
@@ -45,48 +69,27 @@ pub struct CassCluster {
 
 pub struct CassCustomPayload;
 
-pub fn build_session_builder(cluster: &CassCluster) -> SessionBuilder {
-    let known_nodes: Vec<_> = cluster
+// We want to make sure that the returned future does not depend
+// on the provided &CassCluster, hence the `static here.
+pub fn build_session_builder(
+    cluster: &CassCluster,
+) -> impl Future<Output = SessionBuilder> + 'static {
+    let known_nodes = cluster
         .contact_points
-        .clone()
-        .into_iter()
-        .map(|cp| format!("{}:{}", cp, cluster.port))
-        .collect();
-
-    let load_balancing: Arc<dyn LoadBalancingPolicy> =
-        match cluster.child_load_balancing_policy.clone() {
-            CassClusterChildLoadBalancingPolicy::RoundRobinPolicy => {
-                if cluster.token_aware_policy_enabled {
-                    Arc::new(TokenAwarePolicy::new(Box::new(RoundRobinPolicy::new())))
-                } else {
-                    Arc::new(RoundRobinPolicy::new())
-                }
-            }
-            CassClusterChildLoadBalancingPolicy::DcAwareRoundRobinPolicy {
-                local_dc,
-                include_remote_nodes,
-            } => {
-                let mut dc_aware_policy = DcAwareRoundRobinPolicy::new(local_dc);
-                dc_aware_policy.set_include_remote_nodes(include_remote_nodes);
-
-                if cluster.token_aware_policy_enabled {
-                    Arc::new(TokenAwarePolicy::new(Box::new(dc_aware_policy)))
-                } else {
-                    Arc::new(dc_aware_policy)
-                }
-            }
-        };
-
-    let builder = cluster
-        .session_builder
-        .clone()
-        .known_nodes(&known_nodes)
-        .load_balancing(load_balancing);
-
+        .iter()
+        .map(|cp| format!("{}:{}", cp, cluster.port));
+    let mut execution_profile_builder = cluster.default_execution_profile_builder.clone();
+    let load_balancing_config = cluster.load_balancing_config.clone();
+    let mut session_builder = cluster.session_builder.clone().known_nodes(known_nodes);
     if let (Some(username), Some(password)) = (&cluster.auth_username, &cluster.auth_password) {
-        builder.user(username, password)
-    } else {
-        builder
+        session_builder = session_builder.user(username, password)
+    }
+
+    async move {
+        let load_balancing = load_balancing_config.clone().build().await;
+        execution_profile_builder = execution_profile_builder.load_balancing_policy(load_balancing);
+        session_builder
+            .default_execution_profile_handle(execution_profile_builder.build().into_handle())
     }
 }
 
@@ -98,14 +101,11 @@ pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
         contact_points: Vec::new(),
         // Per DataStax documentation: Without additional configuration the C/C++ driver
         // defaults to using Datacenter-aware load balancing with token-aware routing.
-        child_load_balancing_policy: CassClusterChildLoadBalancingPolicy::DcAwareRoundRobinPolicy {
-            local_dc: "".to_string(),
-            include_remote_nodes: true,
-        },
-        token_aware_policy_enabled: true,
         use_beta_protocol_version: false,
         auth_username: None,
         auth_password: None,
+        default_execution_profile_builder: Default::default(),
+        load_balancing_config: Default::default(),
     }))
 }
 
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn cass_cluster_set_credentials_n(
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_round_robin(cluster_raw: *mut CassCluster) {
     let cluster = ptr_to_ref_mut(cluster_raw);
-    cluster.child_load_balancing_policy = CassClusterChildLoadBalancingPolicy::RoundRobinPolicy;
+    cluster.load_balancing_config.dc_awareness = None;
 }
 
 #[no_mangle]
@@ -267,9 +267,8 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware(
     )
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
-    cluster_raw: *mut CassCluster,
+pub(crate) unsafe fn set_load_balance_dc_aware_n(
+    load_balancing_config: &mut LoadBalancingConfig,
     local_dc_raw: *const c_char,
     local_dc_length: size_t,
     used_hosts_per_remote_dc: c_uint,
@@ -279,8 +278,8 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
 
-    if used_hosts_per_remote_dc != 0 {
-        // TODO: Add warning that the parameter is deprecated and not supported in the driver.
+    if used_hosts_per_remote_dc != 0 || allow_remote_dcs_for_local_cl != 0 {
+        // TODO: Add warning that the parameters are deprecated and not supported in the driver.
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
 
@@ -288,14 +287,28 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
         .unwrap()
         .to_string();
 
-    let cluster = ptr_to_ref_mut(cluster_raw);
-    cluster.child_load_balancing_policy =
-        CassClusterChildLoadBalancingPolicy::DcAwareRoundRobinPolicy {
-            local_dc,
-            include_remote_nodes: allow_remote_dcs_for_local_cl != 0,
-        };
+    load_balancing_config.dc_awareness = Some(DcAwareness { local_dc });
 
     CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
+    cluster_raw: *mut CassCluster,
+    local_dc_raw: *const c_char,
+    local_dc_length: size_t,
+    used_hosts_per_remote_dc: c_uint,
+    allow_remote_dcs_for_local_cl: cass_bool_t,
+) -> CassError {
+    let cluster = ptr_to_ref_mut(cluster_raw);
+
+    set_load_balance_dc_aware_n(
+        &mut cluster.load_balancing_config,
+        local_dc_raw,
+        local_dc_length,
+        used_hosts_per_remote_dc,
+        allow_remote_dcs_for_local_cl,
+    )
 }
 
 #[no_mangle]
@@ -418,7 +431,9 @@ pub unsafe extern "C" fn cass_cluster_set_constant_speculative_execution_policy(
         retry_interval: Duration::from_millis(constant_delay_ms as u64),
     };
 
-    cluster.session_builder.config.speculative_execution_policy = Some(Arc::new(policy));
+    cluster.default_execution_profile_builder =
+        std::mem::take(&mut cluster.default_execution_profile_builder)
+            .speculative_execution_policy(Some(Arc::new(policy)));
 
     CassError::CASS_OK
 }
@@ -428,8 +443,9 @@ pub unsafe extern "C" fn cass_cluster_set_no_speculative_execution_policy(
     cluster_raw: *mut CassCluster,
 ) -> CassError {
     let cluster = ptr_to_ref_mut(cluster_raw);
-    cluster.session_builder.config.speculative_execution_policy = None;
-
+    cluster.default_execution_profile_builder =
+        std::mem::take(&mut cluster.default_execution_profile_builder)
+            .speculative_execution_policy(None);
     CassError::CASS_OK
 }
 
@@ -439,7 +455,7 @@ pub unsafe extern "C" fn cass_cluster_set_token_aware_routing(
     enabled: cass_bool_t,
 ) {
     let cluster = ptr_to_ref_mut(cluster_raw);
-    cluster.token_aware_policy_enabled = enabled != 0;
+    cluster.load_balancing_config.token_awareness_enabled = enabled != 0;
 }
 
 #[no_mangle]
@@ -449,14 +465,16 @@ pub unsafe extern "C" fn cass_cluster_set_retry_policy(
 ) {
     let cluster = ptr_to_ref_mut(cluster_raw);
 
-    let retry_policy: &dyn RetryPolicy = match ptr_to_ref(retry_policy) {
-        DefaultRetryPolicy(default) => default,
-        FallthroughRetryPolicy(fallthrough) => fallthrough,
-        DowngradingConsistencyRetryPolicy(downgrading) => downgrading,
+    let retry_policy: Arc<dyn RetryPolicy> = match ptr_to_ref(retry_policy) {
+        DefaultRetryPolicy(default) => default.clone(),
+        FallthroughRetryPolicy(fallthrough) => fallthrough.clone(),
+        DowngradingConsistencyRetryPolicy(downgrading) => downgrading.clone(),
     };
     let boxed_retry_policy = retry_policy.clone_boxed();
 
-    cluster.session_builder.config.retry_policy = boxed_retry_policy;
+    cluster.default_execution_profile_builder =
+        std::mem::take(&mut cluster.default_execution_profile_builder)
+            .retry_policy(boxed_retry_policy);
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -646,6 +646,7 @@ mod tests {
     };
 
     #[test]
+    #[ntest::timeout(100)]
     fn test_load_balancing_config() {
         unsafe {
             let cluster_raw = cass_cluster_new();
@@ -714,6 +715,7 @@ mod tests {
     }
 
     #[test]
+    #[ntest::timeout(100)]
     fn test_register_exec_profile() {
         unsafe {
             let cluster_raw = cass_cluster_new();

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -1,7 +1,7 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::cass_types::CassConsistency;
-use crate::exec_profile::exec_profile_builder_modify;
+use crate::exec_profile::{exec_profile_builder_modify, CassExecProfile, ExecProfileName};
 use crate::future::CassFuture;
 use crate::retry_policy::CassRetryPolicy;
 use crate::retry_policy::RetryPolicy::*;
@@ -18,6 +18,7 @@ use scylla::retry_policy::RetryPolicy;
 use scylla::speculative_execution::SimpleSpeculativeExecutionPolicy;
 use scylla::statement::{Consistency, SerialConsistency};
 use scylla::SessionBuilder;
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::future::Future;
 use std::os::raw::{c_char, c_int, c_uint};
@@ -68,6 +69,7 @@ pub(crate) struct DcAwareness {
 pub struct CassCluster {
     session_builder: SessionBuilder,
     default_execution_profile_builder: ExecutionProfileBuilder,
+    execution_profile_map: HashMap<ExecProfileName, CassExecProfile>,
 
     contact_points: Vec<String>,
     port: u16,
@@ -77,6 +79,12 @@ pub struct CassCluster {
     use_beta_protocol_version: bool,
     auth_username: Option<String>,
     auth_password: Option<String>,
+}
+
+impl CassCluster {
+    pub(crate) fn execution_profile_map(&self) -> &HashMap<ExecProfileName, CassExecProfile> {
+        &self.execution_profile_map
+    }
 }
 
 pub struct CassCustomPayload;
@@ -121,6 +129,7 @@ pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
         auth_username: None,
         auth_password: None,
         default_execution_profile_builder,
+        execution_profile_map: Default::default(),
         load_balancing_config: Default::default(),
     }))
 }

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -13,6 +13,7 @@ use scylla::frame::Compression;
 use scylla::load_balancing::{DefaultPolicyBuilder, LoadBalancingPolicy};
 use scylla::retry_policy::RetryPolicy;
 use scylla::speculative_execution::SimpleSpeculativeExecutionPolicy;
+use scylla::statement::Consistency;
 use scylla::SessionBuilder;
 use std::future::Future;
 use std::os::raw::{c_char, c_int, c_uint};
@@ -95,6 +96,10 @@ pub fn build_session_builder(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
+    // According to `cassandra.h` the default CPP driver's consistency for statements is LOCAL_ONE.
+    let default_execution_profile_builder =
+        ExecutionProfileBuilder::default().consistency(Consistency::LocalOne);
+
     Box::into_raw(Box::new(CassCluster {
         session_builder: SessionBuilder::new(),
         port: 9042,
@@ -104,7 +109,7 @@ pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
         use_beta_protocol_version: false,
         auth_username: None,
         auth_password: None,
-        default_execution_profile_builder: Default::default(),
+        default_execution_profile_builder,
         load_balancing_config: Default::default(),
     }))
 }

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -93,8 +93,7 @@ pub fn build_session_builder(cluster: &CassCluster) -> SessionBuilder {
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
     Box::into_raw(Box::new(CassCluster {
-        session_builder: SessionBuilder::new()
-            .retry_policy(Box::new(scylla::retry_policy::DefaultRetryPolicy)),
+        session_builder: SessionBuilder::new(),
         port: 9042,
         contact_points: Vec::new(),
         // Per DataStax documentation: Without additional configuration the C/C++ driver

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -425,6 +425,7 @@ mod tests {
     use assert_matches::assert_matches;
 
     #[test]
+    #[ntest::timeout(100)]
     fn test_exec_profile_name() {
         use std::convert::TryInto;
         let empty = "".to_owned();
@@ -440,6 +441,7 @@ mod tests {
     }
 
     #[test]
+    #[ntest::timeout(100)]
     fn test_load_balancing_config() {
         unsafe {
             let profile_raw = cass_execution_profile_new();
@@ -532,6 +534,7 @@ mod tests {
     }
 
     #[test]
+    #[ntest::timeout(100)]
     fn test_statement_and_batch_set_exec_profile() {
         unsafe {
             let empty_query = make_c_str!("");

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -15,7 +15,6 @@ use crate::argconv::{free_boxed, ptr_to_ref, ptr_to_ref_mut, strlen};
 use crate::batch::CassBatch;
 use crate::cass_error::CassError;
 use crate::cass_types::CassConsistency;
-use crate::cluster::CassCluster;
 use crate::cluster::{set_load_balance_dc_aware_n, LoadBalancingConfig};
 use crate::retry_policy::CassRetryPolicy;
 use crate::retry_policy::RetryPolicy::{
@@ -312,25 +311,6 @@ pub unsafe extern "C" fn cass_batch_set_execution_profile_n(
     batch: *mut CassBatch,
     name: *const c_char,
     name_length: size_t,
-) -> CassError {
-    unimplemented!()
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_cluster_set_execution_profile(
-    cluster: *mut CassCluster,
-    name: *const c_char,
-    profile: *const CassExecProfile,
-) -> CassError {
-    unimplemented!()
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
-    cluster: *mut CassCluster,
-    name: *const c_char,
-    name_length: size_t,
-    profile: *const CassExecProfile,
 ) -> CassError {
     unimplemented!()
 }

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -1,0 +1,160 @@
+use std::ffi::c_char;
+
+use crate::argconv::free_boxed;
+use crate::batch::CassBatch;
+use crate::cass_error::CassError;
+use crate::cass_types::CassConsistency;
+use crate::cluster::CassCluster;
+use crate::retry_policy::CassRetryPolicy;
+use crate::statement::CassStatement;
+use crate::types::{cass_bool_t, cass_int32_t, cass_int64_t, cass_uint32_t, cass_uint64_t, size_t};
+
+pub struct CassExecProfile;
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_new() -> *mut CassExecProfile {
+    Box::into_raw(Box::new(CassExecProfile))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_free(profile: *mut CassExecProfile) {
+    free_boxed(profile);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_consistency(
+    profile: *mut CassExecProfile,
+    consistency: CassConsistency,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_constant_speculative_execution_policy(
+    profile: *mut CassExecProfile,
+    constant_delay_ms: cass_int64_t,
+    max_speculative_executions: cass_int32_t,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_latency_aware_routing(
+    profile: *mut CassExecProfile,
+    enabled: cass_bool_t,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware(
+    profile: *mut CassExecProfile,
+    local_dc: *const c_char,
+    used_hosts_per_remote_dc: cass_uint32_t,
+    allow_remote_dcs_for_local_cl: cass_bool_t,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware_n(
+    profile: *mut CassExecProfile,
+    local_dc: *const c_char,
+    local_dc_length: size_t,
+    used_hosts_per_remote_dc: cass_uint32_t,
+    allow_remote_dcs_for_local_cl: cass_bool_t,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_load_balance_round_robin(
+    profile: *mut CassExecProfile,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_request_timeout(
+    profile: *mut CassExecProfile,
+    timeout_ms: cass_uint64_t,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_retry_policy(
+    profile: *mut CassExecProfile,
+    retry_policy: *const CassRetryPolicy,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_serial_consistency(
+    profile: *mut CassExecProfile,
+    serial_consistency: CassConsistency,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_token_aware_routing(
+    profile: *mut CassExecProfile,
+    enabled: cass_bool_t,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_statement_set_execution_profile(
+    statement: *mut CassStatement,
+    name: *const c_char,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_statement_set_execution_profile_n(
+    statement: *mut CassStatement,
+    name: *const c_char,
+    name_length: size_t,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_set_execution_profile(
+    batch: *mut CassBatch,
+    name: *const c_char,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_batch_set_execution_profile_n(
+    batch: *mut CassBatch,
+    name: *const c_char,
+    name_length: size_t,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_execution_profile(
+    cluster: *mut CassCluster,
+    name: *const c_char,
+    profile: *const CassExecProfile,
+) -> CassError {
+    unimplemented!()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
+    cluster: *mut CassCluster,
+    name: *const c_char,
+    name_length: size_t,
+    profile: *const CassExecProfile,
+) -> CassError {
+    unimplemented!()
+}

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -275,6 +275,7 @@ mod tests {
     // In the incorrect implementation that inspired this test to be written, this test
     // results with unwrap on a PoisonError on the CassFuture's mutex.
     #[test]
+    #[ntest::timeout(100)]
     fn cass_future_thread_safety() {
         const ERROR_MSG: &str = "NOBODY EXPECTED SPANISH INQUISITION";
         let fut = async {

--- a/scylla-rust-wrapper/src/inet.rs
+++ b/scylla-rust-wrapper/src/inet.rs
@@ -1,4 +1,4 @@
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, non_snake_case)]
 use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::types::*;

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cass_error;
 pub mod cass_types;
 pub mod cluster;
 pub mod collection;
+pub mod exec_profile;
 mod external;
 pub mod future;
 pub mod inet;

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -28,6 +28,7 @@ pub mod retry_policy;
 pub mod session;
 pub mod ssl;
 pub mod statement;
+#[cfg(test)]
 pub mod testing;
 pub mod tuple;
 pub mod types;

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -16,7 +16,7 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::Layer;
 
 mod cass_log {
-    #![allow(non_camel_case_types)]
+    #![allow(non_camel_case_types, non_snake_case)]
     include!(concat!(env!("OUT_DIR"), "/cppdriver_log.rs"));
 }
 use cass_log::*;

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -2,7 +2,7 @@ use crate::argconv::*;
 use crate::cass_types::get_column_type_from_cql_type;
 use crate::cass_types::CassDataType;
 use crate::types::*;
-use scylla::transport::topology::{ColumnKind, CqlType, Table};
+use scylla::transport::topology::{ColumnKind, Table, UserDefinedType};
 use std::collections::HashMap;
 use std::os::raw::c_char;
 use std::sync::Arc;
@@ -47,7 +47,7 @@ pub unsafe fn create_table_metadata(
     keyspace_name: &str,
     table_name: &str,
     table_metadata: &Table,
-    user_defined_types: &HashMap<String, Vec<(String, CqlType)>>,
+    user_defined_types: &HashMap<String, Arc<UserDefinedType>>,
 ) -> CassTableMeta {
     let mut columns_metadata = HashMap::new();
     table_metadata

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -30,5 +30,6 @@ pub unsafe extern "C" fn cass_prepared_bind(
         bound_values: vec![Unset; bound_values_size],
         paging_state: None,
         request_timeout_ms: None,
+        exec_profile: None,
     }))
 }

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -1,38 +1,38 @@
-use crate::argconv::free_arced;
+use crate::argconv::free_boxed;
 use scylla::retry_policy::{DefaultRetryPolicy, FallthroughRetryPolicy};
 use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
 use std::sync::Arc;
 
 pub enum RetryPolicy {
-    DefaultRetryPolicy(DefaultRetryPolicy),
-    FallthroughRetryPolicy(FallthroughRetryPolicy),
-    DowngradingConsistencyRetryPolicy(DowngradingConsistencyRetryPolicy),
+    DefaultRetryPolicy(Arc<DefaultRetryPolicy>),
+    FallthroughRetryPolicy(Arc<FallthroughRetryPolicy>),
+    DowngradingConsistencyRetryPolicy(Arc<DowngradingConsistencyRetryPolicy>),
 }
 
 pub type CassRetryPolicy = RetryPolicy;
 
 #[no_mangle]
 pub extern "C" fn cass_retry_policy_default_new() -> *const CassRetryPolicy {
-    Arc::into_raw(Arc::new(RetryPolicy::DefaultRetryPolicy(
+    Box::into_raw(Box::new(RetryPolicy::DefaultRetryPolicy(Arc::new(
         DefaultRetryPolicy,
-    )))
+    ))))
 }
 
 #[no_mangle]
 pub extern "C" fn cass_retry_policy_downgrading_consistency_new() -> *const CassRetryPolicy {
-    Arc::into_raw(Arc::new(RetryPolicy::DowngradingConsistencyRetryPolicy(
-        DowngradingConsistencyRetryPolicy,
+    Box::into_raw(Box::new(RetryPolicy::DowngradingConsistencyRetryPolicy(
+        Arc::new(DowngradingConsistencyRetryPolicy),
     )))
 }
 
 #[no_mangle]
 pub extern "C" fn cass_retry_policy_fallthrough_new() -> *const CassRetryPolicy {
-    Arc::into_raw(Arc::new(RetryPolicy::FallthroughRetryPolicy(
+    Box::into_raw(Box::new(RetryPolicy::FallthroughRetryPolicy(Arc::new(
         FallthroughRetryPolicy,
-    )))
+    ))))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_retry_policy_free(retry_policy: *const CassRetryPolicy) {
-    free_arced(retry_policy);
+pub unsafe extern "C" fn cass_retry_policy_free(retry_policy: *mut CassRetryPolicy) {
+    free_boxed(retry_policy);
 }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -4,6 +4,7 @@ use crate::cass_error::*;
 use crate::cass_types::{get_column_type, CassDataType, UDTDataType};
 use crate::cluster::build_session_builder;
 use crate::cluster::CassCluster;
+use crate::exec_profile::ExecProfileName;
 use crate::future::{CassFuture, CassResultValue};
 use crate::logging::init_logging;
 use crate::metadata::create_table_metadata;
@@ -17,6 +18,7 @@ use scylla::frame::response::result::{CqlValue, Row};
 use scylla::frame::types::Consistency;
 use scylla::query::Query;
 use scylla::transport::errors::QueryError;
+use scylla::transport::execution_profile::ExecutionProfileHandle;
 use scylla::{QueryResult, Session};
 use std::collections::HashMap;
 use std::future::Future;
@@ -27,6 +29,7 @@ use tokio::sync::RwLock;
 
 pub struct CassSessionInner {
     session: Session,
+    exec_profile_map: HashMap<ExecProfileName, ExecutionProfileHandle>,
 }
 
 pub type CassSession = RwLock<Option<CassSessionInner>>;
@@ -45,7 +48,7 @@ pub unsafe extern "C" fn cass_session_connect(
     cluster_raw: *const CassCluster,
 ) -> *const CassFuture {
     let session_opt = ptr_to_ref(session_raw);
-    let cluster: CassCluster = (*ptr_to_ref(cluster_raw)).clone();
+    let cluster: CassCluster = ptr_to_ref(cluster_raw).clone();
 
     CassFuture::make_raw(async move {
         // This can sleep for a long time, but only if someone connects/closes session
@@ -57,6 +60,10 @@ pub unsafe extern "C" fn cass_session_connect(
                 "Already connecting, closing, or connected".msg(),
             ));
         }
+        let mut exec_profile_map = HashMap::with_capacity(cluster.execution_profile_map().len());
+        for (name, builder) in cluster.execution_profile_map() {
+            exec_profile_map.insert(name.clone(), builder.clone().build().await.into_handle());
+        }
 
         let session = build_session_builder(&cluster)
             .await
@@ -64,7 +71,10 @@ pub unsafe extern "C" fn cass_session_connect(
             .await
             .map_err(|err| (CassError::from(&err), err.msg()))?;
 
-        *session_guard = Some(CassSessionInner { session });
+        *session_guard = Some(CassSessionInner {
+            session,
+            exec_profile_map,
+        });
         Ok(CassResultValue::Empty)
     })
 }
@@ -87,7 +97,9 @@ pub unsafe extern "C" fn cass_session_execute_batch(
                 "Session is not connected".msg(),
             ));
         }
-        let session = &session_guard.as_ref().unwrap().session;
+
+        let cass_session_inner = &session_guard.as_ref().unwrap();
+        let session = &cass_session_inner.session;
 
         let query_res = session.batch(&state.batch, &state.bound_values).await;
         match query_res {
@@ -485,4 +497,179 @@ pub unsafe extern "C" fn cass_session_get_schema_meta(
     }
 
     Box::into_raw(Box::new(CassSchemaMeta { keyspaces }))
+}
+
+#[cfg(test)]
+mod tests {
+    use scylla_proxy::{
+        Condition, Node, Proxy, Reaction, RequestFrame, RequestOpcode, RequestReaction,
+        RequestRule, ResponseFrame, RunningProxy,
+    };
+    use tracing::instrument::WithSubscriber;
+
+    use super::*;
+    use crate::{
+        argconv::{make_c_str, ptr_to_ref},
+        cluster::{
+            cass_cluster_free, cass_cluster_new, cass_cluster_set_contact_points_n,
+            cass_cluster_set_execution_profile,
+        },
+        exec_profile::{cass_execution_profile_free, cass_execution_profile_new, ExecProfileName},
+        future::{
+            cass_future_error_code, cass_future_error_message, cass_future_free, cass_future_wait,
+        },
+        testing::assert_cass_error_eq,
+    };
+    use std::{collections::HashSet, convert::TryFrom, net::SocketAddr};
+
+    // This is for convenient logs from failing tests. Just call it at the beginning of a test.
+    #[allow(unused)]
+    fn init_logger() {
+        let _ = tracing_subscriber::fmt::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .without_time()
+            .try_init();
+    }
+
+    unsafe fn cass_future_wait_check_and_free(fut: *const CassFuture) {
+        cass_future_wait(fut);
+        if cass_future_error_code(fut) != CassError::CASS_OK {
+            let mut message: *const c_char = std::ptr::null();
+            let mut message_len: size_t = 0;
+            cass_future_error_message(fut as *mut CassFuture, &mut message, &mut message_len);
+            eprintln!("{:?}", ptr_to_cstr_n(message, message_len));
+        }
+        assert_cass_error_eq!(cass_future_error_code(fut), CassError::CASS_OK);
+        cass_future_free(fut);
+    }
+
+    fn handshake_rules() -> impl IntoIterator<Item = RequestRule> {
+        [
+            RequestRule(
+                Condition::RequestOpcode(RequestOpcode::Options),
+                RequestReaction::forge_response(Arc::new(move |frame: RequestFrame| {
+                    ResponseFrame::forged_supported(frame.params, &HashMap::new()).unwrap()
+                })),
+            ),
+            RequestRule(
+                Condition::RequestOpcode(RequestOpcode::Startup)
+                    .or(Condition::RequestOpcode(RequestOpcode::Register)),
+                RequestReaction::forge_response(Arc::new(move |frame: RequestFrame| {
+                    ResponseFrame::forged_ready(frame.params)
+                })),
+            ),
+        ]
+    }
+
+    // As these are very generic, they should be put last in the rules Vec.
+    fn generic_drop_queries_rules() -> impl IntoIterator<Item = RequestRule> {
+        [RequestRule(
+            Condition::RequestOpcode(RequestOpcode::Query),
+            // We won't respond to any queries (including metadata fetch),
+            // but the driver will manage to continue with dummy metadata.
+            RequestReaction::drop_connection(),
+        )]
+    }
+
+    pub(crate) async fn test_with_one_proxy_one(
+        test: impl FnOnce(SocketAddr, RunningProxy) -> RunningProxy + Send + 'static,
+        rules: impl IntoIterator<Item = RequestRule>,
+    ) {
+        let proxy_addr = SocketAddr::new(scylla_proxy::get_exclusive_local_address(), 9042);
+
+        let proxy = Proxy::builder()
+            .with_node(
+                Node::builder()
+                    .proxy_address(proxy_addr)
+                    .request_rules(rules.into_iter().collect())
+                    .build_dry_mode(),
+            )
+            .build()
+            .run()
+            .await
+            .unwrap();
+
+        // This is required to avoid the clash of a runtime built inside another runtime
+        // (the test runs one runtime to drive the proxy, and CassFuture implementation uses another)
+        let proxy = tokio::task::spawn_blocking(move || test(proxy_addr, proxy))
+            .await
+            .expect("Test thread panicked");
+
+        let _ = proxy.finish().await;
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(5000)]
+    async fn session_clones_and_freezes_exec_profiles_mapping() {
+        init_logger();
+        test_with_one_proxy_one(
+            session_clones_and_freezes_exec_profiles_mapping_do,
+            handshake_rules()
+                .into_iter()
+                .chain(generic_drop_queries_rules()),
+        )
+        .with_current_subscriber()
+        .await;
+    }
+
+    fn session_clones_and_freezes_exec_profiles_mapping_do(
+        node_addr: SocketAddr,
+        proxy: RunningProxy,
+    ) -> RunningProxy {
+        unsafe {
+            let cluster_raw = cass_cluster_new();
+            let ip = node_addr.ip().to_string();
+            let (c_ip, c_ip_len) = str_to_c_str_n(ip.as_str());
+
+            assert_cass_error_eq!(
+                cass_cluster_set_contact_points_n(cluster_raw, c_ip, c_ip_len),
+                CassError::CASS_OK
+            );
+            let session_raw = cass_session_new();
+            let profile_raw = cass_execution_profile_new();
+            {
+                cass_future_wait_check_and_free(cass_session_connect(session_raw, cluster_raw));
+                // Initially, the profile map is empty.
+
+                assert!(ptr_to_ref(session_raw)
+                    .blocking_read()
+                    .as_ref()
+                    .unwrap()
+                    .exec_profile_map
+                    .is_empty());
+
+                cass_cluster_set_execution_profile(cluster_raw, make_c_str!("prof"), profile_raw);
+                // Mutations in cluster do not affect the session that was connected before.
+                assert!(ptr_to_ref(session_raw)
+                    .blocking_read()
+                    .as_ref()
+                    .unwrap()
+                    .exec_profile_map
+                    .is_empty());
+
+                cass_future_wait_check_and_free(cass_session_close(session_raw));
+
+                // Mutations in cluster are now propagated to the session.
+                cass_future_wait_check_and_free(cass_session_connect(session_raw, cluster_raw));
+                let profile_map_keys = ptr_to_ref(session_raw)
+                    .blocking_read()
+                    .as_ref()
+                    .unwrap()
+                    .exec_profile_map
+                    .keys()
+                    .cloned()
+                    .collect::<HashSet<_>>();
+                assert_eq!(
+                    profile_map_keys,
+                    std::iter::once(ExecProfileName::try_from("prof".to_owned()).unwrap())
+                        .collect::<HashSet<_>>()
+                );
+                cass_future_wait_check_and_free(cass_session_close(session_raw));
+            }
+            cass_execution_profile_free(profile_raw);
+            cass_session_free(session_raw);
+            cass_cluster_free(cluster_raw);
+        }
+        proxy
+    }
 }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -28,11 +28,11 @@ use tokio::sync::RwLock;
 pub type CassSession = RwLock<Option<Session>>;
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_session_new() -> *const CassSession {
+pub unsafe extern "C" fn cass_session_new() -> *mut CassSession {
     init_logging();
 
-    let session = Arc::new(RwLock::new(None));
-    Arc::into_raw(session)
+    let session = Arc::new(RwLock::new(None::<Session>));
+    Arc::into_raw(session) as *mut CassSession
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -55,6 +55,7 @@ pub unsafe extern "C" fn cass_session_connect(
         }
 
         let session = build_session_builder(&cluster)
+            .await
             .build()
             .await
             .map_err(|err| (CassError::from(&err), err.msg()))?;

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -146,6 +146,29 @@ pub unsafe extern "C" fn cass_session_connect(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn cass_session_connect_keyspace(
+    session_raw: *mut CassSession,
+    cluster_raw: *const CassCluster,
+    keyspace: *const c_char,
+) -> *const CassFuture {
+    cass_session_connect_keyspace_n(session_raw, cluster_raw, keyspace, strlen(keyspace))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_session_connect_keyspace_n(
+    session_raw: *mut CassSession,
+    cluster_raw: *const CassCluster,
+    keyspace: *const c_char,
+    keyspace_length: size_t,
+) -> *const CassFuture {
+    let session_opt = ptr_to_ref(session_raw);
+    let cluster: &CassCluster = ptr_to_ref(cluster_raw);
+    let keyspace = ptr_to_cstr_n(keyspace, keyspace_length).map(ToOwned::to_owned);
+
+    CassSessionInner::connect(session_opt, cluster, keyspace)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn cass_session_execute_batch(
     session_raw: *mut CassSession,
     batch_raw: *const CassBatch,

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -987,6 +987,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ntest::timeout(30000)]
     async fn retry_policy_on_statement_and_batch_is_handled_properly() {
         init_logger();
         test_with_one_proxy_one(
@@ -1158,6 +1159,7 @@ mod tests {
 
                 // With no exec profile nor retry policy set on statement/batch,
                 // the default cluster-wide retry policy should be used: in this case, fallthrough.
+
                 // F - -
                 assert_query_with_fallthrough_policy(&mut proxy);
 

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -146,10 +146,6 @@ pub unsafe extern "C" fn cass_statement_new_n(
 
     // Set Cpp Driver default configuration for queries:
     query.disable_paging();
-    // TODO: Consider moving this configuration to the default execution profile.
-    // With the current way, any changes to consistency on exec profile level will be
-    // anyway overriden with this setting.
-    query.set_consistency(Consistency::LocalOne);
 
     let simple_query = SimpleQuery {
         query,

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -146,7 +146,10 @@ pub unsafe extern "C" fn cass_statement_new_n(
 
     // Set Cpp Driver default configuration for queries:
     query.disable_paging();
-    query.set_consistency(Consistency::One);
+    // TODO: Consider moving this configuration to the default execution profile.
+    // With the current way, any changes to consistency on exec profile level will be
+    // anyway overriden with this setting.
+    query.set_consistency(Consistency::LocalOne);
 
     let simple_query = SimpleQuery {
         query,

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -1,5 +1,6 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
+use crate::exec_profile::PerStatementExecProfile;
 use crate::query_result::CassResult;
 use crate::retry_policy::CassRetryPolicy;
 use crate::types::*;
@@ -36,6 +37,8 @@ pub struct CassStatement {
     pub bound_values: Vec<MaybeUnset<Option<CqlValue>>>,
     pub paging_state: Option<Bytes>,
     pub request_timeout_ms: Option<cass_uint64_t>,
+
+    pub(crate) exec_profile: Option<PerStatementExecProfile>,
 }
 
 impl CassStatement {
@@ -157,6 +160,7 @@ pub unsafe extern "C" fn cass_statement_new_n(
         bound_values: vec![Unset; parameter_count as usize],
         paging_state: None,
         request_timeout_ms: None,
+        exec_profile: None,
     }))
 }
 

--- a/scylla-rust-wrapper/src/testing.rs
+++ b/scylla-rust-wrapper/src/testing.rs
@@ -1,1 +1,15 @@
-
+macro_rules! assert_cass_error_eq {
+    ($expr:expr, $error:expr $(,)?) => {{
+        use crate::argconv::ptr_to_cstr;
+        use crate::external::cass_error_desc;
+        let ___x = $expr;
+        assert_eq!(
+            ___x,
+            $error,
+            "expected \"{}\", instead got \"{}\"",
+            ptr_to_cstr(cass_error_desc($error)).unwrap(),
+            ptr_to_cstr(cass_error_desc(___x)).unwrap()
+        );
+    }};
+}
+pub(crate) use assert_cass_error_eq;

--- a/scylla-rust-wrapper/src/types.rs
+++ b/scylla-rust-wrapper/src/types.rs
@@ -16,6 +16,7 @@ pub type cass_int64_t = i64;
 pub type cass_uint64_t = u64;
 pub type cass_byte_t = cass_uint8_t;
 pub type cass_duration_t = cass_uint64_t;
+pub type size_t = cass_uint64_t;
 
 // Implementation directly ported from Cpp Driver implementation:
 

--- a/scylla-rust-wrapper/src/uuid.rs
+++ b/scylla-rust-wrapper/src/uuid.rs
@@ -1,4 +1,4 @@
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, non_snake_case)]
 use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::types::*;

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -116,20 +116,6 @@ cass_cluster_set_host_listener_callback(CassCluster* cluster,
                                         void* data){
 	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_host_listener_callback\n");
 }
-CASS_EXPORT void
-cass_cluster_set_latency_aware_routing(CassCluster* cluster,
-                                       cass_bool_t enabled){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_latency_aware_routing\n");
-}
-CASS_EXPORT void
-cass_cluster_set_latency_aware_routing_settings(CassCluster* cluster,
-                                                cass_double_t exclusion_threshold,
-                                                cass_uint64_t scale_ms,
-                                                cass_uint64_t retry_period_ms,
-                                                cass_uint64_t update_rate_ms,
-                                                cass_uint64_t min_measured){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_latency_aware_routing_settings\n");
-}
 CASS_EXPORT CassError
 cass_cluster_set_local_address(CassCluster* cluster,
                                const char* name){

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -53,11 +53,6 @@ cass_authenticator_set_error(CassAuthenticator* auth,
 	throw std::runtime_error("UNIMPLEMENTED cass_authenticator_set_error\n");
 }
 CASS_EXPORT CassError
-cass_batch_set_execution_profile(CassBatch* batch,
-                                 const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_batch_set_execution_profile\n");
-}
-CASS_EXPORT CassError
 cass_batch_set_keyspace(CassBatch* batch,
                         const char* keyspace){
 	throw std::runtime_error("UNIMPLEMENTED cass_batch_set_keyspace\n");
@@ -103,12 +98,6 @@ CASS_EXPORT CassError
 cass_cluster_set_core_connections_per_host(CassCluster* cluster,
                                            unsigned num_connections){
 	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_core_connections_per_host\n");
-}
-CASS_EXPORT CassError
-cass_cluster_set_execution_profile(CassCluster* cluster,
-                                   const char* name,
-                                   CassExecProfile* profile){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_execution_profile\n");
 }
 CASS_EXPORT CassError
 cass_cluster_set_host_listener_callback(CassCluster* cluster,
@@ -203,14 +192,6 @@ cass_custom_payload_set(CassCustomPayload* payload,
                         size_t value_size){
 	throw std::runtime_error("UNIMPLEMENTED cass_custom_payload_set\n");
 }
-CASS_EXPORT void
-cass_execution_profile_free(CassExecProfile* profile){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_free\n");
-}
-CASS_EXPORT CassExecProfile*
-cass_execution_profile_new(){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_new\n");
-}
 CASS_EXPORT CassError
 cass_execution_profile_set_blacklist_dc_filtering(CassExecProfile* profile,
                                                   const char* dcs){
@@ -220,53 +201,6 @@ CASS_EXPORT CassError
 cass_execution_profile_set_blacklist_filtering(CassExecProfile* profile,
                                                const char* hosts){
 	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_blacklist_filtering\n");
-}
-CASS_EXPORT CassError
-cass_execution_profile_set_consistency(CassExecProfile* profile,
-                                       CassConsistency consistency){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_consistency\n");
-}
-CASS_EXPORT CassError
-cass_execution_profile_set_constant_speculative_execution_policy(CassExecProfile* profile,
-                                                                 cass_int64_t constant_delay_ms,
-                                                                 int max_speculative_executions){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_constant_speculative_execution_policy\n");
-}
-CASS_EXPORT CassError
-cass_execution_profile_set_latency_aware_routing(CassExecProfile* profile,
-                                                 cass_bool_t enabled){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_latency_aware_routing\n");
-}
-CASS_EXPORT CassError
-cass_execution_profile_set_load_balance_dc_aware(CassExecProfile* profile,
-                                                 const char* local_dc,
-                                                 unsigned used_hosts_per_remote_dc,
-                                                 cass_bool_t allow_remote_dcs_for_local_cl){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_load_balance_dc_aware\n");
-}
-CASS_EXPORT CassError
-cass_execution_profile_set_load_balance_round_robin(CassExecProfile* profile){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_load_balance_round_robin\n");
-}
-CASS_EXPORT CassError
-cass_execution_profile_set_request_timeout(CassExecProfile* profile,
-                                           cass_uint64_t timeout_ms){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_request_timeout\n");
-}
-CASS_EXPORT CassError
-cass_execution_profile_set_retry_policy(CassExecProfile* profile,
-                                        CassRetryPolicy* retry_policy){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_retry_policy\n");
-}
-CASS_EXPORT CassError
-cass_execution_profile_set_serial_consistency(CassExecProfile* profile,
-                                              CassConsistency serial_consistency){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_serial_consistency\n");
-}
-CASS_EXPORT CassError
-cass_execution_profile_set_token_aware_routing(CassExecProfile* profile,
-                                               cass_bool_t enabled){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_token_aware_routing\n");
 }
 CASS_EXPORT CassError
 cass_execution_profile_set_whitelist_dc_filtering(CassExecProfile* profile,
@@ -458,11 +392,6 @@ CASS_EXPORT CassError
 cass_statement_set_custom_payload(CassStatement* statement,
                                   const CassCustomPayload* payload){
 	throw std::runtime_error("UNIMPLEMENTED cass_statement_set_custom_payload\n");
-}
-CASS_EXPORT CassError
-cass_statement_set_execution_profile(CassStatement* statement,
-                                     const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_set_execution_profile\n");
 }
 CASS_EXPORT CassError
 cass_statement_set_host(CassStatement* statement,

--- a/tests/src/integration/objects/execution_profile.hpp
+++ b/tests/src/integration/objects/execution_profile.hpp
@@ -63,27 +63,28 @@ public:
    */
   static ExecutionProfile build() { return ExecutionProfile(); }
 
-  /**
-   * Append/Assign/Set the blacklist hosts for statement/batch execution
-   *
-   * @param hosts A comma delimited list of hosts addresses
-   * @return Execution profile object
-   */
-  ExecutionProfile& with_blacklist_filtering(const std::string& hosts) {
-    EXPECT_EQ(CASS_OK, cass_execution_profile_set_blacklist_filtering(get(), hosts.c_str()));
-    return *this;
-  }
+  // Host filtering is not supported in cpp-rust-driver
+  // /**
+  //  * Append/Assign/Set the blacklist hosts for statement/batch execution
+  //  *
+  //  * @param hosts A comma delimited list of hosts addresses
+  //  * @return Execution profile object
+  //  */
+  // ExecutionProfile& with_blacklist_filtering(const std::string& hosts) {
+  //   EXPECT_EQ(CASS_OK, cass_execution_profile_set_blacklist_filtering(get(), hosts.c_str()));
+  //   return *this;
+  // }
 
-  /**
-   * Append/Assign/Set the blacklist data centers for statement/batch execution
-   *
-   * @param dcs A comma delimited list of data center names
-   * @return Execution profile object
-   */
-  ExecutionProfile& with_blacklist_dc_filtering(const std::string& dcs) {
-    EXPECT_EQ(CASS_OK, cass_execution_profile_set_blacklist_dc_filtering(get(), dcs.c_str()));
-    return *this;
-  }
+  // /**
+  //  * Append/Assign/Set the blacklist data centers for statement/batch execution
+  //  *
+  //  * @param dcs A comma delimited list of data center names
+  //  * @return Execution profile object
+  //  */
+  // ExecutionProfile& with_blacklist_dc_filtering(const std::string& dcs) {
+  //   EXPECT_EQ(CASS_OK, cass_execution_profile_set_blacklist_dc_filtering(get(), dcs.c_str()));
+  //   return *this;
+  // }
 
   /**
    * Assign/Set the profile consistency level for statement/batch execution
@@ -257,27 +258,28 @@ public:
     return *this;
   }
 
-  /**
-   * Append/Assign/Set the whitelist hosts for statement/batch execution
-   *
-   * @param hosts A comma delimited list of hosts addresses
-   * @return Execution profile object
-   */
-  ExecutionProfile& with_whitelist_filtering(const std::string& hosts) {
-    EXPECT_EQ(CASS_OK, cass_execution_profile_set_whitelist_filtering(get(), hosts.c_str()));
-    return *this;
-  }
+  // Host filtering is not supported in cpp-rust-driver
+  // /**
+  //  * Append/Assign/Set the whitelist hosts for statement/batch execution
+  //  *
+  //  * @param hosts A comma delimited list of hosts addresses
+  //  * @return Execution profile object
+  //  */
+  // ExecutionProfile& with_whitelist_filtering(const std::string& hosts) {
+  //   EXPECT_EQ(CASS_OK, cass_execution_profile_set_whitelist_filtering(get(), hosts.c_str()));
+  //   return *this;
+  // }
 
-  /**
-   * Append/Assign/Set the whitelist data centers for statement/batch execution
-   *
-   * @param dcs A comma delimited list of data center names
-   * @return Execution profile object
-   */
-  ExecutionProfile& with_whitelist_dc_filtering(const std::string& dcs) {
-    EXPECT_EQ(CASS_OK, cass_execution_profile_set_whitelist_dc_filtering(get(), dcs.c_str()));
-    return *this;
-  }
+  // /**
+  //  * Append/Assign/Set the whitelist data centers for statement/batch execution
+  //  *
+  //  * @param dcs A comma delimited list of data center names
+  //  * @return Execution profile object
+  //  */
+  // ExecutionProfile& with_whitelist_dc_filtering(const std::string& dcs) {
+  //   EXPECT_EQ(CASS_OK, cass_execution_profile_set_whitelist_dc_filtering(get(), dcs.c_str()));
+  //   return *this;
+  // }
 };
 
 }} // namespace test::driver

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -27,7 +27,8 @@ public:
       : insert_(NULL)
       //, child_retry_policy_(IgnoreRetryPolicy::policy()) // Used for counting retry
       , child_retry_policy_(DefaultRetryPolicy())
-      , logging_retry_policy_(child_retry_policy_)
+      // We do not implement logging retry policy in cpp-rust-driver
+      // , logging_retry_policy_(child_retry_policy_)
       , skip_base_execution_profile_(false) {
     replication_factor_ = 2;
     number_dc1_nodes_ = 2;
@@ -41,24 +42,27 @@ public:
     // Create the execution profiles for the test cases
     if (!skip_base_execution_profile_) {
       profiles_["request_timeout"] = ExecutionProfile::build().with_request_timeout(1);
-      profiles_["consistency"] =
-          ExecutionProfile::build().with_consistency(CASS_CONSISTENCY_SERIAL);
-      profiles_["serial_consistency"] =
-          ExecutionProfile::build().with_serial_consistency(CASS_CONSISTENCY_ONE);
+      // Setting bad consistency type for exec profile is forbidden in cpp-rust-driver
+      // profiles_["consistency"] =
+      //     ExecutionProfile::build().with_consistency(CASS_CONSISTENCY_SERIAL);
+      // profiles_["serial_consistency"] =
+      //     ExecutionProfile::build().with_serial_consistency(CASS_CONSISTENCY_ONE);
       profiles_["round_robin"] =
           ExecutionProfile::build().with_load_balance_round_robin().with_token_aware_routing(false);
       profiles_["latency_aware"] =
           ExecutionProfile::build().with_latency_aware_routing().with_load_balance_round_robin();
       profiles_["token_aware"] =
           ExecutionProfile::build().with_token_aware_routing().with_load_balance_round_robin();
-      profiles_["blacklist"] = ExecutionProfile::build()
-                                   .with_blacklist_filtering(Options::host_prefix() + "1")
-                                   .with_load_balance_round_robin();
-      profiles_["whitelist"] = ExecutionProfile::build()
-                                   .with_whitelist_filtering(Options::host_prefix() + "1")
-                                   .with_load_balance_round_robin();
+      // Host filtering is not supported in cpp-rust-driver
+      // profiles_["blacklist"] = ExecutionProfile::build()
+      //                              .with_blacklist_filtering(Options::host_prefix() + "1")
+      //                              .with_load_balance_round_robin();
+      // profiles_["whitelist"] = ExecutionProfile::build()
+      //                              .with_whitelist_filtering(Options::host_prefix() + "1")
+      //                              .with_load_balance_round_robin();
       profiles_["retry_policy"] = ExecutionProfile::build()
-                                      .with_retry_policy(logging_retry_policy_)
+      // We do not implement logging retry policy in cpp-rust-driver
+                                      .with_retry_policy(child_retry_policy_)
                                       .with_consistency(CASS_CONSISTENCY_THREE);
       profiles_["speculative_execution"] =
           ExecutionProfile::build().with_constant_speculative_execution_policy(100, 20);
@@ -95,10 +99,12 @@ protected:
    * Child retry policy for 'retry_policy' execution profile
    */
   RetryPolicy child_retry_policy_;
+
   /**
    * Logging retry policy for 'retry_policy' execution profile
    */
-  LoggingRetryPolicy logging_retry_policy_;
+  // We do not implement logging retry policy in cpp-rust-driver
+  // LoggingRetryPolicy logging_retry_policy_;
   /**
    * Flag to determine if base execution profiles should be built or not
    */
@@ -191,14 +197,15 @@ public:
     profiles_["dc_aware"] = ExecutionProfile::build()
                                 .with_load_balance_dc_aware("dc1", 1, false)
                                 .with_consistency(CASS_CONSISTENCY_LOCAL_ONE);
-    profiles_["blacklist_dc"] = ExecutionProfile::build()
-                                    .with_blacklist_dc_filtering("dc1")
-                                    .with_load_balance_dc_aware("dc1", 1, true)
-                                    .with_consistency(CASS_CONSISTENCY_LOCAL_ONE);
-    profiles_["whitelist_dc"] = ExecutionProfile::build()
-                                    .with_whitelist_dc_filtering("dc2")
-                                    .with_load_balance_dc_aware("dc1", 1, true)
-                                    .with_consistency(CASS_CONSISTENCY_LOCAL_ONE);
+    // Host filtering is not supported in cpp-rust-driver
+    // profiles_["blacklist_dc"] = ExecutionProfile::build()
+    //                                 .with_blacklist_dc_filtering("dc1")
+    //                                 .with_load_balance_dc_aware("dc1", 1, true)
+    //                                 .with_consistency(CASS_CONSISTENCY_LOCAL_ONE);
+    // profiles_["whitelist_dc"] = ExecutionProfile::build()
+    //                                 .with_whitelist_dc_filtering("dc2")
+    //                                 .with_load_balance_dc_aware("dc1", 1, true)
+    //                                 .with_consistency(CASS_CONSISTENCY_LOCAL_ONE);
 
     // Call the parent setup function
     skip_base_execution_profile_ = true;


### PR DESCRIPTION
The Rust driver has had recently added support for Execution Profiles. As that concept is present in the CPP driver, this PR implements the bridge between them (as there are, of course, some differences to be handled).
As a side effect, this PR raises the supported Rust driver version to a recent one, featuring a small UDT refactor, a major load balancing refactor and support for Serverless Cloud connections. 

This PR contains a considerable number of tests, including unit tests and integration tests (to which end proxy is used). The existing integration tests inherited from CPP driver are (for various reasons) not suitable for use in bindings (see listing below).

Existing integration tests:
- `ExecutionProfileTest.Integration_Cassandra_*`
  These tests assume that it is possible to set Consistency as SerialConsistency and vice versa on an execution profile and that such error will be reported only when querying with that profile. Our implementation reports error already on setting bad LegacyConsistency variant on a profile, so in order to run any of those tests, it is required to swap those consistencies (in the source code) not to throw exceptions while preparing for tests. 
  - `InvalidName` - valid, works (after the swap mentioned above).
  - `RequestTimeout` - fails due to `tokio` being unable to handle such small delays in sleeps.
  - `Consistency` and `SerialConsistency` - fails to the mentioned above different error semantics (expects error on query, not on exec profile definition).
  - `RoundRobin` - fails due to unimplemented `get_host_from_future()` (and we aren't able to implement it in Rust driver architecture).
  - `LatencyAwareRouting`, `RetryPolicy` - fail due to nonsupported logging (at least in my case, I was unable to turn on tracing and see any traces coming from the Rust driver).
  - `SpeculativeExecutionPolicy` - fails due to unimplemented `set_record_attempted_hosts()`.
  - `BlacklistFiltering`, `WhitelistFiltering` - nonsupported in Rust driver.
- `LatencyAwarePolicyTest.Integration_Cassandra_IsEnabled` - fails due to nonsupported logging.

Fixes: #38 

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.