### PR TITLE
cass_data_type: frozen support

### DIFF
--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -22,6 +22,7 @@ pub struct UDTDataType {
 
     pub keyspace: String,
     pub name: String,
+    pub frozen: bool,
 }
 
 impl UDTDataType {
@@ -30,6 +31,7 @@ impl UDTDataType {
             field_types: Vec::new(),
             keyspace: "".to_string(),
             name: "".to_string(),
+            frozen: false,
         }
     }
 
@@ -37,6 +39,7 @@ impl UDTDataType {
         user_defined_types: &HashMap<String, Arc<UserDefinedType>>,
         keyspace_name: &str,
         name: &str,
+        frozen: bool,
     ) -> UDTDataType {
         UDTDataType {
             field_types: user_defined_types
@@ -57,6 +60,7 @@ impl UDTDataType {
                 .collect(),
             keyspace: keyspace_name.to_string(),
             name: name.to_owned(),
+            frozen,
         }
     }
 
@@ -65,6 +69,7 @@ impl UDTDataType {
             field_types: Vec::with_capacity(capacity),
             keyspace: "".to_string(),
             name: "".to_string(),
+            frozen: false,
         }
     }
 
@@ -188,7 +193,7 @@ pub fn get_column_type_from_cql_type(
                 })
                 .collect(),
         ),
-        CqlType::UserDefinedType { definition, .. } => {
+        CqlType::UserDefinedType { definition, frozen } => {
             let name = match definition {
                 Ok(resolved) => &resolved.name,
                 Err(not_resolved) => &not_resolved.name,
@@ -197,6 +202,7 @@ pub fn get_column_type_from_cql_type(
                 user_defined_types,
                 keyspace_name,
                 name,
+                *frozen,
             ))
         }
     }
@@ -317,6 +323,7 @@ pub fn get_column_type(column_type: &ColumnType) -> CassDataType {
                 .collect(),
             keyspace: (*keyspace).clone(),
             name: (*type_name).clone(),
+            frozen: false,
         }),
         ColumnType::SmallInt => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_SMALL_INT),
         ColumnType::TinyInt => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_TINY_INT),

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -403,8 +403,19 @@ pub unsafe extern "C" fn cass_data_type_type(data_type: *const CassDataType) -> 
     data_type.get_value_type()
 }
 
-// #[no_mangle]
-// pub unsafe extern "C" fn cass_data_type_is_frozen(data_type: *const CassDataType) -> cass_bool_t {}
+#[no_mangle]
+pub unsafe extern "C" fn cass_data_type_is_frozen(data_type: *const CassDataType) -> cass_bool_t {
+    let data_type = ptr_to_ref(data_type);
+    let is_frozen = match data_type {
+        CassDataType::UDT(udt) => udt.frozen,
+        CassDataType::List { frozen, .. } => *frozen,
+        CassDataType::Set { frozen, .. } => *frozen,
+        CassDataType::Map { frozen, .. } => *frozen,
+        _ => false,
+    };
+
+    is_frozen as cass_bool_t
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_type_name(

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -1170,9 +1170,14 @@ pub unsafe extern "C" fn cass_value_primary_sub_type(
     let val = ptr_to_ref(collection);
 
     match val.value_type.as_ref() {
-        CassDataType::List(Some(list)) => list.get_value_type(),
-        CassDataType::Set(Some(set)) => set.get_value_type(),
-        CassDataType::Map(Some(key), _) => key.get_value_type(),
+        CassDataType::List {
+            typ: Some(list), ..
+        } => list.get_value_type(),
+        CassDataType::Set { typ: Some(set), .. } => set.get_value_type(),
+        CassDataType::Map {
+            key_type: Some(key),
+            ..
+        } => key.get_value_type(),
         _ => CassValueType::CASS_VALUE_TYPE_UNKNOWN,
     }
 }
@@ -1184,7 +1189,10 @@ pub unsafe extern "C" fn cass_value_secondary_sub_type(
     let val = ptr_to_ref(collection);
 
     match val.value_type.as_ref() {
-        CassDataType::Map(_, Some(value)) => value.get_value_type(),
+        CassDataType::Map {
+            val_type: Some(value),
+            ..
+        } => value.get_value_type(),
         _ => CassValueType::CASS_VALUE_TYPE_UNKNOWN,
     }
 }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -573,6 +573,7 @@ pub unsafe extern "C" fn cass_session_get_schema_meta(
                     &keyspace.user_defined_types,
                     keyspace_name,
                     udt_name,
+                    false,
                 ))),
             );
         }


### PR DESCRIPTION
Fix: https://github.com/scylladb/cpp-rust-driver/issues/49

This PR adds information about whether the type is frozen (applicable for collections and UDTs only).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~