### PR TITLE
Fix errors detected by a new toolchain

### DIFF
--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -36,6 +36,9 @@ pub unsafe fn ptr_to_cstr(ptr: *const c_char) -> Option<&'static str> {
 }
 
 pub unsafe fn ptr_to_cstr_n(ptr: *const c_char, size: size_t) -> Option<&'static str> {
+    if ptr.is_null() {
+        return None;
+    }
     std::str::from_utf8(std::slice::from_raw_parts(ptr as *const u8, size as usize)).ok()
 }
 

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -147,6 +147,9 @@ impl CassFuture {
     }
 }
 
+// Do not remove; this asserts that `CassFuture` implements Send + Sync,
+// which is required by the cpp-driver (saying that `CassFuture` is thread-safe).
+#[allow(unused)]
 trait CheckSendSync: Send + Sync {}
 impl CheckSendSync for CassFuture {}
 

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -179,7 +179,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_table_by_name_n(
     let table_meta = keyspace_meta.tables.get(table_name);
 
     match table_meta {
-        Some(meta) => Arc::as_ptr(meta) as *const CassTableMeta,
+        Some(meta) => Arc::as_ptr(meta),
         None => std::ptr::null(),
     }
 }

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -473,7 +473,7 @@ pub unsafe extern "C" fn cass_iterator_get_table_meta(
             .nth(iter_position);
 
         return match table_meta_entry_opt {
-            Some(table_meta_entry) => Arc::as_ptr(table_meta_entry.1) as *const CassTableMeta,
+            Some(table_meta_entry) => Arc::as_ptr(table_meta_entry.1),
             None => std::ptr::null(),
         };
     }
@@ -570,9 +570,7 @@ pub unsafe extern "C" fn cass_iterator_get_materialized_view_meta(
             let view_meta_entry_opt = keyspace_meta_iterator.value.views.iter().nth(iter_position);
 
             match view_meta_entry_opt {
-                Some(view_meta_entry) => {
-                    Arc::as_ptr(view_meta_entry.1) as *const CassMaterializedViewMeta
-                }
+                Some(view_meta_entry) => Arc::as_ptr(view_meta_entry.1),
                 None => std::ptr::null(),
             }
         }

--- a/scylla-rust-wrapper/src/ssl.rs
+++ b/scylla-rust-wrapper/src/ssl.rs
@@ -43,8 +43,15 @@ pub unsafe extern "C" fn cass_ssl_new_no_lib_init() -> *const CassSsl {
         trusted_store,
     };
 
-    Arc::into_raw(Arc::new(ssl)) as *const CassSsl
+    Arc::into_raw(Arc::new(ssl))
 }
+
+// This is required for the type system to impl Send + Sync for Arc<CassSsl>.
+// Otherwise, clippy complains about using Arc where Rc would do.
+// In our case, though, we need to use Arc because we potentially do share
+// the Arc between threads, so employing Rc here would lead to races.
+unsafe impl Send for CassSsl {}
+unsafe impl Sync for CassSsl {}
 
 impl Drop for CassSsl {
     fn drop(&mut self) {

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -222,7 +222,9 @@ pub unsafe extern "C" fn cass_statement_set_paging_state(
     let statement = ptr_to_ref_mut(statement);
     let result = ptr_to_ref(result);
 
-    statement.paging_state = result.metadata.paging_state.clone();
+    statement
+        .paging_state
+        .clone_from(&result.metadata.paging_state);
     CassError::CASS_OK
 }
 

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -41,7 +41,7 @@ impl CassUserType {
                 if !is_compatible_type(field_type, &value) {
                     return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
                 }
-                self.field_values[index] = value.clone();
+                self.field_values[index].clone_from(&value);
             }
         }
 


### PR DESCRIPTION
### The new toolchain running in the CI detected two problems:
1. `trait CheckSendSync` is unused - the warning is silenced now, because the trait exists to assert thread-safety of `CassFuture`.
2. `std::slice::from_raw_parts` was called with invalid pointer - this was because a null pointer was passed a C string in one of the tests; the correspoding argconv routine was changed to handle null pointers properly (by immediately returning `None`).

**Merging this quickly is needed for the CI to pass in other PRs.** 

Fixes: #123 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~~