### PR TITLE
cluster: global request client timeout

### DIFF
--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -115,9 +115,12 @@ pub fn build_session_builder(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
-    // According to `cassandra.h` the default CPP driver's consistency for statements is LOCAL_ONE.
-    let default_execution_profile_builder =
-        ExecutionProfileBuilder::default().consistency(Consistency::LocalOne);
+    // According to `cassandra.h` the default CPP driver's
+    // - consistency for statements is LOCAL_ONE,
+    // - request client timeout is 12000 millis.
+    let default_execution_profile_builder = ExecutionProfileBuilder::default()
+        .consistency(Consistency::LocalOne)
+        .request_timeout(Some(Duration::from_millis(12000)));
 
     Box::into_raw(Box::new(CassCluster {
         session_builder: SessionBuilder::new(),

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -225,6 +225,19 @@ pub unsafe extern "C" fn cass_cluster_set_connect_timeout(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_request_timeout(
+    cluster_raw: *mut CassCluster,
+    timeout_ms: c_uint,
+) {
+    let cluster = ptr_to_ref_mut(cluster_raw);
+
+    exec_profile_builder_modify(&mut cluster.default_execution_profile_builder, |builder| {
+        // 0 -> no timeout
+        builder.request_timeout((timeout_ms > 0).then(|| Duration::from_millis(timeout_ms.into())))
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_port(
     cluster_raw: *mut CassCluster,
     port: c_int,

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -26,6 +26,12 @@ use std::time::Duration;
 
 include!(concat!(env!("OUT_DIR"), "/cppdriver_compression_types.rs"));
 
+// According to `cassandra.h` the default CPP driver's
+// - consistency for statements is LOCAL_ONE,
+// - request client timeout is 12000 millis.
+const DEFAULT_CONSISTENCY: Consistency = Consistency::LocalOne;
+const DEFAULT_REQUEST_TIMEOUT_MILLIS: u64 = 12000;
+
 #[derive(Clone, Debug)]
 pub(crate) struct LoadBalancingConfig {
     pub(crate) token_awareness_enabled: bool,
@@ -115,12 +121,9 @@ pub fn build_session_builder(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
-    // According to `cassandra.h` the default CPP driver's
-    // - consistency for statements is LOCAL_ONE,
-    // - request client timeout is 12000 millis.
     let default_execution_profile_builder = ExecutionProfileBuilder::default()
-        .consistency(Consistency::LocalOne)
-        .request_timeout(Some(Duration::from_millis(12000)));
+        .consistency(DEFAULT_CONSISTENCY)
+        .request_timeout(Some(Duration::from_millis(DEFAULT_REQUEST_TIMEOUT_MILLIS)));
 
     Box::into_raw(Box::new(CassCluster {
         session_builder: SessionBuilder::new(),

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -131,11 +131,6 @@ cass_cluster_set_prepare_on_up_or_add_host(CassCluster* cluster,
 	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_prepare_on_up_or_add_host\n");
 }
 CASS_EXPORT void
-cass_cluster_set_request_timeout(CassCluster* cluster,
-                                 unsigned timeout_ms){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_request_timeout\n");
-}
-CASS_EXPORT void
 cass_cluster_set_retry_policy(CassCluster* cluster,
                               CassRetryPolicy* retry_policy){
 	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_retry_policy\n");


### PR DESCRIPTION
This PR implements `cass_cluster_set_request_timeout`.

In addition, it adjusts the default request client timeout, according to documentation in `cassandra.h`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~