### PR TITLE
Logging: set event subscriber globally for all threads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,10 @@ jobs:
 :*19.Integration_Cassandra_*\
 :ExecutionProfileTest.InvalidName"
       run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --scylla --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
+
+    - name: Upload test logs
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: test-logs-scylla
+        path: ./log/*

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -57,3 +57,10 @@ jobs:
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
 :ExecutionProfileTest.InvalidName"
         run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --version=3.0.9 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: test-logs-cassandra
+          path: ./log/*

--- a/README.md
+++ b/README.md
@@ -90,6 +90,31 @@ int main(int argc, char* argv[]) {
 }
 ```
 
+# Logging
+___
+
+The logging API and implementation are compatible with the C++ driver, for more details please refer to the [logging documentation](https://cpp-driver.docs.scylladb.com/master/topics/logging/index.html).
+As the `tracing` framework is used under the hood to instrument the collection of logs from the Rust driver and the Cpp-Rust wrapper,
+the logging level and callback are passed through a custom event subscriber which is globally set as default when `cass_log_set_level` is called.
+So, `cass_log_set_level` *must* be called only once as subsequent attempts trying to modify the globally set event subscriber will be ignored.
+Also, Rust programs using Cpp-Rust driver under the hood must avoid calling `tracing::subscriber::set_global_default` as this will cause conflicts.    
+
+##### Note: The logging configuration must be done before any other driver function is called, otherwise, the default logging callback will be used, and logs will appear on stderr.
+
+```c++
+void on_log(const CassLogMessage* message, void* data) {
+  /* Handle logging */
+}
+
+int main() {
+  void* log_data = NULL /* Custom log resource */;
+  cass_log_set_callback(on_log, log_data);
+  cass_log_set_level(CASS_LOG_INFO);
+
+  /* Create cluster and connect session */
+}
+```
+
 # Features
 ___
 

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -1,12 +1,10 @@
 #![allow(clippy::missing_safety_doc)]
 
-use crate::logging::set_tracing_subscriber_with_level;
 use crate::logging::stderr_log_callback;
 use crate::logging::Logger;
 use lazy_static::lazy_static;
 use std::sync::RwLock;
 use tokio::runtime::Runtime;
-use tracing::dispatcher::DefaultGuard;
 
 #[macro_use]
 mod binding;
@@ -42,9 +40,6 @@ lazy_static! {
         cb: Some(stderr_log_callback),
         data: std::ptr::null_mut(),
     });
-    pub static ref LOG: RwLock<Option<DefaultGuard>> = RwLock::new(Some(
-        set_tracing_subscriber_with_level(tracing::Level::WARN)
-    ));
 }
 
 // To send a Rust object to C:

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -6,7 +6,6 @@ use crate::cluster::build_session_builder;
 use crate::cluster::CassCluster;
 use crate::exec_profile::{CassExecProfile, ExecProfileName, PerStatementExecProfile};
 use crate::future::{CassFuture, CassFutureResult, CassResultValue};
-use crate::logging::init_logging;
 use crate::metadata::create_table_metadata;
 use crate::metadata::{CassKeyspaceMeta, CassMaterializedViewMeta, CassSchemaMeta};
 use crate::query_result::Value::{CollectionValue, RegularValue};
@@ -128,8 +127,6 @@ pub type CassSession = RwLock<Option<CassSessionInner>>;
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_new() -> *mut CassSession {
-    init_logging();
-
     let session = Arc::new(RwLock::new(None::<CassSessionInner>));
     Arc::into_raw(session) as *mut CassSession
 }


### PR DESCRIPTION
## Pre-review checklist

The previous attempt for adding logging support in the driver was to set a custom event subscriber with an option to replace it with a new subscriber if the logging configuration is changed during the program's runtime. The `tracing::subscriber::set_default` function was used to set a scoped subscriber and be able to drop it gracefully. However, the documentation of the function fails to mention that the default subscriber is set only for the current thread hence making it unsuitable for the needs of multi-threaded applications. So, as of now, the `tracing::subscriber::set_global_default` is the only reliable way to set a default subscriber available for all threads within an application. However, it can be set only once and cannot be gracefully dropped later, so multiple attempts to set a global default subscriber will fail.
This PR replaces `set_default` with `set_global_default`, which implies that `cass_log_set_level` must be called only once and later attempts to modify the logging configuration will be ignored. For informational purposes, a logging section is added to the README to explain the details of the implementation and usage. Additionally, the test logs from `build` and `cassandra` jobs will be uploaded as an artifact in order to help in some debugging processes in the future.

Fixes #110

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.