### PR TITLE
types: Implement API functions for `duration` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,13 +197,10 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
         </tr>
         <tr>
             <td>cass_user_type_set_custom[by_name]</td>
-            <td rowspan="3">Unimplemented because of the same reasons as binding for statements.<br> <b>Note</b>: The driver does not check whether the type of the value being set for a field of the UDT is compatible with the field's actual type.</td>
+            <td rowspan="2">Unimplemented because of the same reasons as binding for statements.<br> <b>Note</b>: The driver does not check whether the type of the value being set for a field of the UDT is compatible with the field's actual type.</td>
         </tr>
         <tr>
             <td>cass_user_type_set_decimal[by_name]</td>
-        </tr>
-        <tr>
-            <td>cass_user_type_set_duration[by_name]</td>
         </tr>
         <tr>
             <td colspan=2 align="center" style="font-weight:bold">Value</td>

--- a/README.md
+++ b/README.md
@@ -160,13 +160,10 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
         </tr>
         <tr>
             <td>cass_statement_bind_custom[by_name]</td>
-            <td rowspan="3">Binding is not implemented for custom types in the Rust driver. <br> Binding Decimal and Duration types requires encoding raw bytes into BigDecimal and CqlDuration types in the Rust driver. <br> <b>Note</b>: The driver does not validate the types of the values passed to queries.</td>
+            <td rowspan="2">Binding is not implemented for custom types in the Rust driver. <br> Binding Decimal type requires encoding raw bytes into BigDecimal type in the Rust driver. <br> <b>Note</b>: The driver does not validate the types of the values passed to queries.</td>
         </tr>
         <tr>
             <td>cass_statement_bind_decimal[by_name]</td>
-        </tr>
-        <tr>
-            <td>cass_statement_bind_duration[by_name]</td>
         </tr>
         <tr>
             <td colspan=2 align="center" style="font-weight:bold">Future</td>

--- a/README.md
+++ b/README.md
@@ -190,13 +190,10 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
         </tr>
         <tr>
             <td>cass_collection_append_custom[_n]</td>
-            <td rowspan="3">Unimplemented because of the same reasons as binding for statements.<br> <b>Note</b>: The driver does not check whether the type of the appended value is compatible with the type of the collection items.</td>
+            <td rowspan="2">Unimplemented because of the same reasons as binding for statements.<br> <b>Note</b>: The driver does not check whether the type of the appended value is compatible with the type of the collection items.</td>
         </tr>
         <tr>
             <td>cass_collection_append_decimal</td>
-        </tr>
-        <tr>
-            <td>cass_collection_append_duration</td>
         </tr>
         <tr>
             <td colspan=2 align="center" style="font-weight:bold">User Defined Type</td>

--- a/README.md
+++ b/README.md
@@ -215,15 +215,8 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
             <td colspan=2 align="center" style="font-weight:bold">Value</td>
         </tr>
         <tr>
-            <td>cass_value_is_duration</td>
-            <td>Unimplemented</td>
-        </tr>
-        <tr>
             <td>cass_value_get_decimal</td>
-            <td rowspan="2">Getting raw bytes of Decimal and Duration values requires lazy deserialization feature in the Rust driver.</td>
-        </tr>
-        <tr>
-            <td>cass_value_get_duration</td>
+            <td>Getting raw bytes of Decimal values requires lazy deserialization feature in the Rust driver.</td>
         </tr>
         <tr>
             <td>cass_value_get_bytes</td>

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -137,9 +137,8 @@ macro_rules! make_appender {
 }
 
 // TODO: Types for which binding is not implemented yet:
-// custom - Not implemented in Rust driver?
+// custom - Not implemented in Rust driver
 // decimal
