### PR TITLE
CI: Fix error on apt-get install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
 
     - name: Setup environment
       run: |
+        sudo apt-get update
         sudo apt-get install libssl1.1 libuv1-dev libkrb5-dev libc6-dbg
         sudo snap install valgrind --classic
         pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Setup environment
         run: |
+          sudo apt-get update
           sudo apt-get install libssl1.1 libuv1-dev libkrb5-dev libc6-dbg
           sudo snap install valgrind --classic
           pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip


### PR DESCRIPTION
On Ubuntu, we need to run "apt-get update" prior to "apt-get install", otherwise it does not gurantee the package database is up to date. If we don't do that, "apt-get install" with outdated database may cause error something like:

Err:9 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/main amd64 libc6-dbg amd64 2.35-0ubuntu3.7
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/g/glibc/libc6-dbg_2.35-0ubuntu3.7_amd64.deb  404  Not Found [IP: 52.252.75.106 80] E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing? Fetched 504 kB in 0s (1279 kB/s)

To fix this, add "apt-get update" on the begging of "Setup environment".

Related #122