### PR TITLE
Set panic behaviour to abort instead of unwinding

### DIFF
--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -38,5 +38,9 @@ scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev
 name = "scylla_cpp_driver"
 crate-type = ["cdylib", "staticlib"]
 
+[profile.dev]
+panic = "abort"
+
 [profile.release]
 lto = true
+panic = "abort"


### PR DESCRIPTION
As bindings' code is called by C/C++ code, and unwinding into foreign code is UB in Rust, panic behaviour is set to abort. From now on, panicking is a perfectly valid way of handling critical errors.

Resolves: #117 

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~~