### PR TITLE
future: cass future wait timed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,8 @@ run-test-integration-scylla: build-integration-test-bin
 endif
 	@echo "Running integration tests on scylla ${SCYLLA_VERSION}"
 	valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite build/cassandra-integration-tests --scylla --version=${SCYLLA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${SCYLLA_TEST_FILTER}"
+	@echo "Running timeout sensitive tests on scylla ${SCYLLA_VERSION}"
+	build/cassandra-integration-tests --scylla --version=${SCYLLA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="AsyncTests.Integration_Cassandra_Simple"
 
 run-test-integration-cassandra: prepare-integration-test download-ccm-cassandra-image install-java8-if-missing
 ifdef DONT_REBUILD_INTEGRATION_BIN
@@ -197,6 +199,8 @@ run-test-integration-cassandra: build-integration-test-bin
 endif
 	@echo "Running integration tests on cassandra ${CASSANDRA_VERSION}"
 	valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite build/cassandra-integration-tests --version=${CASSANDRA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${CASSANDRA_TEST_FILTER}"
+	@echo "Running timeout sensitive tests on cassandra ${CASSANDRA_VERSION}"
+	build/cassandra-integration-tests --version=${CASSANDRA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="AsyncTests.Integration_Cassandra_Simple"
 
 run-test-unit: install-cargo-if-missing _update-rust-tooling
 	@cd ${CURRENT_DIR}/scylla-rust-wrapper; cargo test

--- a/README.md
+++ b/README.md
@@ -166,11 +166,8 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
             <td colspan=2 align="center" style="font-weight:bold">Future</td>
         </tr>
         <tr>
-            <td>cass_future_wait_timed</td>
-            <td rowspan="3">Unimplemented</td>
-        </tr>
-        <tr>
             <td>cass_future_coordinator</td>
+            <td>Unimplemented</td>
         </tr>
         <tr>
             <td colspan=2 align="center" style="font-weight:bold">Collection</td>

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1064,6 +1064,7 @@ dependencies = [
  "assert_matches",
  "bindgen",
  "chrono",
+ "futures",
  "lazy_static",
  "libc",
  "machine-uid",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -25,6 +25,7 @@ openssl-sys = "0.9.75"
 openssl = "0.10.32"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing = "0.1.37"
+futures = "0.3"
 
 [build-dependencies]
 bindgen = "0.65"

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -412,10 +412,14 @@ pub unsafe extern "C" fn cass_future_tracing_id(
 
 #[cfg(test)]
 mod tests {
-    use crate::testing::assert_cass_future_error_message_eq;
+    use crate::testing::{assert_cass_error_eq, assert_cass_future_error_message_eq};
 
     use super::*;
-    use std::{os::raw::c_char, thread, time::Duration};
+    use std::{
+        os::raw::c_char,
+        thread::{self},
+        time::Duration,
+    };
 
     // This is not a particularly smart test, but if some thread is granted access the value
     // before it is truly computed, then weird things should happen, even a segfault.
@@ -473,6 +477,99 @@ mod tests {
             assert_cass_future_error_message_eq!(cass_fut, Some(ERROR_MSG));
 
             cass_future_free(cass_fut);
+        }
+    }
+
+    // This test checks whether the future callback is executed correctly when:
+    // - a future is awaited indefinitely
+    // - a future is awaited, after the timeout appeared (_wait_timed)
+    // - a future is not awaited. We simply sleep, and let the tokio runtime resolve
+    //   the future, and execute its callback
+    #[test]
+    #[ntest::timeout(600)]
+    fn test_cass_future_callback() {
+        unsafe {
+            const ERROR_MSG: &str = "NOBODY EXPECTED SPANISH INQUISITION";
+            const HUNDRED_MILLIS_IN_MICROS: u64 = 100 * 1000;
+
+            let create_future_and_flag = || {
+                unsafe extern "C" fn mark_flag_cb(_fut: *const CassFuture, data: *mut c_void) {
+                    let flag = data as *mut bool;
+                    *flag = true;
+                }
+
+                let fut = async move {
+                    tokio::time::sleep(Duration::from_micros(HUNDRED_MILLIS_IN_MICROS)).await;
+                    Err((CassError::CASS_OK, ERROR_MSG.into()))
+                };
+                let cass_fut = CassFuture::make_raw(fut);
+                let flag = Box::new(false);
+                let flag_ptr = Box::into_raw(flag);
+
+                assert_cass_error_eq!(
+                    cass_future_set_callback(cass_fut, Some(mark_flag_cb), flag_ptr as *mut c_void),
+                    CassError::CASS_OK
+                );
+
+                (cass_fut, flag_ptr)
+            };
+
+            // Callback executed after awaiting.
+            {
+                let (cass_fut, flag_ptr) = create_future_and_flag();
+                cass_future_wait(cass_fut);
+
+                assert_cass_future_error_message_eq!(cass_fut, Some(ERROR_MSG));
+                assert!(*flag_ptr);
+
+                cass_future_free(cass_fut);
+                let _ = Box::from_raw(flag_ptr);
+            }
+
+            // Future awaited via `assert_cass_future_error_message_eq`.
+            {
+                let (cass_fut, flag_ptr) = create_future_and_flag();
+
+                assert_cass_future_error_message_eq!(cass_fut, Some(ERROR_MSG));
+                assert!(*flag_ptr);
+
+                cass_future_free(cass_fut);
+                let _ = Box::from_raw(flag_ptr);
+            }
+
+            // Callback executed after timeouts.
+            {
+                let (cass_fut, flag_ptr) = create_future_and_flag();
+
+                // This should timeout on tokio::time::timeout.
+                let timed_result = cass_future_wait_timed(cass_fut, HUNDRED_MILLIS_IN_MICROS / 5);
+                assert_eq!(0, timed_result);
+                // This should timeout as well.
+                let timed_result = cass_future_wait_timed(cass_fut, HUNDRED_MILLIS_IN_MICROS / 5);
+                assert_eq!(0, timed_result);
+
+                // Await and check result.
+                assert_cass_future_error_message_eq!(cass_fut, Some(ERROR_MSG));
+                assert!(*flag_ptr);
+
+                cass_future_free(cass_fut);
+                let _ = Box::from_raw(flag_ptr);
+            }
+
+            // Don't await the future. Just sleep.
+            {
+                let (cass_fut, flag_ptr) = create_future_and_flag();
+
+                RUNTIME.block_on(async {
+                    tokio::time::sleep(Duration::from_micros(HUNDRED_MILLIS_IN_MICROS + 10 * 1000))
+                        .await
+                });
+
+                assert!(*flag_ptr);
+
+                cass_future_free(cass_fut);
+                let _ = Box::from_raw(flag_ptr);
+            }
         }
     }
 }

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -270,6 +270,8 @@ pub unsafe extern "C" fn cass_future_tracing_id(
 
 #[cfg(test)]
 mod tests {
+    use crate::testing::assert_cass_future_error_message_eq;
+
     use super::*;
     use std::{os::raw::c_char, thread, time::Duration};
 
@@ -293,17 +295,11 @@ mod tests {
         unsafe {
             let handle = thread::spawn(move || {
                 let wrapper = wrapped_cass_fut;
-                let cass_fut = wrapper.0;
-                let mut message: *const c_char = std::ptr::null();
-                let mut msg_len: size_t = 0;
-                cass_future_error_message(cass_fut, &mut message, &mut msg_len);
-                assert_eq!(ptr_to_cstr_n(message, msg_len), Some(ERROR_MSG));
+                let PtrWrapper(cass_fut) = wrapper;
+                assert_cass_future_error_message_eq!(cass_fut, Some(ERROR_MSG));
             });
 
-            let mut message: *const c_char = std::ptr::null();
-            let mut msg_len: size_t = 0;
-            cass_future_error_message(cass_fut, &mut message, &mut msg_len);
-            assert_eq!(ptr_to_cstr_n(message, msg_len), Some(ERROR_MSG));
+            assert_cass_future_error_message_eq!(cass_fut, Some(ERROR_MSG));
 
             handle.join().unwrap();
             cass_future_free(cass_fut);

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -108,7 +108,7 @@ impl CassFuture {
         self.with_waited_state(|s| f(s.value.as_mut().unwrap()))
     }
 
-    pub(self) fn with_waited_state<T>(&self, f: impl FnOnce(&mut CassFutureState) -> T) -> T {
+    fn with_waited_state<T>(&self, f: impl FnOnce(&mut CassFutureState) -> T) -> T {
         let mut guard = self.state.lock().unwrap();
         let handle = guard.join_handle.take();
         if let Some(handle) = handle {

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -13,6 +13,7 @@ use std::mem;
 use std::os::raw::c_void;
 use std::sync::{Arc, Condvar, Mutex};
 use tokio::task::JoinHandle;
+use tokio::time::Duration;
 
 pub enum CassResultValue {
     Empty,
@@ -56,6 +57,11 @@ struct CassFutureState {
 pub struct CassFuture {
     state: Mutex<CassFutureState>,
     wait_for_value: Condvar,
+}
+
+/// An error that can appear during `cass_future_wait_timed`.
+enum FutureError {
+    TimeoutError,
 }
 
 impl CassFuture {
@@ -113,15 +119,58 @@ impl CassFuture {
         let handle = guard.join_handle.take();
         if let Some(handle) = handle {
             mem::drop(guard);
+            // unwrap: JoinError appears only when future either panic'ed or canceled.
             RUNTIME.block_on(handle).unwrap();
             guard = self.state.lock().unwrap();
         } else {
             guard = self
                 .wait_for_value
                 .wait_while(guard, |state| state.value.is_none())
+                // unwrap: Error appears only when mutex is poisoned.
                 .unwrap();
         }
         f(&mut guard)
+    }
+
+    fn with_waited_result_timed<T>(
+        &self,
+        f: impl FnOnce(&mut CassFutureResult) -> T,
+        timeout_duration: Duration,
+    ) -> Result<T, FutureError> {
+        self.with_waited_state_timed(|s| f(s.value.as_mut().unwrap()), timeout_duration)
+    }
+
+    fn with_waited_state_timed<T>(
+        &self,
+        f: impl FnOnce(&mut CassFutureState) -> T,
+        timeout_duration: Duration,
+    ) -> Result<T, FutureError> {
+        let mut guard = self.state.lock().unwrap();
+        let handle = guard.join_handle.take();
+        if let Some(handle) = handle {
+            mem::drop(guard);
+            // Need to wrap it with async{} block, so the timeout is lazily executed inside the runtime.
+            // See mention about panics: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html.
+            let timed = async { tokio::time::timeout(timeout_duration, handle).await };
+            // unwrap: JoinError appears only when future either panic'ed or canceled.
+            RUNTIME
+                .block_on(timed)
+                .map_err(|_| FutureError::TimeoutError)?
+                .unwrap();
+            guard = self.state.lock().unwrap();
+        } else {
+            let (guard_result, timeout_result) = self
+                .wait_for_value
+                .wait_timeout_while(guard, timeout_duration, |state| state.value.is_none())
+                // unwrap: Error appears only when mutex is poisoned.
+                .unwrap();
+            if timeout_result.timed_out() {
+                return Err(FutureError::TimeoutError);
+            }
+            guard = guard_result;
+        }
+
+        Ok(f(&mut guard))
     }
 
     pub fn set_callback(&self, cb: CassFutureCallback, data: *mut c_void) -> CassError {
@@ -165,6 +214,16 @@ pub unsafe extern "C" fn cass_future_set_callback(
 #[no_mangle]
 pub unsafe extern "C" fn cass_future_wait(future_raw: *const CassFuture) {
     ptr_to_ref(future_raw).with_waited_result(|_| ());
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_future_wait_timed(
+    future_raw: *const CassFuture,
+    timeout_us: cass_duration_t,
+) -> cass_bool_t {
+    ptr_to_ref(future_raw)
+        .with_waited_result_timed(|_| (), Duration::from_micros(timeout_us))
+        .is_ok() as cass_bool_t
 }
 
 #[no_mangle]
@@ -302,6 +361,34 @@ mod tests {
             assert_cass_future_error_message_eq!(cass_fut, Some(ERROR_MSG));
 
             handle.join().unwrap();
+            cass_future_free(cass_fut);
+        }
+    }
+
+    // This test makes sure that the future resolves even if timeout happens.
+    #[test]
+    #[ntest::timeout(200)]
+    fn cass_future_resolves_after_timeout() {
+        const ERROR_MSG: &str = "NOBODY EXPECTED SPANISH INQUISITION";
+        const HUNDRED_MILLIS_IN_MICROS: u64 = 100 * 1000;
+        let fut = async move {
+            tokio::time::sleep(Duration::from_micros(HUNDRED_MILLIS_IN_MICROS)).await;
+            Err((CassError::CASS_OK, ERROR_MSG.into()))
+        };
+        let cass_fut = CassFuture::make_raw(fut);
+
+        unsafe {
+            // This should timeout on tokio::time::timeout.
+            let timed_result = cass_future_wait_timed(cass_fut, HUNDRED_MILLIS_IN_MICROS / 5);
+            assert_eq!(0, timed_result);
+
+            // This should timeout as well.
+            let timed_result = cass_future_wait_timed(cass_fut, HUNDRED_MILLIS_IN_MICROS / 5);
+            assert_eq!(0, timed_result);
+
+            // Verify that future eventually resolves, even though timeouts occurred before.
+            assert_cass_future_error_message_eq!(cass_fut, Some(ERROR_MSG));
+
             cass_future_free(cass_fut);
         }
     }

--- a/scylla-rust-wrapper/src/testing.rs
+++ b/scylla-rust-wrapper/src/testing.rs
@@ -13,3 +13,16 @@ macro_rules! assert_cass_error_eq {
     }};
 }
 pub(crate) use assert_cass_error_eq;
+
+macro_rules! assert_cass_future_error_message_eq {
+    ($cass_fut:ident, $error_msg_opt:expr) => {
+        use crate::argconv::ptr_to_cstr_n;
+        use crate::future::cass_future_error_message;
+
+        let mut ___message: *const c_char = ::std::ptr::null();
+        let mut ___msg_len: size_t = 0;
+        cass_future_error_message($cass_fut, &mut ___message, &mut ___msg_len);
+        assert_eq!(ptr_to_cstr_n(___message, ___msg_len), $error_msg_opt);
+    };
+}
+pub(crate) use assert_cass_future_error_message_eq;

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -246,11 +246,6 @@ CASS_EXPORT const CassNode*
 cass_future_coordinator(CassFuture* future){
 	throw std::runtime_error("UNIMPLEMENTED cass_future_coordinator\n");
 }
-CASS_EXPORT cass_bool_t
-cass_future_wait_timed(CassFuture* future,
-                       cass_duration_t timeout_us){
-	throw std::runtime_error("UNIMPLEMENTED cass_future_wait_timed\n");
-}
 CASS_EXPORT const CassValue*
 cass_index_meta_field_by_name(const CassIndexMeta* index_meta,
                                const char* name){


### PR DESCRIPTION
ref: https://github.com/scylladb/cpp-rust-driver/issues/42

This PR implements a `cass_future_wait_timed` API function which allows to wait for a future to resolve within a given period of time.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.