### PR TITLE
binding: typechecks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,6 @@
 - [ ] I have split my patch into logically separate commits.
 - [ ] All commit messages clearly explain what they change and why.
 - [ ] PR description sums up the changes and reasons why they should be introduced.
+- [ ] I have implemented Rust unit tests for the features/changes introduced.
 - [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
 - [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.

--- a/README.md
+++ b/README.md
@@ -173,13 +173,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
             <td colspan=2 align="center" style="font-weight:bold">Collection</td>
         </tr>
         <tr>
-            <td>cass_collection_new_from_data_type</td>
-            <td rowspan="2">Unimplemented</td>
-        </tr>
-        <tr>
-            <td>cass_collection_data_type</td>
-        </tr>
-        <tr>
             <td>cass_collection_append_custom[_n]</td>
             <td>Unimplemented because of the same reasons as binding for statements.<br> <b>Note</b>: The driver does not check whether the type of the appended value is compatible with the type of the collection items.</td>
         </tr>

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -165,7 +165,7 @@ pub unsafe extern "C" fn cass_batch_add_statement(
 
     match &statement.statement {
         Statement::Simple(q) => state.batch.append_statement(q.query.clone()),
-        Statement::Prepared(p) => state.batch.append_statement((**p).clone()),
+        Statement::Prepared(p) => state.batch.append_statement(p.statement.clone()),
     };
 
     state.bound_values.push(statement.bound_values.clone());

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -47,12 +47,6 @@
 //!     It can be used for binding named parameter in CassStatement or field by name in CassUserType.
 //!  * Functions from make_appender don't take any extra argument, as they are for use by CassCollection
 //!     functions - values are appended to collection.
-use crate::{cass_types::CassDataType, value::CassCqlValue};
-
-pub fn is_compatible_type(_data_type: &CassDataType, _value: &Option<CassCqlValue>) -> bool {
-    // TODO: cppdriver actually checks types.
-    true
-}
 
 macro_rules! make_index_binder {
     ($this:ty, $consume_v:expr, $fn_by_idx:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -116,6 +116,25 @@ pub enum CassDataType {
     Custom(String),
 }
 
+impl CassDataType {
+    /// Checks for equality during typechecks.
+    ///
+    /// This takes into account the fact that tuples/collections may be untyped.
+    pub fn typecheck_equals(&self, other: &CassDataType) -> bool {
+        match self {
+            CassDataType::Value(t) => *t == other.get_value_type(),
+            CassDataType::UDT(_) => todo!(),
+            CassDataType::List { .. } => todo!(),
+            CassDataType::Set { .. } => todo!(),
+            CassDataType::Map { .. } => todo!(),
+            CassDataType::Tuple(_) => todo!(),
+            CassDataType::Custom(_) => {
+                unimplemented!("Cpp-rust-driver does not support custom types!")
+            }
+        }
+    }
+}
+
 impl From<NativeType> for CassValueType {
     fn from(native_type: NativeType) -> CassValueType {
         match native_type {

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -15,7 +15,7 @@ include!(concat!(env!("OUT_DIR"), "/cppdriver_data_types.rs"));
 include!(concat!(env!("OUT_DIR"), "/cppdriver_data_query_error.rs"));
 include!(concat!(env!("OUT_DIR"), "/cppdriver_batch_types.rs"));
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct UDTDataType {
     // Vec to preserve the order of types
     pub field_types: Vec<(String, Arc<CassDataType>)>,
@@ -95,7 +95,7 @@ impl Default for UDTDataType {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum CassDataType {
     Value(CassValueType),
     UDT(UDTDataType),

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -44,10 +44,12 @@ impl TryFrom<&CassCollection> for CassCqlValue {
     type Error = ();
     fn try_from(collection: &CassCollection) -> Result<Self, Self::Error> {
         // FIXME: validate that collection items are correct
+        let data_type = collection.data_type.clone();
         match collection.collection_type {
-            CassCollectionType::CASS_COLLECTION_TYPE_LIST => {
-                Ok(CassCqlValue::List(collection.items.clone()))
-            }
+            CassCollectionType::CASS_COLLECTION_TYPE_LIST => Ok(CassCqlValue::List {
+                data_type,
+                values: collection.items.clone(),
+            }),
             CassCollectionType::CASS_COLLECTION_TYPE_MAP => {
                 let mut grouped_items = Vec::new();
                 // FIXME: validate even number of items
@@ -58,11 +60,15 @@ impl TryFrom<&CassCollection> for CassCqlValue {
                     grouped_items.push((key, value));
                 }
 
-                Ok(CassCqlValue::Map(grouped_items))
+                Ok(CassCqlValue::Map {
+                    data_type,
+                    values: grouped_items,
+                })
             }
-            CassCollectionType::CASS_COLLECTION_TYPE_SET => {
-                Ok(CassCqlValue::Set(collection.items.clone()))
-            }
+            CassCollectionType::CASS_COLLECTION_TYPE_SET => Ok(CassCqlValue::Set {
+                data_type,
+                values: collection.items.clone(),
+            }),
             _ => Err(()),
         }
     }

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -1,14 +1,32 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
+use crate::cass_types::CassDataType;
 use crate::types::*;
 use crate::value::CassCqlValue;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
 include!(concat!(env!("OUT_DIR"), "/cppdriver_data_collection.rs"));
+
+// These constants help us to save an allocation in case user calls `cass_collection_new` (untyped collection).
+static UNTYPED_LIST_TYPE: CassDataType = CassDataType::List {
+    typ: None,
+    frozen: false,
+};
+static UNTYPED_SET_TYPE: CassDataType = CassDataType::Set {
+    typ: None,
+    frozen: false,
+};
+static UNTYPED_MAP_TYPE: CassDataType = CassDataType::Map {
+    key_type: None,
+    val_type: None,
+    frozen: false,
+};
 
 #[derive(Clone)]
 pub struct CassCollection {
     pub collection_type: CassCollectionType,
+    pub data_type: Option<Arc<CassDataType>>,
     pub capacity: usize,
     pub items: Vec<CassCqlValue>,
 }
@@ -57,16 +75,62 @@ pub unsafe extern "C" fn cass_collection_new(
 ) -> *mut CassCollection {
     let capacity = match collection_type {
         // Maps consist of a key and a value, so twice
-        // the number of CqlValue will be stored.
+        // the number of CassCqlValue will be stored.
         CassCollectionType::CASS_COLLECTION_TYPE_MAP => item_count * 2,
         _ => item_count,
     } as usize;
 
     Box::into_raw(Box::new(CassCollection {
         collection_type,
+        data_type: None,
         capacity,
         items: Vec::with_capacity(capacity),
     }))
+}
+
+#[no_mangle]
+unsafe extern "C" fn cass_collection_new_from_data_type(
+    data_type: *const CassDataType,
+    item_count: size_t,
+) -> *mut CassCollection {
+    let data_type = clone_arced(data_type);
+    let (capacity, collection_type) = match data_type.as_ref() {
+        CassDataType::List { .. } => (item_count, CassCollectionType::CASS_COLLECTION_TYPE_LIST),
+        CassDataType::Set { .. } => (item_count, CassCollectionType::CASS_COLLECTION_TYPE_SET),
+        // Maps consist of a key and a value, so twice
+        // the number of CassCqlValue will be stored.
+        CassDataType::Map { .. } => (item_count * 2, CassCollectionType::CASS_COLLECTION_TYPE_MAP),
+        _ => return std::ptr::null_mut(),
+    };
+    let capacity = capacity as usize;
+
+    Box::into_raw(Box::new(CassCollection {
+        collection_type,
+        data_type: Some(data_type),
+        capacity,
+        items: Vec::with_capacity(capacity),
+    }))
+}
+
+#[no_mangle]
+unsafe extern "C" fn cass_collection_data_type(
+    collection: *const CassCollection,
+) -> *const CassDataType {
+    let collection_ref = ptr_to_ref(collection);
+
+    match &collection_ref.data_type {
+        Some(dt) => Arc::as_ptr(dt),
+        None => match collection_ref.collection_type {
+            CassCollectionType::CASS_COLLECTION_TYPE_LIST => &UNTYPED_LIST_TYPE,
+            CassCollectionType::CASS_COLLECTION_TYPE_SET => &UNTYPED_SET_TYPE,
+            CassCollectionType::CASS_COLLECTION_TYPE_MAP => &UNTYPED_MAP_TYPE,
+            // CassCollectionType is a C enum. Panic, if it's out of range.
+            _ => panic!(
+                "CassCollectionType enum value out of range: {}",
+                collection_ref.collection_type.0
+            ),
+        },
+    }
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -8,7 +8,6 @@ use crate::types::*;
 use crate::uuid::CassUuid;
 use crate::RUNTIME;
 use futures::future;
-use scylla::prepared_statement::PreparedStatement;
 use std::future::Future;
 use std::mem;
 use std::os::raw::c_void;
@@ -20,7 +19,7 @@ pub enum CassResultValue {
     Empty,
     QueryResult(Arc<CassResult>),
     QueryError(Arc<CassErrorResult>),
-    Prepared(Arc<PreparedStatement>),
+    Prepared(Arc<CassPrepared>),
 }
 
 type CassFutureError = (CassError, String);

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -1,6 +1,6 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
-use crate::cass_types::{cass_data_type_type, CassDataType, CassValueType};
+use crate::cass_types::{cass_data_type_type, CassDataType, CassValueType, MapDataType};
 use crate::inet::CassInet;
 use crate::metadata::{
     CassColumnMeta, CassKeyspaceMeta, CassMaterializedViewMeta, CassSchemaMeta, CassTableMeta,
@@ -1239,7 +1239,7 @@ pub unsafe extern "C" fn cass_value_primary_sub_type(
         } => list.get_value_type(),
         CassDataType::Set { typ: Some(set), .. } => set.get_value_type(),
         CassDataType::Map {
-            key_type: Some(key),
+            typ: MapDataType::Key(key) | MapDataType::KeyAndValue(key, _),
             ..
         } => key.get_value_type(),
         _ => CassValueType::CASS_VALUE_TYPE_UNKNOWN,
@@ -1254,7 +1254,7 @@ pub unsafe extern "C" fn cass_value_secondary_sub_type(
 
     match val.value_type.as_ref() {
         CassDataType::Map {
-            val_type: Some(value),
+            typ: MapDataType::KeyAndValue(_, value),
             ..
         } => value.get_value_type(),
         _ => CassValueType::CASS_VALUE_TYPE_UNKNOWN,

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -1,7 +1,7 @@
 use crate::argconv::*;
 use crate::batch::CassBatch;
 use crate::cass_error::*;
-use crate::cass_types::{get_column_type, CassDataType, UDTDataType};
+use crate::cass_types::{get_column_type, CassDataType, MapDataType, UDTDataType};
 use crate::cluster::build_session_builder;
 use crate::cluster::CassCluster;
 use crate::exec_profile::{CassExecProfile, ExecProfileName, PerStatementExecProfile};
@@ -388,8 +388,7 @@ fn get_column_value(column: CqlValue, column_type: &Arc<CassDataType>) -> Value 
         (
             CqlValue::Map(map),
             CassDataType::Map {
-                key_type: Some(key_typ),
-                val_type: Some(value_type),
+                typ: MapDataType::KeyAndValue(key_type, value_type),
                 ..
             },
         ) => CollectionValue(Collection::Map(
@@ -397,8 +396,8 @@ fn get_column_value(column: CqlValue, column_type: &Arc<CassDataType>) -> Value 
                 .map(|(key, val)| {
                     (
                         CassValue {
-                            value_type: key_typ.clone(),
-                            value: Some(get_column_value(key, key_typ)),
+                            value_type: key_type.clone(),
+                            value: Some(get_column_value(key, key_type)),
                         },
                         CassValue {
                             value_type: value_type.clone(),

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -1,6 +1,7 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::exec_profile::PerStatementExecProfile;
+use crate::prepared::CassPrepared;
 use crate::query_result::CassResult;
 use crate::retry_policy::CassRetryPolicy;
 use crate::types::*;
@@ -9,7 +10,6 @@ use scylla::frame::types::Consistency;
 use scylla::frame::value::MaybeUnset;
 use scylla::frame::value::MaybeUnset::{Set, Unset};
 use scylla::query::Query;
-use scylla::statement::prepared_statement::PreparedStatement;
 use scylla::statement::SerialConsistency;
 use scylla::transport::{PagingState, PagingStateResponse};
 use std::collections::HashMap;
@@ -24,7 +24,7 @@ include!(concat!(env!("OUT_DIR"), "/cppdriver_data_query_error.rs"));
 pub enum Statement {
     Simple(SimpleQuery),
     // Arc is needed, because PreparedStatement is passed by reference to session.execute
-    Prepared(Arc<PreparedStatement>),
+    Prepared(Arc<CassPrepared>),
 }
 
 #[derive(Clone)]
@@ -83,6 +83,7 @@ impl CassStatement {
         match &self.statement {
             Statement::Prepared(prepared) => {
                 let indices: Vec<usize> = prepared
+                    .statement
                     .get_variable_col_specs()
                     .iter()
                     .enumerate()
@@ -185,7 +186,9 @@ pub unsafe extern "C" fn cass_statement_set_consistency(
     if let Some(consistency) = consistency_opt {
         match &mut ptr_to_ref_mut(statement).statement {
             Statement::Simple(inner) => inner.query.set_consistency(consistency),
-            Statement::Prepared(inner) => Arc::make_mut(inner).set_consistency(consistency),
+            Statement::Prepared(inner) => {
+                Arc::make_mut(inner).statement.set_consistency(consistency)
+            }
         }
     }
 
@@ -205,7 +208,7 @@ pub unsafe extern "C" fn cass_statement_set_paging_size(
         statement.paging_enabled = true;
         match &mut statement.statement {
             Statement::Simple(inner) => inner.query.set_page_size(page_size),
-            Statement::Prepared(inner) => Arc::make_mut(inner).set_page_size(page_size),
+            Statement::Prepared(inner) => Arc::make_mut(inner).statement.set_page_size(page_size),
         }
     }
 
@@ -253,7 +256,9 @@ pub unsafe extern "C" fn cass_statement_set_is_idempotent(
 ) -> CassError {
     match &mut ptr_to_ref_mut(statement_raw).statement {
         Statement::Simple(inner) => inner.query.set_is_idempotent(is_idempotent != 0),
-        Statement::Prepared(inner) => Arc::make_mut(inner).set_is_idempotent(is_idempotent != 0),
+        Statement::Prepared(inner) => Arc::make_mut(inner)
+            .statement
+            .set_is_idempotent(is_idempotent != 0),
     }
 
     CassError::CASS_OK
@@ -266,7 +271,7 @@ pub unsafe extern "C" fn cass_statement_set_tracing(
 ) -> CassError {
     match &mut ptr_to_ref_mut(statement_raw).statement {
         Statement::Simple(inner) => inner.query.set_tracing(enabled != 0),
-        Statement::Prepared(inner) => Arc::make_mut(inner).set_tracing(enabled != 0),
+        Statement::Prepared(inner) => Arc::make_mut(inner).statement.set_tracing(enabled != 0),
     }
 
     CassError::CASS_OK
@@ -288,9 +293,9 @@ pub unsafe extern "C" fn cass_statement_set_retry_policy(
 
     match &mut ptr_to_ref_mut(statement).statement {
         Statement::Simple(inner) => inner.query.set_retry_policy(maybe_arced_retry_policy),
-        Statement::Prepared(inner) => {
-            Arc::make_mut(inner).set_retry_policy(maybe_arced_retry_policy)
-        }
+        Statement::Prepared(inner) => Arc::make_mut(inner)
+            .statement
+            .set_retry_policy(maybe_arced_retry_policy),
     }
 
     CassError::CASS_OK
@@ -317,9 +322,9 @@ pub unsafe extern "C" fn cass_statement_set_serial_consistency(
 
     match &mut ptr_to_ref_mut(statement).statement {
         Statement::Simple(inner) => inner.query.set_serial_consistency(Some(consistency)),
-        Statement::Prepared(inner) => {
-            Arc::make_mut(inner).set_serial_consistency(Some(consistency))
-        }
+        Statement::Prepared(inner) => Arc::make_mut(inner)
+            .statement
+            .set_serial_consistency(Some(consistency)),
     }
 
     CassError::CASS_OK
@@ -349,7 +354,9 @@ pub unsafe extern "C" fn cass_statement_set_timestamp(
 ) -> CassError {
     match &mut ptr_to_ref_mut(statement).statement {
         Statement::Simple(inner) => inner.query.set_timestamp(Some(timestamp)),
-        Statement::Prepared(inner) => Arc::make_mut(inner).set_timestamp(Some(timestamp)),
+        Statement::Prepared(inner) => Arc::make_mut(inner)
+            .statement
+            .set_timestamp(Some(timestamp)),
     }
 
     CassError::CASS_OK

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -6,7 +6,7 @@ use crate::value;
 use crate::value::CassCqlValue;
 use std::sync::Arc;
 
-static EMPTY_TUPLE_TYPE: CassDataType = CassDataType::Tuple(Vec::new());
+static UNTYPED_TUPLE_TYPE: CassDataType = CassDataType::Tuple(Vec::new());
 
 #[derive(Clone)]
 pub struct CassTuple {
@@ -89,7 +89,7 @@ unsafe extern "C" fn cass_tuple_free(tuple: *mut CassTuple) {
 unsafe extern "C" fn cass_tuple_data_type(tuple: *const CassTuple) -> *const CassDataType {
     match &ptr_to_ref(tuple).data_type {
         Some(t) => Arc::as_ptr(t),
-        None => &EMPTY_TUPLE_TYPE,
+        None => &UNTYPED_TUPLE_TYPE,
     }
 }
 

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -1,8 +1,8 @@
 use crate::argconv::*;
-use crate::binding;
 use crate::cass_error::CassError;
 use crate::cass_types::CassDataType;
 use crate::types::*;
+use crate::value;
 use crate::value::CassCqlValue;
 use std::sync::Arc;
 
@@ -37,7 +37,7 @@ impl CassTuple {
         }
 
         if let Some(inner_types) = self.get_types() {
-            if !binding::is_compatible_type(&inner_types[index], &v) {
+            if !value::is_type_compatible(&v, &inner_types[index]) {
                 return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
             }
         }

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -50,7 +50,10 @@ impl CassTuple {
 
 impl From<&CassTuple> for CassCqlValue {
     fn from(tuple: &CassTuple) -> Self {
-        CassCqlValue::Tuple(tuple.items.clone())
+        CassCqlValue::Tuple {
+            data_type: tuple.data_type.clone(),
+            fields: tuple.items.clone(),
+        }
     }
 }
 

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -1,9 +1,8 @@
-use crate::argconv::*;
-use crate::binding::is_compatible_type;
 use crate::cass_error::CassError;
 use crate::cass_types::CassDataType;
 use crate::types::*;
 use crate::value::CassCqlValue;
+use crate::{argconv::*, value};
 use std::os::raw::c_char;
 use std::sync::Arc;
 
@@ -20,7 +19,7 @@ impl CassUserType {
         if index >= self.field_values.len() {
             return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
         }
-        if !is_compatible_type(&self.data_type.get_udt_type().field_types[index].1, &value) {
+        if !value::is_type_compatible(&value, &self.data_type.get_udt_type().field_types[index].1) {
             return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
         }
         self.field_values[index] = value;
@@ -37,7 +36,7 @@ impl CassUserType {
                 if index >= self.field_values.len() {
                     return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
                 }
-                if !is_compatible_type(field_type, &value) {
+                if !value::is_type_compatible(&value, field_type) {
                     return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
                 }
                 self.field_values[index].clone_from(&value);

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -54,8 +54,7 @@ impl CassUserType {
 impl From<&CassUserType> for CassCqlValue {
     fn from(user_type: &CassUserType) -> Self {
         CassCqlValue::UserDefinedType {
-            keyspace: user_type.data_type.get_udt_type().keyspace.clone(),
-            type_name: user_type.data_type.get_udt_type().name.clone(),
+            data_type: user_type.data_type.clone(),
             fields: user_type
                 .field_values
                 .iter()

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -78,7 +78,7 @@ impl CassCqlValue {
             CassCqlValue::SmallInt(_) => {
                 typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_SMALL_INT
             }
-            CassCqlValue::Int(_) => todo!(),
+            CassCqlValue::Int(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_INT,
             CassCqlValue::BigInt(_) => todo!(),
             CassCqlValue::Float(_) => todo!(),
             CassCqlValue::Double(_) => todo!(),
@@ -385,6 +385,11 @@ mod tests {
             TestCase {
                 value: Some(CassCqlValue::SmallInt(Default::default())),
                 compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_SMALL_INT)],
+            },
+            // i32 -> int
+            TestCase {
+                value: Some(CassCqlValue::Int(Default::default())),
+                compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_INT)],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -174,7 +174,7 @@ impl SerializeValue for CassCqlValue {
         _typ: &ColumnType,
         writer: CellWriter<'b>,
     ) -> Result<WrittenCellProof<'b>, SerializationError> {
-        // _typ is not used, since we do the typechecks during binding (this is still a TODO, high priority).
+        // _typ is not used, since we do the typechecks during binding.
         // This is the same approach as cpp-driver.
         self.do_serialize(writer)
     }

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -75,7 +75,9 @@ impl CassCqlValue {
             CassCqlValue::TinyInt(_) => {
                 typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_TINY_INT
             }
-            CassCqlValue::SmallInt(_) => todo!(),
+            CassCqlValue::SmallInt(_) => {
+                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_SMALL_INT
+            }
             CassCqlValue::Int(_) => todo!(),
             CassCqlValue::BigInt(_) => todo!(),
             CassCqlValue::Float(_) => todo!(),
@@ -378,6 +380,11 @@ mod tests {
             TestCase {
                 value: Some(CassCqlValue::TinyInt(Default::default())),
                 compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_TINY_INT)],
+            },
+            // i16 -> smallint
+            TestCase {
+                value: Some(CassCqlValue::SmallInt(Default::default())),
+                compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_SMALL_INT)],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -88,7 +88,7 @@ impl CassCqlValue {
                         | CassValueType::CASS_VALUE_TYPE_TIME
                 )
             }
-            CassCqlValue::Float(_) => todo!(),
+            CassCqlValue::Float(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_FLOAT,
             CassCqlValue::Double(_) => todo!(),
             CassCqlValue::Boolean(_) => todo!(),
             CassCqlValue::Text(_) => todo!(),
@@ -408,6 +408,11 @@ mod tests {
                     from(CassValueType::CASS_VALUE_TYPE_TIME),
                     from(CassValueType::CASS_VALUE_TYPE_TIMESTAMP),
                 ],
+            },
+            // f32 -> float
+            TestCase {
+                value: Some(CassCqlValue::Float(Default::default())),
+                compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_FLOAT)],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -118,7 +118,9 @@ impl CassCqlValue {
             CassCqlValue::Duration(_) => {
                 typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DURATION
             }
-            CassCqlValue::Decimal(_) => todo!(),
+            CassCqlValue::Decimal(_) => {
+                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DECIMAL
+            }
             CassCqlValue::Tuple(_) => todo!(),
             CassCqlValue::List(_) => todo!(),
             CassCqlValue::Map(_) => todo!(),
@@ -355,7 +357,7 @@ fn serialize_udt<'b>(
 mod tests {
     use std::net::Ipv4Addr;
 
-    use scylla::frame::value::{CqlDate, CqlDuration};
+    use scylla::frame::value::{CqlDate, CqlDecimal, CqlDuration};
 
     use crate::{
         cass_types::{CassDataType, CassValueType},
@@ -495,6 +497,13 @@ mod tests {
                     nanoseconds: 0,
                 })),
                 compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_DURATION)],
+            },
+            // CqlDecimal -> decimal
+            TestCase {
+                value: Some(CassCqlValue::Decimal(
+                    CqlDecimal::from_signed_be_bytes_slice_and_exponent(&[], 0),
+                )),
+                compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_DECIMAL)],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -115,7 +115,9 @@ impl CassCqlValue {
             ),
             CassCqlValue::Date(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DATE,
             CassCqlValue::Inet(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_INET,
-            CassCqlValue::Duration(_) => todo!(),
+            CassCqlValue::Duration(_) => {
+                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DURATION
+            }
             CassCqlValue::Decimal(_) => todo!(),
             CassCqlValue::Tuple(_) => todo!(),
             CassCqlValue::List(_) => todo!(),
@@ -353,7 +355,7 @@ fn serialize_udt<'b>(
 mod tests {
     use std::net::Ipv4Addr;
 
-    use scylla::frame::value::CqlDate;
+    use scylla::frame::value::{CqlDate, CqlDuration};
 
     use crate::{
         cass_types::{CassDataType, CassValueType},
@@ -484,6 +486,15 @@ mod tests {
                     Ipv4Addr::LOCALHOST,
                 ))),
                 compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_INET)],
+            },
+            // CqlDuration -> duration
+            TestCase {
+                value: Some(CassCqlValue::Duration(CqlDuration {
+                    months: 0,
+                    days: 0,
+                    nanoseconds: 0,
+                })),
+                compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_DURATION)],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -105,7 +105,10 @@ impl CassCqlValue {
                         | CassValueType::CASS_VALUE_TYPE_VARINT
                 )
             }
-            CassCqlValue::Blob(_) => todo!(),
+            CassCqlValue::Blob(_) => matches!(
+                typ.get_value_type(),
+                CassValueType::CASS_VALUE_TYPE_BLOB | CassValueType::CASS_VALUE_TYPE_VARINT
+            ),
             CassCqlValue::Uuid(_) => todo!(),
             CassCqlValue::Date(_) => todo!(),
             CassCqlValue::Inet(_) => todo!(),
@@ -443,6 +446,14 @@ mod tests {
                     from(CassValueType::CASS_VALUE_TYPE_TEXT),
                     from(CassValueType::CASS_VALUE_TYPE_VARCHAR),
                     from(CassValueType::CASS_VALUE_TYPE_ASCII),
+                    from(CassValueType::CASS_VALUE_TYPE_BLOB),
+                    from(CassValueType::CASS_VALUE_TYPE_VARINT),
+                ],
+            },
+            // Vec<u8> -> blob/varint
+            TestCase {
+                value: Some(CassCqlValue::Blob(Default::default())),
+                compatible_types: vec![
                     from(CassValueType::CASS_VALUE_TYPE_BLOB),
                     from(CassValueType::CASS_VALUE_TYPE_VARINT),
                 ],

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -17,6 +17,8 @@ use scylla::{
 };
 use uuid::Uuid;
 
+use crate::cass_types::CassDataType;
+
 /// A narrower version of rust driver's CqlValue.
 ///
 /// cpp-driver's API allows to map single rust type to
@@ -58,6 +60,19 @@ pub enum CassCqlValue {
         fields: Vec<(String, Option<CassCqlValue>)>,
     },
     // TODO: custom (?), duration and decimal
+}
+
+pub fn is_type_compatible(value: &Option<CassCqlValue>, typ: &CassDataType) -> bool {
+    match value {
+        Some(v) => v.is_type_compatible(typ),
+        None => true,
+    }
+}
+
+impl CassCqlValue {
+    pub fn is_type_compatible(&self, _typ: &CassDataType) -> bool {
+        true
+    }
 }
 
 impl SerializeValue for CassCqlValue {

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -92,7 +92,9 @@ impl CassCqlValue {
             CassCqlValue::Double(_) => {
                 typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DOUBLE
             }
-            CassCqlValue::Boolean(_) => todo!(),
+            CassCqlValue::Boolean(_) => {
+                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_BOOLEAN
+            }
             CassCqlValue::Text(_) => todo!(),
             CassCqlValue::Blob(_) => todo!(),
             CassCqlValue::Uuid(_) => todo!(),
@@ -420,6 +422,11 @@ mod tests {
             TestCase {
                 value: Some(CassCqlValue::Double(Default::default())),
                 compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_DOUBLE)],
+            },
+            // bool -> boolean
+            TestCase {
+                value: Some(CassCqlValue::Boolean(Default::default())),
+                compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_BOOLEAN)],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -17,7 +17,7 @@ use scylla::{
 };
 use uuid::Uuid;
 
-use crate::cass_types::CassDataType;
+use crate::cass_types::{CassDataType, CassValueType};
 
 /// A narrower version of rust driver's CqlValue.
 ///
@@ -70,8 +70,30 @@ pub fn is_type_compatible(value: &Option<CassCqlValue>, typ: &CassDataType) -> b
 }
 
 impl CassCqlValue {
-    pub fn is_type_compatible(&self, _typ: &CassDataType) -> bool {
-        true
+    pub fn is_type_compatible(&self, typ: &CassDataType) -> bool {
+        match self {
+            CassCqlValue::TinyInt(_) => {
+                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_TINY_INT
+            }
+            CassCqlValue::SmallInt(_) => todo!(),
+            CassCqlValue::Int(_) => todo!(),
+            CassCqlValue::BigInt(_) => todo!(),
+            CassCqlValue::Float(_) => todo!(),
+            CassCqlValue::Double(_) => todo!(),
+            CassCqlValue::Boolean(_) => todo!(),
+            CassCqlValue::Text(_) => todo!(),
+            CassCqlValue::Blob(_) => todo!(),
+            CassCqlValue::Uuid(_) => todo!(),
+            CassCqlValue::Date(_) => todo!(),
+            CassCqlValue::Inet(_) => todo!(),
+            CassCqlValue::Duration(_) => todo!(),
+            CassCqlValue::Decimal(_) => todo!(),
+            CassCqlValue::Tuple(_) => todo!(),
+            CassCqlValue::List(_) => todo!(),
+            CassCqlValue::Map(_) => todo!(),
+            CassCqlValue::Set(_) => todo!(),
+            CassCqlValue::UserDefinedType { .. } => todo!(),
+        }
     }
 }
 
@@ -340,6 +362,7 @@ mod tests {
 
     #[test]
     fn typecheck_simple_test() {
+        let from = |v_typ: CassValueType| CassDataType::Value(v_typ);
         struct TestCase {
             value: Option<CassCqlValue>,
             compatible_types: Vec<CassDataType>,
@@ -350,6 +373,11 @@ mod tests {
             TestCase {
                 value: None,
                 compatible_types: all_value_data_types().to_vec(),
+            },
+            // i8 -> tinyint
+            TestCase {
+                value: Some(CassCqlValue::TinyInt(Default::default())),
+                compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_TINY_INT)],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -355,7 +355,7 @@ fn serialize_udt<'b>(
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::{net::Ipv4Addr, sync::Arc};
 
     use scylla::frame::value::{CqlDate, CqlDecimal, CqlDuration};
 
@@ -519,5 +519,35 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn typecheck_complex_test() {
+        struct TestCase {
+            value: CassCqlValue,
+            compatible_types: Vec<Arc<CassDataType>>,
+            incompatible_types: Vec<Arc<CassDataType>>,
+        }
+
+        let run_test_cases = |test_cases: &[TestCase]| {
+            for case in test_cases {
+                for typ in case.compatible_types.iter() {
+                    assert!(
+                        case.value.is_type_compatible(typ),
+                        "Typecheck failed, when it should pass. Value: {:?}, Type: {:?}",
+                        case.value,
+                        typ
+                    );
+                }
+                for typ in case.incompatible_types.iter() {
+                    assert!(
+                        !case.value.is_type_compatible(typ),
+                        "Typecheck passed, when it should fail. Value: {:?}, Type: {:?}",
+                        case.value,
+                        typ
+                    )
+                }
+            }
+        };
     }
 }

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -114,7 +114,7 @@ impl CassCqlValue {
                 CassValueType::CASS_VALUE_TYPE_UUID | CassValueType::CASS_VALUE_TYPE_TIMEUUID
             ),
             CassCqlValue::Date(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DATE,
-            CassCqlValue::Inet(_) => todo!(),
+            CassCqlValue::Inet(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_INET,
             CassCqlValue::Duration(_) => todo!(),
             CassCqlValue::Decimal(_) => todo!(),
             CassCqlValue::Tuple(_) => todo!(),
@@ -351,6 +351,8 @@ fn serialize_udt<'b>(
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use scylla::frame::value::CqlDate;
 
     use crate::{
@@ -475,6 +477,13 @@ mod tests {
             TestCase {
                 value: Some(CassCqlValue::Date(CqlDate(Default::default()))),
                 compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_DATE)],
+            },
+            // IpAddr -> inet
+            TestCase {
+                value: Some(CassCqlValue::Inet(std::net::IpAddr::V4(
+                    Ipv4Addr::LOCALHOST,
+                ))),
+                compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_INET)],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -113,7 +113,7 @@ impl CassCqlValue {
                 typ.get_value_type(),
                 CassValueType::CASS_VALUE_TYPE_UUID | CassValueType::CASS_VALUE_TYPE_TIMEUUID
             ),
-            CassCqlValue::Date(_) => todo!(),
+            CassCqlValue::Date(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DATE,
             CassCqlValue::Inet(_) => todo!(),
             CassCqlValue::Duration(_) => todo!(),
             CassCqlValue::Decimal(_) => todo!(),
@@ -351,6 +351,8 @@ fn serialize_udt<'b>(
 
 #[cfg(test)]
 mod tests {
+    use scylla::frame::value::CqlDate;
+
     use crate::{
         cass_types::{CassDataType, CassValueType},
         value::{is_type_compatible, CassCqlValue},
@@ -468,6 +470,11 @@ mod tests {
                     from(CassValueType::CASS_VALUE_TYPE_UUID),
                     from(CassValueType::CASS_VALUE_TYPE_TIMEUUID),
                 ],
+            },
+            // u32 -> date
+            TestCase {
+                value: Some(CassCqlValue::Date(CqlDate(Default::default()))),
+                compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_DATE)],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -402,7 +402,7 @@ mod tests {
     use scylla::frame::value::{CqlDate, CqlDecimal, CqlDuration};
 
     use crate::{
-        cass_types::{CassDataType, CassValueType, UDTDataType},
+        cass_types::{CassDataType, CassValueType, MapDataType, UDTDataType},
         value::{is_type_compatible, CassCqlValue},
     };
 
@@ -630,8 +630,7 @@ mod tests {
         });
 
         let data_type_bool_float_map = Arc::new(CassDataType::Map {
-            key_type: Some(data_type_bool.clone()),
-            val_type: Some(data_type_float.clone()),
+            typ: MapDataType::KeyAndValue(data_type_bool.clone(), data_type_float.clone()),
             frozen: false,
         });
 
@@ -820,18 +819,16 @@ mod tests {
             });
 
             let data_type_untyped_map = Arc::new(CassDataType::Map {
-                key_type: None,
-                val_type: None,
+                typ: MapDataType::Untyped,
                 frozen: false,
             });
             let data_type_typed_key_float_map = Arc::new(CassDataType::Map {
-                key_type: Some(data_type_float.clone()),
-                val_type: None,
+                typ: MapDataType::Key(data_type_float.clone()),
+
                 frozen: false,
             });
             let data_type_float_int_map = Arc::new(CassDataType::Map {
-                key_type: Some(data_type_float.clone()),
-                val_type: Some(data_type_int.clone()),
+                typ: MapDataType::KeyAndValue(data_type_float.clone(), data_type_int.clone()),
                 frozen: false,
             });
 

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -95,7 +95,16 @@ impl CassCqlValue {
             CassCqlValue::Boolean(_) => {
                 typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_BOOLEAN
             }
-            CassCqlValue::Text(_) => todo!(),
+            CassCqlValue::Text(_) => {
+                matches!(
+                    typ.get_value_type(),
+                    CassValueType::CASS_VALUE_TYPE_TEXT
+                        | CassValueType::CASS_VALUE_TYPE_VARCHAR
+                        | CassValueType::CASS_VALUE_TYPE_ASCII
+                        | CassValueType::CASS_VALUE_TYPE_BLOB
+                        | CassValueType::CASS_VALUE_TYPE_VARINT
+                )
+            }
             CassCqlValue::Blob(_) => todo!(),
             CassCqlValue::Uuid(_) => todo!(),
             CassCqlValue::Date(_) => todo!(),
@@ -427,6 +436,16 @@ mod tests {
             TestCase {
                 value: Some(CassCqlValue::Boolean(Default::default())),
                 compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_BOOLEAN)],
+            },
+            TestCase {
+                value: Some(CassCqlValue::Text(Default::default())),
+                compatible_types: vec![
+                    from(CassValueType::CASS_VALUE_TYPE_TEXT),
+                    from(CassValueType::CASS_VALUE_TYPE_VARCHAR),
+                    from(CassValueType::CASS_VALUE_TYPE_ASCII),
+                    from(CassValueType::CASS_VALUE_TYPE_BLOB),
+                    from(CassValueType::CASS_VALUE_TYPE_VARINT),
+                ],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -109,7 +109,10 @@ impl CassCqlValue {
                 typ.get_value_type(),
                 CassValueType::CASS_VALUE_TYPE_BLOB | CassValueType::CASS_VALUE_TYPE_VARINT
             ),
-            CassCqlValue::Uuid(_) => todo!(),
+            CassCqlValue::Uuid(_) => matches!(
+                typ.get_value_type(),
+                CassValueType::CASS_VALUE_TYPE_UUID | CassValueType::CASS_VALUE_TYPE_TIMEUUID
+            ),
             CassCqlValue::Date(_) => todo!(),
             CassCqlValue::Inet(_) => todo!(),
             CassCqlValue::Duration(_) => todo!(),
@@ -456,6 +459,14 @@ mod tests {
                 compatible_types: vec![
                     from(CassValueType::CASS_VALUE_TYPE_BLOB),
                     from(CassValueType::CASS_VALUE_TYPE_VARINT),
+                ],
+            },
+            // uuid -> uuid/timeuuid
+            TestCase {
+                value: Some(CassCqlValue::Uuid(Default::default())),
+                compatible_types: vec![
+                    from(CassValueType::CASS_VALUE_TYPE_UUID),
+                    from(CassValueType::CASS_VALUE_TYPE_TIMEUUID),
                 ],
             },
         ];

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -89,7 +89,9 @@ impl CassCqlValue {
                 )
             }
             CassCqlValue::Float(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_FLOAT,
-            CassCqlValue::Double(_) => todo!(),
+            CassCqlValue::Double(_) => {
+                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DOUBLE
+            }
             CassCqlValue::Boolean(_) => todo!(),
             CassCqlValue::Text(_) => todo!(),
             CassCqlValue::Blob(_) => todo!(),
@@ -413,6 +415,11 @@ mod tests {
             TestCase {
                 value: Some(CassCqlValue::Float(Default::default())),
                 compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_FLOAT)],
+            },
+            // f64 -> double
+            TestCase {
+                value: Some(CassCqlValue::Double(Default::default())),
+                compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_DOUBLE)],
             },
         ];
         let all_simple_types = all_value_data_types();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -79,7 +79,15 @@ impl CassCqlValue {
                 typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_SMALL_INT
             }
             CassCqlValue::Int(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_INT,
-            CassCqlValue::BigInt(_) => todo!(),
+            CassCqlValue::BigInt(_) => {
+                matches!(
+                    typ.get_value_type(),
+                    CassValueType::CASS_VALUE_TYPE_BIGINT
+                        | CassValueType::CASS_VALUE_TYPE_COUNTER
+                        | CassValueType::CASS_VALUE_TYPE_TIMESTAMP
+                        | CassValueType::CASS_VALUE_TYPE_TIME
+                )
+            }
             CassCqlValue::Float(_) => todo!(),
             CassCqlValue::Double(_) => todo!(),
             CassCqlValue::Boolean(_) => todo!(),
@@ -390,6 +398,16 @@ mod tests {
             TestCase {
                 value: Some(CassCqlValue::Int(Default::default())),
                 compatible_types: vec![from(CassValueType::CASS_VALUE_TYPE_INT)],
+            },
+            // i64 -> bigint/counter/time/timestamp
+            TestCase {
+                value: Some(CassCqlValue::BigInt(Default::default())),
+                compatible_types: vec![
+                    from(CassValueType::CASS_VALUE_TYPE_BIGINT),
+                    from(CassValueType::CASS_VALUE_TYPE_COUNTER),
+                    from(CassValueType::CASS_VALUE_TYPE_TIME),
+                    from(CassValueType::CASS_VALUE_TYPE_TIMESTAMP),
+                ],
             },
         ];
         let all_simple_types = all_value_data_types();


### PR DESCRIPTION
Fix: https://github.com/scylladb/cpp-rust-driver/issues/142

## Motivation

Right now, cpp-rust-driver does not perform any typechecks during binding. This PR changes that and implements a typecheck logic based on cpp-driver's logic.

### Why not just use a builtin rust-driver's typechecks mechanism?
The reason for this is that cpp-driver has a bit different language (cpp/rust) to CQL type mapping. A simple example is an int64_t/i64 value which in cpp-driver can be mapped to 4 different CQL types.

Other reason is that cpp-driver allows users to define untyped tuples/collections. For such objects, the typechecks are skipped.

Cpp-driver performs typechecks during binding - we will follow the same approach. It is much convenient and cleaner to handle untyped objects this way.

## Implemented API functions
- `cass_collection_new_from_data_type` -> allows user to create a TYPED collection. We also adjusted the `cass_collection_new` logic - this function is responsible for creating an UNTYPED version of a collection.
- `cass_collection_data_type` -> returns a data type representing a collection. Since collections now hold info about the data types, this function was very trivial to implement.

## Unit tests
I implemented unit tests for simple and complex (udt, tuples, collections) types. Please make sure that all edge cases are covered.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`~