### PR TITLE
Latency awareness - support `scale` parameter

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +63,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bigdecimal"
@@ -330,6 +360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -437,9 +473,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -478,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.9.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74141c8af4bb8136dafb5705826bdd9dce823021db897c1129191804140ddf84"
+checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
 dependencies = [
  "twox-hash",
 ]
@@ -516,15 +552,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "mio"
-version = "0.8.4"
+name = "miniz_oxide"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -627,7 +671,16 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.7",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -640,6 +693,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.98",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -866,6 +940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,8 +991,8 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scylla"
-version = "0.8.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=1a913a19#1a913a191fef6ba1ad05d4f4260037609d6fc64e"
+version = "0.9.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=40aaee6#40aaee6ed8d5f644c9a1d781c4fc0d5c6b9ce3d1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -926,7 +1006,7 @@ dependencies = [
  "itertools",
  "lz4_flex",
  "num-bigint",
- "num_enum",
+ "num_enum 0.6.1",
  "openssl",
  "rand",
  "rand_pcg",
@@ -934,6 +1014,7 @@ dependencies = [
  "scylla-macros",
  "smallvec",
  "snap",
+ "socket2 0.5.3",
  "strum",
  "strum_macros",
  "thiserror",
@@ -970,8 +1051,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.0.6"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=1a913a19#1a913a191fef6ba1ad05d4f4260037609d6fc64e"
+version = "0.0.8"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=40aaee6#40aaee6ed8d5f644c9a1d781c4fc0d5c6b9ce3d1"
 dependencies = [
  "async-trait",
  "bigdecimal",
@@ -980,7 +1061,7 @@ dependencies = [
  "chrono",
  "lz4_flex",
  "num-bigint",
- "num_enum",
+ "num_enum 0.6.1",
  "scylla-macros",
  "snap",
  "thiserror",
@@ -991,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "0.2.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=1a913a19#1a913a191fef6ba1ad05d4f4260037609d6fc64e"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=40aaee6#40aaee6ed8d5f644c9a1d781c4fc0d5c6b9ce3d1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1000,8 +1081,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-proxy"
-version = "0.0.2"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=1a913a19#1a913a191fef6ba1ad05d4f4260037609d6fc64e"
+version = "0.0.3"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=40aaee6#40aaee6ed8d5f644c9a1d781c4fc0d5c6b9ce3d1"
 dependencies = [
  "bigdecimal",
  "byteorder",
@@ -1009,7 +1090,7 @@ dependencies = [
  "chrono",
  "futures",
  "num-bigint",
- "num_enum",
+ "num_enum 0.5.7",
  "rand",
  "scylla-cql",
  "thiserror",
@@ -1071,12 +1152,22 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1181,34 +1272,33 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.98",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -10,8 +10,8 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "1a913a19", features = ["ssl"]}
-tokio = { version = "1.1.0", features = ["full"] }
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "40aaee6", features = ["ssl"]}
+tokio = { version = "1.27.0", features = ["full"] }
 lazy_static = "1.4.0"
 uuid = "1.1.2"
 machine-uid = "0.2.0"
@@ -32,7 +32,7 @@ chrono = "0.4.20"
 assert_matches = "1.5.0"
 ntest = "0.9.0"
 rusty-fork = "0.3.0"
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "1a913a19"}
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "40aaee6"}
 
 [lib]
 name = "scylla_cpp_driver"

--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -65,7 +65,7 @@ impl From<&BadQuery> for CassError {
 impl From<&NewSessionError> for CassError {
     fn from(error: &NewSessionError) -> Self {
         match error {
-            NewSessionError::FailedToResolveAddress(_string) => {
+            NewSessionError::FailedToResolveAnyHostname(_hostnames) => {
                 CassError::CASS_ERROR_LIB_NO_HOSTS_AVAILABLE
             }
             NewSessionError::EmptyKnownNodesList => CassError::CASS_ERROR_LIB_NO_HOSTS_AVAILABLE,

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -1,8 +1,9 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::types::*;
-use scylla::batch::{BatchType, Consistency, SerialConsistency};
+use scylla::batch::BatchType;
 use scylla::frame::response::result::ColumnType;
+use scylla::frame::types::{Consistency, SerialConsistency};
 use scylla::transport::topology::{CollectionType, CqlType, NativeType, UserDefinedType};
 use std::collections::HashMap;
 use std::convert::TryFrom;

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -543,7 +543,7 @@ pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing(
 pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing_settings(
     cluster: *mut CassCluster,
     exclusion_threshold: cass_double_t,
-    _scale_ms: cass_uint64_t, // Currently ignored, TODO: add this parameter to Rust driver
+    scale_ms: cass_uint64_t,
     retry_period_ms: cass_uint64_t,
     update_rate_ms: cass_uint64_t,
     min_measured: cass_uint64_t,
@@ -551,6 +551,7 @@ pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing_settings(
     let cluster = ptr_to_ref_mut(cluster);
     cluster.load_balancing_config.latency_awareness_builder = LatencyAwarenessBuilder::new()
         .exclusion_threshold(exclusion_threshold)
+        .scale(Duration::from_millis(scale_ms))
         .retry_period(Duration::from_millis(retry_period_ms))
         .update_rate(Duration::from_millis(update_rate_ms))
         .minimum_measurements(min_measured as usize);

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -7,7 +7,6 @@ use crate::retry_policy::CassRetryPolicy;
 use crate::retry_policy::RetryPolicy::*;
 use crate::ssl::CassSsl;
 use crate::types::*;
-use core::time::Duration;
 use openssl::ssl::SslContextBuilder;
 use openssl_sys::SSL_CTX_up_ref;
 use scylla::execution_profile::ExecutionProfileBuilder;
@@ -23,6 +22,7 @@ use std::convert::TryInto;
 use std::future::Future;
 use std::os::raw::{c_char, c_int, c_uint};
 use std::sync::Arc;
+use std::time::Duration;
 
 include!(concat!(env!("OUT_DIR"), "/cppdriver_compression_types.rs"));
 

--- a/scylla-rust-wrapper/src/query_error.rs
+++ b/scylla-rust-wrapper/src/query_error.rs
@@ -1,8 +1,7 @@
 use crate::argconv::*;
 use crate::cass_error::*;
 use crate::types::*;
-use scylla::batch::SerialConsistency;
-use scylla::frame::types::LegacyConsistency;
+use scylla::frame::types::{LegacyConsistency, SerialConsistency};
 use scylla::statement::Consistency;
 use scylla::transport::errors::*;
 


### PR DESCRIPTION
As the `scale` parameter is now supported by the Rust driver, it is also supported in the bindings' code.
For this to be available, the Rust driver dependency is updated to the newest at the moment of opening this PR.


## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~~