### PR TITLE
types: implement API functions for decimal type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,8 +51,6 @@ jobs:
 :CompressionTests.*\
 :LoggingTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
-:*5.Integration_Cassandra_*\
-:*19.Integration_Cassandra_*\
 :ExecutionProfileTest.InvalidName"
       run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --scylla --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
 

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -53,8 +53,6 @@ jobs:
 :LoggingTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
-:*5.Integration_Cassandra_*\
-:*19.Integration_Cassandra_*\
 :*7.Integration_Cassandra_*\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
 :ExecutionProfileTest.InvalidName"

--- a/README.md
+++ b/README.md
@@ -187,10 +187,7 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
         </tr>
         <tr>
             <td>cass_collection_append_custom[_n]</td>
-            <td rowspan="2">Unimplemented because of the same reasons as binding for statements.<br> <b>Note</b>: The driver does not check whether the type of the appended value is compatible with the type of the collection items.</td>
-        </tr>
-        <tr>
-            <td>cass_collection_append_decimal</td>
+            <td>Unimplemented because of the same reasons as binding for statements.<br> <b>Note</b>: The driver does not check whether the type of the appended value is compatible with the type of the collection items.</td>
         </tr>
         <tr>
             <td colspan=2 align="center" style="font-weight:bold">User Defined Type</td>

--- a/README.md
+++ b/README.md
@@ -191,10 +191,7 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
         </tr>
         <tr>
             <td>cass_user_type_set_custom[by_name]</td>
-            <td rowspan="2">Unimplemented because of the same reasons as binding for statements.<br> <b>Note</b>: The driver does not check whether the type of the value being set for a field of the UDT is compatible with the field's actual type.</td>
-        </tr>
-        <tr>
-            <td>cass_user_type_set_decimal[by_name]</td>
+            <td>Unimplemented because of the same reasons as binding for statements.<br> <b>Note</b>: The driver does not check whether the type of the value being set for a field of the UDT is compatible with the field's actual type.</td>
         </tr>
         <tr>
             <td colspan=2 align="center" style="font-weight:bold">Value</td>

--- a/README.md
+++ b/README.md
@@ -206,10 +206,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
             <td colspan=2 align="center" style="font-weight:bold">Value</td>
         </tr>
         <tr>
-            <td>cass_value_get_decimal</td>
-            <td>Getting raw bytes of Decimal values requires lazy deserialization feature in the Rust driver.</td>
-        </tr>
-        <tr>
             <td>cass_value_get_bytes</td>
             <td>When the above requirement is satisfied, this should be implemented for all CQL types. Currently, it returns only bytes of a Blob object, otherwise returns CASS_ERROR_LIB_INVALID_VALUE_TYPE.</td>
         </tr>

--- a/README.md
+++ b/README.md
@@ -160,10 +160,7 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
         </tr>
         <tr>
             <td>cass_statement_bind_custom[by_name]</td>
-            <td rowspan="2">Binding is not implemented for custom types in the Rust driver. <br> Binding Decimal type requires encoding raw bytes into BigDecimal type in the Rust driver. <br> <b>Note</b>: The driver does not validate the types of the values passed to queries.</td>
-        </tr>
-        <tr>
-            <td>cass_statement_bind_decimal[by_name]</td>
+            <td>Binding is not implemented for custom types in the Rust driver.</td>
         </tr>
         <tr>
             <td colspan=2 align="center" style="font-weight:bold">Future</td>

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -136,9 +136,8 @@ macro_rules! make_appender {
     }
 }
 
-// TODO: Types for which binding is not implemented yet:
+// Types for which binding is not implemented:
 // custom - Not implemented in Rust driver
-// decimal
 
 macro_rules! invoke_binder_maker_macro_with_type {
     (null, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
@@ -289,6 +288,19 @@ macro_rules! invoke_binder_maker_macro_with_type {
                 })))
             },
             [m @ cass_int32_t, d @ cass_int32_t, n @ cass_int64_t]
