### PR TITLE
cargo: update rust driver's version to 0.13.1

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -18,6 +18,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,11 +105,13 @@ dependencies = [
 
 [[package]]
 name = "bigdecimal"
-version = "0.2.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e50562e37200edf7c6c43e54a08e64a5553bfb59d9c297d5572512aa517256"
+checksum = "51d712318a27c7150326677b321a5fa91b55f6d9034ffd67f20319e147d40cee"
 dependencies = [
- "num-bigint",
+ "autocfg",
+ "libm",
+ "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
 ]
@@ -109,7 +135,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.15",
+ "syn 2.0.61",
  "which",
 ]
 
@@ -160,17 +186,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
- "time",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -191,13 +216,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.61",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "parking_lot_core",
 ]
@@ -356,7 +416,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -378,12 +438,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashbrown"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "unicode-segmentation",
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -420,6 +481,12 @@ dependencies = [
  "wasm-bindgen",
  "winapi",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "instant"
@@ -473,9 +540,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libloading"
@@ -486,6 +553,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
@@ -562,12 +635,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -626,6 +699,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -666,48 +750,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
-dependencies = [
- "num_enum_derive 0.5.7",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-dependencies = [
- "num_enum_derive 0.6.1",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.98",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "object"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
@@ -792,9 +834,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -821,7 +863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
 dependencies = [
  "proc-macro2",
- "syn 2.0.15",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -836,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -851,9 +893,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -966,12 +1008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
-
-[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,22 +1027,22 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scylla"
-version = "0.9.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=40aaee6#40aaee6ed8d5f644c9a1d781c4fc0d5c6b9ce3d1"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b20b46cf4ea921ba41121ba9ddf933185cd830cbe2c4fa6272a6e274a6b7368d"
 dependencies = [
  "arc-swap",
  "async-trait",
- "bigdecimal",
  "byteorder",
  "bytes",
  "chrono",
  "dashmap",
  "futures",
+ "hashbrown 0.14.5",
  "histogram",
  "itertools",
+ "lazy_static",
  "lz4_flex",
- "num-bigint",
- "num_enum 0.6.1",
  "openssl",
  "rand",
  "rand_pcg",
@@ -1014,9 +1050,7 @@ dependencies = [
  "scylla-macros",
  "smallvec",
  "snap",
- "socket2 0.5.3",
- "strum",
- "strum_macros",
+ "socket2",
  "thiserror",
  "tokio",
  "tokio-openssl",
@@ -1051,17 +1085,14 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.0.8"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=40aaee6#40aaee6ed8d5f644c9a1d781c4fc0d5c6b9ce3d1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ea3cd3ff5bf9d7db7a6d65c54cecf52f7c40b8e3e32c8c2d6da84d23776ea4"
 dependencies = [
  "async-trait",
- "bigdecimal",
  "byteorder",
  "bytes",
- "chrono",
  "lz4_flex",
- "num-bigint",
- "num_enum 0.6.1",
  "scylla-macros",
  "snap",
  "thiserror",
@@ -1071,26 +1102,28 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.2.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=40aaee6#40aaee6ed8d5f644c9a1d781c4fc0d5c6b9ce3d1"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50f3e2aec7ea9f495e029fb783eb34c64d26a8f2055e1d6b43d00e04d2fbda6"
 dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.98",
+ "syn 2.0.61",
 ]
 
 [[package]]
 name = "scylla-proxy"
-version = "0.0.3"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=40aaee6#40aaee6ed8d5f644c9a1d781c4fc0d5c6b9ce3d1"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c5b3907e01611b2c514fc7a5563be863814ed9f0034e7080a86515232c20433"
 dependencies = [
  "bigdecimal",
  "byteorder",
  "bytes",
  "chrono",
  "futures",
- "num-bigint",
- "num_enum 0.5.7",
+ "num-bigint 0.3.3",
  "rand",
  "scylla-cql",
  "thiserror",
@@ -1152,22 +1185,12 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1177,23 +1200,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strum"
-version = "0.23.0"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
-
-[[package]]
-name = "strum_macros"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.98",
-]
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1208,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1247,7 +1257,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1260,23 +1270,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
@@ -1285,20 +1283,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1401,12 +1399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
 name = "uuid"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,12 +1433,6 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1567,6 +1559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1598,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1624,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1627,6 +1650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1672,18 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1663,6 +1704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +1728,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +1744,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1711,10 +1770,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
 name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
 ]

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -10,9 +10,7 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "40aaee6", features = [
-    "ssl",
-] }
+scylla = { version = "0.13.1", features = ["ssl"] }
 tokio = { version = "1.27.0", features = ["full"] }
 lazy_static = "1.4.0"
 uuid = "1.1.2"
@@ -34,7 +32,7 @@ chrono = "0.4.20"
 assert_matches = "1.5.0"
 ntest = "0.9.3"
 rusty-fork = "0.3.0"
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "40aaee6" }
+scylla-proxy = { version = "0.0.4" }
 
 [lib]
 name = "scylla_cpp_driver"

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -6,8 +6,8 @@ use crate::exec_profile::PerStatementExecProfile;
 use crate::retry_policy::CassRetryPolicy;
 use crate::statement::{CassStatement, Statement};
 use crate::types::*;
+use crate::value::CassCqlValue;
 use scylla::batch::Batch;
-use scylla::frame::response::result::CqlValue;
 use scylla::frame::value::MaybeUnset;
 use std::convert::TryInto;
 use std::sync::Arc;
@@ -22,7 +22,7 @@ pub struct CassBatch {
 #[derive(Clone)]
 pub struct CassBatchState {
     pub batch: Batch,
-    pub bound_values: Vec<Vec<MaybeUnset<Option<CqlValue>>>>,
+    pub bound_values: Vec<Vec<MaybeUnset<Option<CassCqlValue>>>>,
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -47,10 +47,9 @@
 //!     It can be used for binding named parameter in CassStatement or field by name in CassUserType.
 //!  * Functions from make_appender don't take any extra argument, as they are for use by CassCollection
 //!     functions - values are appended to collection.
-use crate::cass_types::CassDataType;
-use scylla::frame::response::result::CqlValue;
+use crate::{cass_types::CassDataType, value::CassCqlValue};
 
-pub fn is_compatible_type(_data_type: &CassDataType, _value: &Option<CqlValue>) -> bool {
+pub fn is_compatible_type(_data_type: &CassDataType, _value: &Option<CassCqlValue>) -> bool {
     // TODO: cppdriver actually checks types.
     true
 }
@@ -66,7 +65,7 @@ macro_rules! make_index_binder {
         ) -> CassError {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
-            use scylla::frame::response::result::CqlValue::*;
+            use crate::value::CassCqlValue::*;
             match ($e)($($arg), *) {
                 Ok(v) => $consume_v(ptr_to_ref_mut(this), index as usize, v),
                 Err(e) => e,
@@ -86,7 +85,7 @@ macro_rules! make_name_binder {
         ) -> CassError {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
-            use scylla::frame::response::result::CqlValue::*;
+            use crate::value::CassCqlValue::*;
             let name = ptr_to_cstr(name).unwrap();
             match ($e)($($arg), *) {
                 Ok(v) => $consume_v(ptr_to_ref_mut(this), name, v),
@@ -108,7 +107,7 @@ macro_rules! make_name_n_binder {
         ) -> CassError {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
-            use scylla::frame::response::result::CqlValue::*;
+            use crate::value::CassCqlValue::*;
             let name = ptr_to_cstr_n(name, name_length).unwrap();
             match ($e)($($arg), *) {
                 Ok(v) => $consume_v(ptr_to_ref_mut(this), name, v),
@@ -128,7 +127,7 @@ macro_rules! make_appender {
         ) -> CassError {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
-            use scylla::frame::response::result::CqlValue::*;
+            use crate::value::CassCqlValue::*;
             match ($e)($($arg), *) {
                 Ok(v) => $consume_v(ptr_to_ref_mut(this), v),
                 Err(e) => e,
@@ -298,7 +297,7 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $consume_v,
             $fn,
             |p: *const crate::tuple::CassTuple| {
-                std::convert::TryInto::try_into(ptr_to_ref(p)).map(Some)
+                Ok(Some(ptr_to_ref(p).into()))
             },
             [p @ *const crate::tuple::CassTuple]
         );

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -178,7 +178,10 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |v| Ok(Some(Date(v))),
+            |v| {
+                use scylla::frame::value::CqlDate;
+                Ok(Some(Date(CqlDate(v))))
+            },
             [v @ cass_uint32_t]
         );
     };

--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -58,6 +58,8 @@ impl From<&BadQuery> for CassError {
             BadQuery::ValuesTooLongForKey(_usize, _usize2) => CassError::CASS_ERROR_LAST_ENTRY,
             BadQuery::BadKeyspaceName(_bad_keyspace_name) => CassError::CASS_ERROR_LAST_ENTRY,
             BadQuery::Other(_other_query) => CassError::CASS_ERROR_LAST_ENTRY,
+            BadQuery::SerializationError(_) => CassError::CASS_ERROR_LAST_ENTRY,
+            BadQuery::TooManyQueriesInBatchStatement(_) => CassError::CASS_ERROR_LAST_ENTRY,
         }
     }
 }

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -33,6 +33,7 @@ pub mod tuple;
 pub mod types;
 pub mod user_type;
 pub mod uuid;
+pub mod value;
 
 lazy_static! {
     pub static ref RUNTIME: Runtime = Runtime::new().unwrap();

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn cass_prepared_bind(
     prepared_raw: *const CassPrepared,
 ) -> *mut CassStatement {
     let prepared: Arc<_> = clone_arced(prepared_raw);
-    let bound_values_size = prepared.get_prepared_metadata().col_count;
+    let bound_values_size = prepared.get_variable_col_specs().len();
 
     // cloning prepared statement's arc, because creating CassStatement should not invalidate
     // the CassPrepared argument

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -999,7 +999,7 @@ pub unsafe extern "C" fn cass_value_get_uint32(
 ) -> CassError {
     let val: &CassValue = ptr_to_ref(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Date(u))) => std::ptr::write(output, u), // FIXME: hack
+        Some(Value::RegularValue(CqlValue::Date(u))) => std::ptr::write(output, u.0), // FIXME: hack
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -1033,12 +1033,9 @@ pub unsafe extern "C" fn cass_value_get_int64(
         Some(Value::RegularValue(CqlValue::Counter(i))) => {
             std::ptr::write(output, i.0 as cass_int64_t)
         }
-        Some(Value::RegularValue(CqlValue::Time(d))) => match d.num_nanoseconds() {
-            Some(nanos) => std::ptr::write(output, nanos as cass_int64_t),
-            None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
-        },
+        Some(Value::RegularValue(CqlValue::Time(d))) => std::ptr::write(output, d.0),
         Some(Value::RegularValue(CqlValue::Timestamp(d))) => {
-            std::ptr::write(output, d.num_milliseconds() as cass_int64_t)
+            std::ptr::write(output, d.0 as cass_int64_t)
         }
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
@@ -1055,7 +1052,9 @@ pub unsafe extern "C" fn cass_value_get_uuid(
     let val: &CassValue = ptr_to_ref(value);
     match val.value {
         Some(Value::RegularValue(CqlValue::Uuid(uuid))) => std::ptr::write(output, uuid.into()),
-        Some(Value::RegularValue(CqlValue::Timeuuid(uuid))) => std::ptr::write(output, uuid.into()),
+        Some(Value::RegularValue(CqlValue::Timeuuid(uuid))) => {
+            std::ptr::write(output, Into::<Uuid>::into(uuid).into())
+        }
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -617,7 +617,7 @@ pub unsafe extern "C" fn cass_session_get_schema_meta(
 #[cfg(test)]
 mod tests {
     use rusty_fork::rusty_fork_test;
-    use scylla::{frame::types::LegacyConsistency, transport::errors::DbError};
+    use scylla::transport::errors::DbError;
     use scylla_proxy::{
         Condition, Node, Proxy, Reaction, RequestFrame, RequestOpcode, RequestReaction,
         RequestRule, ResponseFrame, RunningProxy,
@@ -1070,7 +1070,7 @@ mod tests {
                 // We don't use the example ReadTimeout error that is included in proxy,
                 // because in order to trigger a retry we need data_present=false.
                 RequestReaction::forge_with_error(DbError::ReadTimeout {
-                    consistency: LegacyConsistency::Regular(Consistency::All),
+                    consistency: Consistency::All,
                     received: 1,
                     required: 1,
                     data_present: false,

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -703,7 +703,7 @@ mod tests {
             Condition::RequestOpcode(RequestOpcode::Query),
             // We won't respond to any queries (including metadata fetch),
             // but the driver will manage to continue with dummy metadata.
-            RequestReaction::drop_connection(),
+            RequestReaction::forge().server_error(),
         )]
     }
 

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -4,7 +4,7 @@ use crate::exec_profile::PerStatementExecProfile;
 use crate::query_result::CassResult;
 use crate::retry_policy::CassRetryPolicy;
 use crate::types::*;
-use scylla::frame::response::result::CqlValue;
+use crate::value::CassCqlValue;
 use scylla::frame::types::Consistency;
 use scylla::frame::value::MaybeUnset;
 use scylla::frame::value::MaybeUnset::{Set, Unset};
@@ -35,7 +35,7 @@ pub struct SimpleQuery {
 
 pub struct CassStatement {
     pub statement: Statement,
-    pub bound_values: Vec<MaybeUnset<Option<CqlValue>>>,
+    pub bound_values: Vec<MaybeUnset<Option<CassCqlValue>>>,
     pub paging_state: Option<Bytes>,
     pub request_timeout_ms: Option<cass_uint64_t>,
 
@@ -43,7 +43,7 @@ pub struct CassStatement {
 }
 
 impl CassStatement {
-    fn bind_cql_value(&mut self, index: usize, value: Option<CqlValue>) -> CassError {
+    fn bind_cql_value(&mut self, index: usize, value: Option<CassCqlValue>) -> CassError {
         if index >= self.bound_values.len() {
             CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS
         } else {
@@ -55,7 +55,7 @@ impl CassStatement {
     fn bind_multiple_values_by_name(
         &mut self,
         indices: &[usize],
-        value: Option<CqlValue>,
+        value: Option<CassCqlValue>,
     ) -> CassError {
         for i in indices {
             let bind_status = self.bind_cql_value(*i, value.clone());
@@ -68,7 +68,7 @@ impl CassStatement {
         CassError::CASS_OK
     }
 
-    fn bind_cql_value_by_name(&mut self, name: &str, value: Option<CqlValue>) -> CassError {
+    fn bind_cql_value_by_name(&mut self, name: &str, value: Option<CassCqlValue>) -> CassError {
         let mut set_bound_val_index: Option<usize> = None;
         let mut name_str = name;
         let mut is_case_sensitive = false;

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -3,8 +3,7 @@ use crate::binding;
 use crate::cass_error::CassError;
 use crate::cass_types::CassDataType;
 use crate::types::*;
-use scylla::frame::response::result::CqlValue;
-use std::convert::TryFrom;
+use crate::value::CassCqlValue;
 use std::sync::Arc;
 
 static EMPTY_TUPLE_TYPE: CassDataType = CassDataType::Tuple(Vec::new());
@@ -12,7 +11,7 @@ static EMPTY_TUPLE_TYPE: CassDataType = CassDataType::Tuple(Vec::new());
 #[derive(Clone)]
 pub struct CassTuple {
     pub data_type: Option<Arc<CassDataType>>,
-    pub items: Vec<Option<CqlValue>>,
+    pub items: Vec<Option<CassCqlValue>>,
 }
 
 impl CassTuple {
@@ -32,7 +31,7 @@ impl CassTuple {
     // not bind items with too high index.
     // If it was created using `cass_tuple_new_from_data_type` we additionally check if
     // value has correct type.
-    fn bind_value(&mut self, index: usize, v: Option<CqlValue>) -> CassError {
+    fn bind_value(&mut self, index: usize, v: Option<CassCqlValue>) -> CassError {
         if index >= self.items.len() {
             return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
         }
@@ -49,10 +48,9 @@ impl CassTuple {
     }
 }
 
-impl TryFrom<&CassTuple> for CqlValue {
-    type Error = CassError;
-    fn try_from(tuple: &CassTuple) -> Result<Self, Self::Error> {
-        Ok(CqlValue::Tuple(tuple.items.clone()))
+impl From<&CassTuple> for CassCqlValue {
+    fn from(tuple: &CassTuple) -> Self {
+        CassCqlValue::Tuple(tuple.items.clone())
     }
 }
 

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -16,7 +16,7 @@ pub struct CassUserType {
 }
 
 impl CassUserType {
-    fn set_option_by_index(&mut self, index: usize, value: Option<CassCqlValue>) -> CassError {
+    fn set_field_by_index(&mut self, index: usize, value: Option<CassCqlValue>) -> CassError {
         if index >= self.field_values.len() {
             return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
         }
@@ -27,7 +27,7 @@ impl CassUserType {
         CassError::CASS_OK
     }
 
-    fn set_option_by_name(&mut self, name: &str, value: Option<CassCqlValue>) -> CassError {
+    fn set_field_by_name(&mut self, name: &str, value: Option<CassCqlValue>) -> CassError {
         let mut found_field: bool = false;
         for (index, (field_name, field_type)) in
             self.data_type.get_udt_type().field_types.iter().enumerate()
@@ -97,8 +97,8 @@ pub unsafe extern "C" fn cass_user_type_data_type(
 }
 
 prepare_binders_macro!(@index_and_name CassUserType,
-    |udt: &mut CassUserType, index, v| udt.set_option_by_index(index, v),
-    |udt: &mut CassUserType, name, v| udt.set_option_by_name(name, v));
+    |udt: &mut CassUserType, index, v| udt.set_field_by_index(index, v),
+    |udt: &mut CassUserType, name, v| udt.set_field_by_name(name, v));
 
 make_binders!(
     null,

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -3,7 +3,7 @@ use crate::binding::is_compatible_type;
 use crate::cass_error::CassError;
 use crate::cass_types::CassDataType;
 use crate::types::*;
-use scylla::frame::response::result::CqlValue;
+use crate::value::CassCqlValue;
 use std::os::raw::c_char;
 use std::sync::Arc;
 
@@ -12,11 +12,11 @@ pub struct CassUserType {
     pub data_type: Arc<CassDataType>,
 
     // Vec to preserve the order of fields
-    pub field_values: Vec<Option<CqlValue>>,
+    pub field_values: Vec<Option<CassCqlValue>>,
 }
 
 impl CassUserType {
-    fn set_option_by_index(&mut self, index: usize, value: Option<CqlValue>) -> CassError {
+    fn set_option_by_index(&mut self, index: usize, value: Option<CassCqlValue>) -> CassError {
         if index >= self.field_values.len() {
             return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
         }
@@ -27,8 +27,7 @@ impl CassUserType {
         CassError::CASS_OK
     }
 
-    //TODO: some hashtable for name lookup?
-    fn set_option_by_name(&mut self, name: &str, value: Option<CqlValue>) -> CassError {
+    fn set_option_by_name(&mut self, name: &str, value: Option<CassCqlValue>) -> CassError {
         let mut found_field: bool = false;
         for (index, (field_name, field_type)) in
             self.data_type.get_udt_type().field_types.iter().enumerate()
@@ -53,9 +52,9 @@ impl CassUserType {
     }
 }
 
-impl From<&CassUserType> for CqlValue {
+impl From<&CassUserType> for CassCqlValue {
     fn from(user_type: &CassUserType) -> Self {
-        CqlValue::UserDefinedType {
+        CassCqlValue::UserDefinedType {
             keyspace: user_type.data_type.get_udt_type().keyspace.clone(),
             type_name: user_type.data_type.get_udt_type().name.clone(),
             fields: user_type

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -1,0 +1,57 @@
+use std::net::IpAddr;
+
+use scylla::{
+    frame::{response::result::ColumnType, value::CqlDate},
+    serialize::{value::SerializeCql, writers::WrittenCellProof, CellWriter, SerializationError},
+};
+use uuid::Uuid;
+
+/// A narrower version of rust driver's CqlValue.
+///
+/// cpp-driver's API allows to map single rust type to
+/// multiple CQL types. For example `cass_statement_bind_int64`
+/// can be used to bind a value to the column of following CQL types:
+/// - bigint
+/// - time
+/// - counter
+/// - timestamp
+/// There is no such method as `cass_statement_bind_counter`, and so
+/// we need to serialize the counter value using `CassCqlValue::BigInt`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CassCqlValue {
+    TinyInt(i8),
+    SmallInt(i16),
+    Int(i32),
+    BigInt(i64),
+    Float(f32),
+    Double(f64),
+    Boolean(bool),
+    Text(String),
+    Blob(Vec<u8>),
+    Uuid(Uuid),
+    Date(CqlDate),
+    Inet(IpAddr),
+    Tuple(Vec<Option<CassCqlValue>>),
+    List(Vec<CassCqlValue>),
+    Map(Vec<(CassCqlValue, CassCqlValue)>),
+    Set(Vec<CassCqlValue>),
+    UserDefinedType {
+        keyspace: String,
+        type_name: String,
+        /// Order of `fields` vector must match the order of fields as defined in the UDT. The
+        /// driver does not check it by itself, so incorrect data will be written if the order is
+        /// wrong.
+        fields: Vec<(String, Option<CassCqlValue>)>,
+    },
+    // TODO: custom (?), duration and decimal
+}
+
+impl SerializeCql for CassCqlValue {
+    fn serialize<'b>(
+        &self,
+        _typ: &ColumnType,
+        _writer: CellWriter<'b>,
+    ) -> Result<WrittenCellProof<'b>, SerializationError> {
+        todo!()
+    }
+}


### PR DESCRIPTION
Fix: https://github.com/scylladb/cpp-rust-driver/issues/126

This PR updates the rust driver's version to 0.13.1

## API breaking changes
First commit fixes some minor issues caused by API breaking changes in rust driver.

## Serialization
Following commits focus on serialization. This version of rust driver already uses a new serialization framework which validates the types. In result, some integration tests are failing, since cpp-driver uses a bit different rust-to-CQL type mapping. A simple example is a `i64` value which can be mapped to 4 CQL types: `bigint/counter/time/timestamp`.

In this PR we address and fix this issue. We introduce a `CassCqlValue` enum which is a narrower version of rust driver's `CqlValue` with a custom `SerializeValue` (still called `SerializeCql` in 0.13) implementation. The serialization DOES NOT contain any typechecks. The typechecks will be introduced in a follow-up PR. We want to follow the same approach as cpp-driver, and do the typechecks during bindings (i.e. binding value to collection, tuple, UDT or statement).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~