### PR TITLE
exec_profile: set no speculative execution

### DIFF
--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -249,6 +249,17 @@ pub unsafe extern "C" fn cass_execution_profile_set_consistency(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_no_speculative_execution_policy(
+    profile: *mut CassExecProfile,
+) -> CassError {
+    let profile_builder = ptr_to_ref_mut(profile);
+
+    profile_builder.modify_in_place(|builder| builder.speculative_execution_policy(None));
+
+    CassError::CASS_OK
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn cass_execution_profile_set_constant_speculative_execution_policy(
     profile: *mut CassExecProfile,
     constant_delay_ms: cass_int64_t,


### PR DESCRIPTION
Implemented `cass_execution_profile_set_no_speculative_execution_policy`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~