+        );
+    };
+    (decimal, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
+        $macro_name!(
+            $this,
+            $consume_v,
+            $fn,
+            |v, v_size, scale| {
+                use scylla::frame::value::CqlDecimal;
+                let varint = std::slice::from_raw_parts(v, v_size as usize);
+                Ok(Some(Decimal(CqlDecimal::from_signed_be_bytes_slice_and_exponent(varint, scale))))
+            },
+            [v @ *const cass_byte_t, v_size @ size_t, scale @ cass_int32_t]
         );
     };
     (collection, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -89,6 +89,7 @@ make_binders!(bytes, cass_collection_append_bytes);
 make_binders!(uuid, cass_collection_append_uuid);
 make_binders!(inet, cass_collection_append_inet);
 make_binders!(duration, cass_collection_append_duration);
+make_binders!(decimal, cass_collection_append_decimal);
 make_binders!(collection, cass_collection_append_collection);
 make_binders!(tuple, cass_collection_append_tuple);
 make_binders!(user_type, cass_collection_append_user_type);

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -1170,6 +1170,11 @@ pub unsafe extern "C" fn cass_value_get_bytes(
             *output = bytes.as_ptr() as *const cass_byte_t;
             *output_size = bytes.len() as u64;
         }
+        Some(Value::RegularValue(CqlValue::Varint(varint))) => {
+            let bytes = varint.as_signed_bytes_be_slice();
+            std::ptr::write(output, bytes.as_ptr());
+            std::ptr::write(output_size, bytes.len() as size_t);
+        }
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     }

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -469,6 +469,12 @@ make_binders!(
     cass_statement_bind_duration_by_name_n
 );
 make_binders!(
+    decimal,
+    cass_statement_bind_decimal,
+    cass_statement_bind_decimal_by_name,
+    cass_statement_bind_decimal_by_name_n
+);
+make_binders!(
     collection,
     cass_statement_bind_collection,
     cass_statement_bind_collection_by_name,

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -106,6 +106,7 @@ make_binders!(bytes, cass_tuple_set_bytes);
 make_binders!(uuid, cass_tuple_set_uuid);
 make_binders!(inet, cass_tuple_set_inet);
 make_binders!(duration, cass_tuple_set_duration);
+make_binders!(decimal, cass_tuple_set_decimal);
 make_binders!(collection, cass_tuple_set_collection);
 make_binders!(tuple, cass_tuple_set_tuple);
 make_binders!(user_type, cass_tuple_set_user_type);

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -188,6 +188,12 @@ make_binders!(
     cass_user_type_set_duration_by_name_n
 );
 make_binders!(
+    decimal,
+    cass_user_type_set_decimal,
+    cass_user_type_set_decimal_by_name,
+    cass_user_type_set_decimal_by_name_n
+);
+make_binders!(
     collection,
     cass_user_type_set_collection,
     cass_user_type_set_collection_by_name,

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -3,7 +3,7 @@ use std::{convert::TryInto, net::IpAddr};
 use scylla::{
     frame::{
         response::result::ColumnType,
-        value::{CqlDate, CqlDuration},
+        value::{CqlDate, CqlDecimal, CqlDuration},
     },
     serialize::{
         value::{
@@ -44,6 +44,7 @@ pub enum CassCqlValue {
     Date(CqlDate),
     Inet(IpAddr),
     Duration(CqlDuration),
+    Decimal(CqlDecimal),
     Tuple(Vec<Option<CassCqlValue>>),
     List(Vec<CassCqlValue>),
     Map(Vec<(CassCqlValue, CassCqlValue)>),
@@ -123,6 +124,9 @@ impl CassCqlValue {
             }
             CassCqlValue::Duration(v) => {
                 <CqlDuration as SerializeCql>::serialize(v, &ColumnType::Duration, writer)
+            }
+            CassCqlValue::Decimal(v) => {
+                <CqlDecimal as SerializeCql>::serialize(v, &ColumnType::Decimal, writer)
             }
             CassCqlValue::Tuple(fields) => serialize_tuple_like(fields.iter(), writer),
             CassCqlValue::List(l) => serialize_sequence(l.len(), l.iter(), writer),

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -338,22 +338,6 @@ cass_statement_bind_custom_by_name(CassStatement* statement,
 	throw std::runtime_error("UNIMPLEMENTED cass_statement_bind_custom_by_name\n");
 }
 CASS_EXPORT CassError
-cass_statement_bind_decimal(CassStatement* statement,
-                            size_t index,
-                            const cass_byte_t* varint,
-                            size_t varint_size,
-                            cass_int32_t scale){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_bind_decimal\n");
-}
-CASS_EXPORT CassError
-cass_statement_bind_decimal_by_name(CassStatement* statement,
-                                    const char* name,
-                                    const cass_byte_t* varint,
-                                    size_t varint_size,
-                                    cass_int32_t scale){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_bind_decimal_by_name\n");
-}
-CASS_EXPORT CassError
 cass_statement_set_custom_payload(CassStatement* statement,
                                   const CassCustomPayload* payload){
 	throw std::runtime_error("UNIMPLEMENTED cass_statement_set_custom_payload\n");

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -450,10 +450,3 @@ cass_user_type_set_decimal_by_name(CassUserType* user_type,
                                    int scale){
 	throw std::runtime_error("UNIMPLEMENTED cass_user_type_set_decimal_by_name\n");
 }
-CASS_EXPORT CassError
-cass_value_get_decimal(const CassValue* value,
-                       const cass_byte_t** varint,
-                       size_t* varint_size,
-                       cass_int32_t* scale){
-	throw std::runtime_error("UNIMPLEMENTED cass_value_get_decimal\n");
-}

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -396,14 +396,6 @@ cass_tuple_set_custom(CassTuple* tuple,
 	throw std::runtime_error("UNIMPLEMENTED cass_tuple_set_custom\n");
 }
 CASS_EXPORT CassError
-cass_tuple_set_decimal(CassTuple* tuple,
-                       size_t index,
-                       const cass_byte_t* varint,
-                       size_t varint_size,
-                       cass_int32_t scale){
-	throw std::runtime_error("UNIMPLEMENTED cass_tuple_set_decimal\n");
-}
-CASS_EXPORT CassError
 cass_user_type_set_custom(CassUserType* user_type,
                           size_t index,
                           const char* class_name,

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -157,13 +157,6 @@ cass_collection_append_custom(CassCollection* collection,
                               size_t value_size){
 	throw std::runtime_error("UNIMPLEMENTED cass_collection_append_custom\n");
 }
-CASS_EXPORT CassError
-cass_collection_append_decimal(CassCollection* collection,
-                               const cass_byte_t* varint,
-                               size_t varint_size,
-                               cass_int32_t scale){
-	throw std::runtime_error("UNIMPLEMENTED cass_collection_append_decimal\n");
-}
 CASS_EXPORT const CassValue*
 cass_column_meta_field_by_name(const CassColumnMeta* column_meta,
                                const char* name){

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -411,11 +411,3 @@ cass_user_type_set_custom_by_name(CassUserType* user_type,
                                   size_t value_size){
 	throw std::runtime_error("UNIMPLEMENTED cass_user_type_set_custom_by_name\n");
 }
-CASS_EXPORT CassError
-cass_user_type_set_decimal_by_name(CassUserType* user_type,
-                                   const char* name,
-                                   const cass_byte_t* varint,
-                                   size_t varint_size,
-                                   int scale){
-	throw std::runtime_error("UNIMPLEMENTED cass_user_type_set_decimal_by_name\n");
-}


### PR DESCRIPTION
This PR implements following set of API functions related to `decimal/varint` types:

- cass_statement_bind_decimal_*
- cass_user_type_set_decimal_*
- cass_tuple_set_decimal
- cass_value_get_decimal
- cass_value_is_decimal
- cass_collection_append_decimal

The other way (I think it's preferred, looking at the integration tests) to bind `varint` values is treating them as bytes (i.e. cass_statement_bind_bytes). The only thing that is missing is to implement `cass_value_get_bytes`'s support for varint type. This PR does that as well. Thanks to this, we can enable both decimal and varint integration test cases.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.