-// duration - DURATION not implemented in Rust Driver
 
 macro_rules! invoke_binder_maker_macro_with_type {
     (null, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
@@ -275,6 +274,21 @@ macro_rules! invoke_binder_maker_macro_with_type {
                 }
             },
             [v @ crate::inet::CassInet]
+        );
+    };
+    (duration, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |m, d, n| {
+                Ok(Some(Duration(scylla::frame::value::CqlDuration {
+                    months: m,
+                    days: d,
+                    nanoseconds: n
+                })))
+            },
+            [m @ cass_int32_t, d @ cass_int32_t, n @ cass_int64_t]
         );
     };
     (collection, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -88,6 +88,7 @@ make_binders!(string_n, cass_collection_append_string_n);
 make_binders!(bytes, cass_collection_append_bytes);
 make_binders!(uuid, cass_collection_append_uuid);
 make_binders!(inet, cass_collection_append_inet);
+make_binders!(duration, cass_collection_append_duration);
 make_binders!(collection, cass_collection_append_collection);
 make_binders!(tuple, cass_collection_append_tuple);
 make_binders!(user_type, cass_collection_append_user_type);

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -1165,12 +1165,12 @@ pub unsafe extern "C" fn cass_value_is_null(value: *const CassValue) -> cass_boo
 pub unsafe extern "C" fn cass_value_is_collection(value: *const CassValue) -> cass_bool_t {
     let val = ptr_to_ref(value);
 
-    match val.value {
-        Some(Value::CollectionValue(Collection::List(_))) => true as cass_bool_t,
-        Some(Value::CollectionValue(Collection::Set(_))) => true as cass_bool_t,
-        Some(Value::CollectionValue(Collection::Map(_))) => true as cass_bool_t,
-        _ => false as cass_bool_t,
-    }
+    matches!(
+        val.value_type.get_value_type(),
+        CassValueType::CASS_VALUE_TYPE_LIST
+            | CassValueType::CASS_VALUE_TYPE_SET
+            | CassValueType::CASS_VALUE_TYPE_MAP
+    ) as cass_bool_t
 }
 
 #[no_mangle]
@@ -1544,9 +1544,6 @@ extern "C" {
 }
 extern "C" {
     pub fn cass_value_type(value: *const CassValue) -> CassValueType;
-}
-extern "C" {
-    pub fn cass_value_is_collection(value: *const CassValue) -> cass_bool_t;
 }
 extern "C" {
     pub fn cass_value_item_count(collection: *const CassValue) -> size_t;

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -915,12 +915,21 @@ pub unsafe extern "C" fn cass_value_data_type(value: *const CassValue) -> *const
     Arc::as_ptr(&value_from_raw.value_type)
 }
 
+macro_rules! val_ptr_to_ref_ensure_non_null {
+    ($ptr:ident) => {{
+        if $ptr.is_null() {
+            return CassError::CASS_ERROR_LIB_NULL_VALUE;
+        }
+        ptr_to_ref($ptr)
+    }};
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn cass_value_get_float(
     value: *const CassValue,
     output: *mut cass_float_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::Float(f))) => std::ptr::write(output, f),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -935,7 +944,7 @@ pub unsafe extern "C" fn cass_value_get_double(
     value: *const CassValue,
     output: *mut cass_double_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::Double(d))) => std::ptr::write(output, d),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -950,7 +959,7 @@ pub unsafe extern "C" fn cass_value_get_bool(
     value: *const CassValue,
     output: *mut cass_bool_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::Boolean(b))) => {
             std::ptr::write(output, b as cass_bool_t)
@@ -967,7 +976,7 @@ pub unsafe extern "C" fn cass_value_get_int8(
     value: *const CassValue,
     output: *mut cass_int8_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::TinyInt(i))) => std::ptr::write(output, i),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -982,7 +991,7 @@ pub unsafe extern "C" fn cass_value_get_int16(
     value: *const CassValue,
     output: *mut cass_int16_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::SmallInt(i))) => std::ptr::write(output, i),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -997,7 +1006,7 @@ pub unsafe extern "C" fn cass_value_get_uint32(
     value: *const CassValue,
     output: *mut cass_uint32_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::Date(u))) => std::ptr::write(output, u.0), // FIXME: hack
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -1012,7 +1021,7 @@ pub unsafe extern "C" fn cass_value_get_int32(
     value: *const CassValue,
     output: *mut cass_int32_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::Int(i))) => std::ptr::write(output, i),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -1027,7 +1036,7 @@ pub unsafe extern "C" fn cass_value_get_int64(
     value: *const CassValue,
     output: *mut cass_int64_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::BigInt(i))) => std::ptr::write(output, i),
         Some(Value::RegularValue(CqlValue::Counter(i))) => {
@@ -1049,7 +1058,7 @@ pub unsafe extern "C" fn cass_value_get_uuid(
     value: *const CassValue,
     output: *mut CassUuid,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::Uuid(uuid))) => std::ptr::write(output, uuid.into()),
         Some(Value::RegularValue(CqlValue::Timeuuid(uuid))) => {
@@ -1067,7 +1076,7 @@ pub unsafe extern "C" fn cass_value_get_inet(
     value: *const CassValue,
     output: *mut CassInet,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::Inet(inet))) => std::ptr::write(output, inet.into()),
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -1083,7 +1092,7 @@ pub unsafe extern "C" fn cass_value_get_string(
     output: *mut *const c_char,
     output_size: *mut size_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match &val.value {
         // It seems that cpp driver doesn't check the type - you can call _get_string
         // on any type and get internal represenation. I don't see how to do it easily in
@@ -1109,7 +1118,7 @@ pub unsafe extern "C" fn cass_value_get_duration(
     days: *mut cass_int32_t,
     nanos: *mut cass_int64_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
 
     match &val.value {
         Some(Value::RegularValue(CqlValue::Duration(duration))) => {
@@ -1130,11 +1139,7 @@ pub unsafe extern "C" fn cass_value_get_bytes(
     output: *mut *const cass_byte_t,
     output_size: *mut size_t,
 ) -> CassError {
-    if value.is_null() {
-        return CassError::CASS_ERROR_LIB_NULL_VALUE;
-    }
-
-    let value_from_raw: &CassValue = ptr_to_ref(value);
+    let value_from_raw: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
 
     // FIXME: This should be implemented for all CQL types
     // Note: currently rust driver does not allow to get raw bytes of the CQL value.

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -463,6 +463,12 @@ make_binders!(
     cass_statement_bind_inet_by_name_n
 );
 make_binders!(
+    duration,
+    cass_statement_bind_duration,
+    cass_statement_bind_duration_by_name,
+    cass_statement_bind_duration_by_name_n
+);
+make_binders!(
     collection,
     cass_statement_bind_collection,
     cass_statement_bind_collection_by_name,

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -105,6 +105,7 @@ make_binders!(string_n, cass_tuple_set_string_n);
 make_binders!(bytes, cass_tuple_set_bytes);
 make_binders!(uuid, cass_tuple_set_uuid);
 make_binders!(inet, cass_tuple_set_inet);
+make_binders!(duration, cass_tuple_set_duration);
 make_binders!(collection, cass_tuple_set_collection);
 make_binders!(tuple, cass_tuple_set_tuple);
 make_binders!(user_type, cass_tuple_set_user_type);

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -182,6 +182,12 @@ make_binders!(
     cass_user_type_set_inet_by_name_n
 );
 make_binders!(
+    duration,
+    cass_user_type_set_duration,
+    cass_user_type_set_duration_by_name,
+    cass_user_type_set_duration_by_name_n
+);
+make_binders!(
     collection,
     cass_user_type_set_collection,
     cass_user_type_set_collection_by_name,

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -1,7 +1,10 @@
 use std::{convert::TryInto, net::IpAddr};
 
 use scylla::{
-    frame::{response::result::ColumnType, value::CqlDate},
+    frame::{
+        response::result::ColumnType,
+        value::{CqlDate, CqlDuration},
+    },
     serialize::{
         value::{
             BuiltinSerializationErrorKind, MapSerializationErrorKind, SerializeCql,
@@ -40,6 +43,7 @@ pub enum CassCqlValue {
     Uuid(Uuid),
     Date(CqlDate),
     Inet(IpAddr),
+    Duration(CqlDuration),
     Tuple(Vec<Option<CassCqlValue>>),
     List(Vec<CassCqlValue>),
     Map(Vec<(CassCqlValue, CassCqlValue)>),
@@ -116,6 +120,9 @@ impl CassCqlValue {
             }
             CassCqlValue::Inet(v) => {
                 <IpAddr as SerializeCql>::serialize(v, &ColumnType::Inet, writer)
+            }
+            CassCqlValue::Duration(v) => {
+                <CqlDuration as SerializeCql>::serialize(v, &ColumnType::Duration, writer)
             }
             CassCqlValue::Tuple(fields) => serialize_tuple_like(fields.iter(), writer),
             CassCqlValue::List(l) => serialize_sequence(l.len(), l.iter(), writer),

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -456,14 +456,6 @@ cass_user_type_set_decimal_by_name(CassUserType* user_type,
 	throw std::runtime_error("UNIMPLEMENTED cass_user_type_set_decimal_by_name\n");
 }
 CASS_EXPORT CassError
-cass_user_type_set_duration_by_name(CassUserType* user_type,
-                                    const char* name,
-                                    cass_int32_t months,
-                                    cass_int32_t days,
-                                    cass_int64_t nanos){
-	throw std::runtime_error("UNIMPLEMENTED cass_user_type_set_duration_by_name\n");
-}
-CASS_EXPORT CassError
 cass_value_get_decimal(const CassValue* value,
                        const cass_byte_t** varint,
                        size_t* varint_size,

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -169,13 +169,6 @@ cass_collection_append_decimal(CassCollection* collection,
                                cass_int32_t scale){
 	throw std::runtime_error("UNIMPLEMENTED cass_collection_append_decimal\n");
 }
-CASS_EXPORT CassError
-cass_collection_append_duration(CassCollection* collection,
-                                cass_int32_t months,
-                                cass_int32_t days,
-                                cass_int64_t nanos){
-	throw std::runtime_error("UNIMPLEMENTED cass_collection_append_duration\n");
-}
 CASS_EXPORT const CassValue*
 cass_column_meta_field_by_name(const CassColumnMeta* column_meta,
                                const char* name){

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -501,10 +501,3 @@ cass_value_get_decimal(const CassValue* value,
                        cass_int32_t* scale){
 	throw std::runtime_error("UNIMPLEMENTED cass_value_get_decimal\n");
 }
-CASS_EXPORT CassError
-cass_value_get_duration(const CassValue* value,
-                        cass_int32_t* months,
-                        cass_int32_t* days,
-                        cass_int64_t* nanos){
-	throw std::runtime_error("UNIMPLEMENTED cass_value_get_duration\n");
-}

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -432,14 +432,6 @@ cass_tuple_set_decimal(CassTuple* tuple,
 	throw std::runtime_error("UNIMPLEMENTED cass_tuple_set_decimal\n");
 }
 CASS_EXPORT CassError
-cass_tuple_set_duration(CassTuple* tuple,
-                        size_t index,
-                        cass_int32_t months,
-                        cass_int32_t days,
-                        cass_int64_t nanos){
-	throw std::runtime_error("UNIMPLEMENTED cass_tuple_set_duration\n");
-}
-CASS_EXPORT CassError
 cass_user_type_set_custom(CassUserType* user_type,
                           size_t index,
                           const char* class_name,

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -366,22 +366,6 @@ cass_statement_bind_decimal_by_name(CassStatement* statement,
 	throw std::runtime_error("UNIMPLEMENTED cass_statement_bind_decimal_by_name\n");
 }
 CASS_EXPORT CassError
-cass_statement_bind_duration(CassStatement* statement,
-                             size_t index,
-                             cass_int32_t months,
-                             cass_int32_t days,
-                             cass_int64_t nanos){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_bind_duration\n");
-}
-CASS_EXPORT CassError
-cass_statement_bind_duration_by_name(CassStatement* statement,
-                                     const char* name,
-                                     cass_int32_t months,
-                                     cass_int32_t days,
-                                     cass_int64_t nanos){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_bind_duration_by_name\n");
-}
-CASS_EXPORT CassError
 cass_statement_set_custom_payload(CassStatement* statement,
                                   const CassCustomPayload* payload){
 	throw std::runtime_error("UNIMPLEMENTED cass_statement_set_custom_payload\n");


### PR DESCRIPTION
This PR implements following set of API functions related to `duration` type:
- cass_statement_bind_duration_*
- cass_user_type_set_duration_*
- cass_tuple_set_duration
- cass_value_get_duration
- cass_value_is_duration
- cass_collection_append_duration

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~