### PR TITLE
ci: fix skipped tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,8 @@ jobs:
 :CompressionTests.*\
 :LoggingTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
-:ExecutionProfileTest.InvalidName"
+:ExecutionProfileTest.InvalidName\
+:*NoCompactEnabledConnection"
       run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --scylla --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
 
     - name: Upload test logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       working-directory: ./scylla-rust-wrapper
       run: cargo test
 
-    - name: Run integration tests on Scylla 5.0.0
+    - name: Run integration tests on Scylla 6.0.0
       env:
 #        Ignored tests are added in the end, after the "-" sign.
         Tests: "ClusterTests.*\
@@ -53,7 +53,7 @@ jobs:
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :ExecutionProfileTest.InvalidName\
 :*NoCompactEnabledConnection"
-      run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --scylla --version=release:5.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
+      run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --scylla --version=release:6.0.0 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
 
     - name: Upload test logs
       uses: actions/upload-artifact@v3

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -53,7 +53,6 @@ jobs:
 :LoggingTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
-:*7.Integration_Cassandra_*\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
 :ExecutionProfileTest.InvalidName\
 :*NoCompactEnabledConnection"

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -55,7 +55,8 @@ jobs:
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :*7.Integration_Cassandra_*\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
-:ExecutionProfileTest.InvalidName"
+:ExecutionProfileTest.InvalidName\
+:*NoCompactEnabledConnection"
         run: valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite ./cassandra-integration-tests --version=4.0.7 --category=CASSANDRA --verbose=ccm --gtest_filter="$Tests"
 
       - name: Upload test logs

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -299,6 +299,7 @@ pub fn get_column_type(column_type: &ColumnType) -> CassDataType {
         ColumnType::Text => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_TEXT),
         ColumnType::Timestamp => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_TIMESTAMP),
         ColumnType::Inet => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_INET),
+        ColumnType::Duration => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_DURATION),
         ColumnType::List(boxed_type) => CassDataType::List {
             typ: Some(Arc::new(get_column_type(boxed_type.as_ref()))),
             frozen: false,
@@ -336,7 +337,6 @@ pub fn get_column_type(column_type: &ColumnType) -> CassDataType {
         ),
         ColumnType::Uuid => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_UUID),
         ColumnType::Varint => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_VARINT),
-        _ => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_UNKNOWN),
     }
 }
 

--- a/tests/src/integration/ccm/bridge.cpp
+++ b/tests/src/integration/ccm/bridge.cpp
@@ -849,7 +849,20 @@ CassVersion CCM::Bridge::get_cassandra_version() {
   // Get the version string from CCM
   std::vector<std::string> active_cluster_version_command;
   active_cluster_version_command.push_back(generate_node_name(1));
+
+  if (is_scylla_) {
+    // For scylla, we need to use `versionfrombuild`. `version` always returns 3.0.8.
+    active_cluster_version_command.push_back("versionfrombuild");
+
+    std::string ccm_output = execute_ccm_command(active_cluster_version_command);
+
+    // versionfrombuild returns a version directly
+    return CassVersion(ccm_output);
+  }
+
+  // Use `version` command for Cassandra.
   active_cluster_version_command.push_back("version");
+
   std::string ccm_output = execute_ccm_command(active_cluster_version_command);
 
   // Ensure the version release information exists and return the version
@@ -861,7 +874,7 @@ CassVersion CCM::Bridge::get_cassandra_version() {
 
   // Unable to determine version information from active cluster
   throw BridgeException("Unable to determine version information from active Cassandra cluster \"" +
-                        get_active_cluster() + "\"");
+                  get_active_cluster() + "\"");
 }
 
 DseVersion CCM::Bridge::get_dse_version() {

--- a/tests/src/integration/ccm/cass_version.hpp
+++ b/tests/src/integration/ccm/cass_version.hpp
@@ -281,7 +281,7 @@ private:
     std::string scylla_version_prefix = "release:";
     std::string version(version_string);
     if (version.compare(0, scylla_version_prefix.size(), scylla_version_prefix) == 0) {
-      version = "3.0.8";
+      version.replace(0, scylla_version_prefix.size(), "");
     }
     std::replace(version.begin(), version.end(), '.', ' ');
     std::size_t found = version.find("-");

--- a/tests/src/integration/integration.hpp
+++ b/tests/src/integration/integration.hpp
@@ -83,28 +83,28 @@
   SKIP_TEST("Unsupported for Apache Cassandra Version "          \
             << server_version_string << ": Server version " << version_string << "+ is required")
 
-#define CHECK_VERSION(version)                                                      \
+// Currently, we only check for the version if tests are being run against
+// Cassandra cluster. It's because, some of the tests were unnecessarily
+// skipped for Scylla. In the future (once it's needed) we might
+// do some version restrictions for Scylla clusters as well.
+#define SKIP_IF_CASSANDRA_VERSION_LT(version)                                                      \
   do {                                                                              \
     CCM::CassVersion cass_version = this->server_version_;                          \
     if (!Options::is_cassandra()) {                                                 \
       cass_version = static_cast<CCM::DseVersion>(cass_version).get_cass_version(); \
     }                                                                               \
-    if (cass_version < #version) {                                                  \
+    if (!Options::is_scylla() && cass_version < #version) {                                                  \
       SKIP_TEST_VERSION(cass_version.to_string(), #version)                         \
     }                                                                               \
   } while (0)
 
-#define CHECK_OPTIONS_VERSION(version)                                 \
-  if (Options::server_version() < #version) {                          \
-    SKIP_TEST_VERSION(Options::server_version().to_string(), #version) \
-  }
 
-#define CHECK_VALUE_TYPE_VERSION(type)                                            \
+#define CHECK_VALUE_TYPE_CASSANDRA_VERSION(type)                                            \
   CCM::CassVersion cass_version = this->server_version_;                          \
   if (!Options::is_cassandra()) {                                                 \
     cass_version = static_cast<CCM::DseVersion>(cass_version).get_cass_version(); \
   }                                                                               \
-  if (cass_version < type::supported_server_version()) {                          \
+  if (!Options::is_scylla() && cass_version < type::supported_server_version()) {                          \
     SKIP_TEST_VERSION(cass_version.to_string(), type::supported_server_version()) \
   }
 

--- a/tests/src/integration/objects/collection.hpp
+++ b/tests/src/integration/objects/collection.hpp
@@ -194,15 +194,17 @@ protected:
       } else {
         FAIL() << "Invalid CassValueType: Value type is not a valid collection";
       }
+  
+      // Check if collection is empty (null).
+      // Scylla does not distinguish between an empty collection and NULL value.
+      // See: https://opensource.docs.scylladb.com/stable/cql/types.html#sets
+      size_t collection_size = cass_value_item_count(value);
+      if (collection_size > 0) {
+        is_null_ = false;
+      }
 
       // Initialize the iterator
       iterator_ = cass_iterator_from_collection(value);
-
-      // Determine if the collection is empty (null)
-      const CassValue* check_value = cass_iterator_get_value(iterator_.get());
-      if (check_value) {
-        is_null_ = false;
-      }
     }
   }
 };

--- a/tests/src/integration/tests/test_basics.cpp
+++ b/tests/src/integration/tests/test_basics.cpp
@@ -331,8 +331,8 @@ CASSANDRA_INTEGRATION_TEST_F(BasicsTests, BindBlobAsString) {
  */
 CASSANDRA_INTEGRATION_TEST_F(BasicsTests, NoCompactEnabledConnection) {
   CHECK_FAILURE;
-  CHECK_VERSION(3.0.16);
-  CHECK_VERSION(3.11.2);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.0.16);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.11.2);
   CCM::CassVersion cass_version = server_version_;
   if (!Options::is_cassandra()) {
     if (server_version_ >= "6.0.0") {

--- a/tests/src/integration/tests/test_basics.cpp
+++ b/tests/src/integration/tests/test_basics.cpp
@@ -343,7 +343,7 @@ CASSANDRA_INTEGRATION_TEST_F(BasicsTests, NoCompactEnabledConnection) {
     }
     cass_version = static_cast<CCM::DseVersion>(cass_version).get_cass_version();
   }
-  if (cass_version >= "4.0.0") {
+  if (!Options::is_scylla() && cass_version >= "4.0.0") {
     SKIP_TEST("Unsupported for Apache Cassandra Version "
               << cass_version.to_string()
               << ": Server version must be less than v4.0.0 and either 3.0.16+"

--- a/tests/src/integration/tests/test_by_name.cpp
+++ b/tests/src/integration/tests/test_by_name.cpp
@@ -261,7 +261,7 @@ CASSANDRA_INTEGRATION_TEST_F(ByNameTests, PreparedCaseSensitive) {
  */
 CASSANDRA_INTEGRATION_TEST_F(ByNameTests, SimpleCaseSensitive) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
 
   // Prepare, create, insert and validate
   Statement statement(format_string(INSERT_CASE_SENSITIVE_FORMAT, table_name_.c_str()), 4);
@@ -391,7 +391,7 @@ CASSANDRA_INTEGRATION_TEST_F(ByNameTests, NullPrepared) {
  */
 CASSANDRA_INTEGRATION_TEST_F(ByNameTests, NullSimple) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
 
   // Prepare, create, insert and validate
   Statement statement(format_string(INSERT_ALL_FORMAT, table_name_.c_str()), 7);

--- a/tests/src/integration/tests/test_cassandra_types.cpp
+++ b/tests/src/integration/tests/test_cassandra_types.cpp
@@ -111,7 +111,7 @@ class CassandraTypesDurationTests : public CassandraTypesTests<Duration> {};
  * @expected_result Cassandra values are inserted and validated
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Basic) {
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   this->default_setup();
   const std::vector<TypeParam>& values = CassandraTypesTests<TypeParam>::values_;
@@ -168,7 +168,7 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Basic) {
  * @expected_result Cassandra values are inserted and validated
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, ByName) {
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   this->default_setup();
   const std::vector<TypeParam>& values = CassandraTypesTests<TypeParam>::values_;
@@ -225,8 +225,8 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, ByName) {
  * @expected_result Cassandra values are inserted and validated
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, NamedParameters) {
-  CHECK_VERSION(2.1.0);
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   this->default_setup(true);
   const std::vector<TypeParam>& values = CassandraTypesTests<TypeParam>::values_;
@@ -281,7 +281,7 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, NamedParameters) {
  * @expected_result Cassandra NULL values are inserted and validated
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, NullValues) {
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   this->is_key_allowed_ = false; // Ensure the TypeParam is not allowed as a key
   this->default_setup();
@@ -324,7 +324,7 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, NullValues) {
  * @expected_result Cassandra NULL values are inserted and validated
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, NullList) {
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   this->is_key_allowed_ = false; // Ensure the TypeParam is not allowed as a key
   this->default_setup();
@@ -368,7 +368,7 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, NullList) {
  * @expected_result Cassandra NULL values are inserted and validated
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, NullMap) {
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   this->is_key_allowed_ = false; // Ensure the TypeParam is not allowed as a key
   this->default_setup();
@@ -412,7 +412,7 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, NullMap) {
  * @expected_result Cassandra NULL values are inserted and validated
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, NullSet) {
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   this->is_key_allowed_ = false; // Ensure the TypeParam is not allowed as a key
   this->default_setup();
@@ -457,7 +457,7 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, NullSet) {
  *                  validated via simple and prepared statement operations
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, List) {
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   // Initialize the table and assign the values for the list
   List<TypeParam> list(CassandraTypesTests<TypeParam>::values_);
@@ -529,7 +529,7 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, List) {
  *                  via simple and prepared statement operations
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Set) {
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
   if (CassandraTypesTests<TypeParam>::values_[0].cql_type().compare("duration") == 0) {
     SKIP_TEST("Unsupported CQL Type Duration: Set does not support duration");
   }
@@ -604,7 +604,7 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Set) {
  *                  via simple and prepared statement operations
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Map) {
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   // TODO(fero): Move this into its own parameterized method or keep this branching?
   if (this->is_key_allowed_) {
@@ -714,8 +714,8 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Map) {
  *                  validated via simple and prepared statement operations
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Tuple) {
-  CHECK_VERSION(2.1.0);
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   // Initialize the table and assign the values for the tuple
   const std::vector<TypeParam>& values = CassandraTypesTests<TypeParam>::values_;
@@ -792,8 +792,8 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Tuple) {
  *                  then validated via simple and prepared statement operations
  */
 CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, UDT) {
-  CHECK_VERSION(2.2.0);
-  CHECK_VALUE_TYPE_VERSION(TypeParam);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(TypeParam);
 
   // Build the UDT type name e.g. udt_pointtype, udt_line_string, etc.
   const std::vector<TypeParam>& values = CassandraTypesTests<TypeParam>::values_;
@@ -905,7 +905,7 @@ REGISTER_TYPED_TEST_CASE_P(CassandraTypesTests, Integration_Cassandra_Basic,
  */
 CASSANDRA_INTEGRATION_TEST_F(CassandraTypesDurationTests, MixedValues) {
   CHECK_FAILURE;
-  CHECK_VALUE_TYPE_VERSION(Duration);
+  CHECK_VALUE_TYPE_CASSANDRA_VERSION(Duration);
 
   this->default_setup();
 

--- a/tests/src/integration/tests/test_cassandra_types.cpp
+++ b/tests/src/integration/tests/test_cassandra_types.cpp
@@ -488,29 +488,8 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, List) {
     }
     Result result = this->session_.execute(select_statement);
     ASSERT_EQ(1u, result.row_count());
-//    List<TypeParam> result_list(result.first_row().next().as<List<TypeParam> >());
-//    ASSERT_EQ(list.value(), result_list.value());
-    const CassValue *result_list(result.first_row().next().get_value());
-
-    bool is_collection = cass_value_is_collection(result_list);
-    EXPECT_TRUE(is_collection);
-
-    size_t collection_size = cass_value_item_count(result_list);
-    ASSERT_EQ(list.size(), collection_size);
-
-    CassIterator* collection_iterator = cass_iterator_from_collection(result_list);
-    std::vector<TypeParam> list_vector = list.value();
-
-    for (size_t j = 0; j < collection_size; ++j) {
-      if (cass_iterator_next(collection_iterator)) {
-        TypeParam value = TypeParam(cass_iterator_get_value(collection_iterator));
-        ASSERT_EQ(value, list_vector[j]);
-      } else {
-        throw Exception("No more values available");
-      }
-    }
-
-    cass_iterator_free(collection_iterator);
+    List<TypeParam> result_list(result.first_row().next().as<List<TypeParam> >());
+    ASSERT_EQ(list.value(), result_list.value());
   }
 }
 
@@ -563,29 +542,8 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Set) {
     }
     Result result = this->session_.execute(select_statement);
     ASSERT_EQ(1u, result.row_count());
-//    Set<TypeParam> result_set = result.first_row().next().as<Set<TypeParam> >();
-//    ASSERT_EQ(set.value(), result_set.value());
-    const CassValue *result_set(result.first_row().next().get_value());
-
-    bool is_collection = cass_value_is_collection(result_set);
-    EXPECT_TRUE(is_collection);
-
-    size_t collection_size = cass_value_item_count(result_set);
-    ASSERT_EQ(set.size(), collection_size);
-
-    CassIterator* collection_iterator = cass_iterator_from_collection(result_set);
-    std::set<TypeParam> set_elems = set.value();
-
-    for (size_t j = 0; j < collection_size; ++j) {
-      if (cass_iterator_next(collection_iterator)) {
-        TypeParam value = TypeParam(cass_iterator_get_value(collection_iterator));
-        EXPECT_TRUE(set_elems.find(value) != set_elems.end());
-      } else {
-        throw Exception("No more values available");
-      }
-    }
-
-    cass_iterator_free(collection_iterator);
+    Set<TypeParam> result_set = result.first_row().next().as<Set<TypeParam> >();
+    ASSERT_EQ(set.value(), result_set.value());
   }
 }
 
@@ -636,30 +594,9 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Map) {
       select_statement.bind<Map<TypeParam, TypeParam> >(0, map);
       Result result = this->session_.execute(select_statement);
       ASSERT_EQ(1u, result.row_count());
-//    Map<TypeParam, TypeParam> result_map(column.as<Map<TypeParam, TypeParam> >());
-//    ASSERT_EQ(map_values, result_map.value());
-      const CassValue *result_map = result.first_row().next().get_value();
-
-      bool is_collection = cass_value_is_collection(result_map);
-      EXPECT_TRUE(is_collection);
-
-      size_t collection_size = cass_value_item_count(result_map);
-      ASSERT_EQ(map.size(), collection_size);
-
-      CassIterator* collection_iterator = cass_iterator_from_collection(result_map);
-      std::map<TypeParam, TypeParam> map_entries = map.value();
-
-      for (size_t j = 0; j < collection_size; ++j) {
-        if (cass_iterator_next(collection_iterator)) {
-          TypeParam key = TypeParam(cass_iterator_get_map_key(collection_iterator));
-          TypeParam value = TypeParam(cass_iterator_get_map_value(collection_iterator));
-          ASSERT_EQ(value, map_entries[key]);
-        } else {
-          throw Exception("No more values available");
-        }
-      }
-
-      cass_iterator_free(collection_iterator);
+      Column column = result.first_row().next();
+      Map<TypeParam, TypeParam> result_map(column.as<Map<TypeParam, TypeParam> >());
+      ASSERT_EQ(map_values, result_map.value());
     }
   } else {
     // Initialize the table and assign the values for the map
@@ -754,25 +691,8 @@ CASSANDRA_INTEGRATION_TYPED_TEST_P(CassandraTypesTests, Tuple) {
     }
     Result result = this->session_.execute(select_statement);
     ASSERT_EQ(1u, result.row_count());
-//    Tuple result_tuple(result.first_row().next().as<Tuple>());
-//    ASSERT_EQ(values, result_tuple.values<TypeParam>());
-    const CassValue *result_tuple(result.first_row().next().get_value());
-
-    size_t collection_size = cass_value_item_count(result_tuple);
-    ASSERT_EQ(tuple.size(), collection_size);
-
-    CassIterator* collection_iterator = cass_iterator_from_tuple(result_tuple);
-
-    for (size_t j = 0; j < collection_size; ++j) {
-      if (cass_iterator_next(collection_iterator)) {
-        TypeParam value = TypeParam(cass_iterator_get_value(collection_iterator));
-        ASSERT_EQ(value, values[j]);
-      } else {
-        throw Exception("No more values available");
-      }
-    }
-
-    cass_iterator_free(collection_iterator);
+    Tuple result_tuple(result.first_row().next().as<Tuple>());
+    ASSERT_EQ(values, result_tuple.values<TypeParam>());
   }
 }
 

--- a/tests/src/integration/tests/test_consistency.cpp
+++ b/tests/src/integration/tests/test_consistency.cpp
@@ -217,7 +217,7 @@ CASSANDRA_INTEGRATION_TEST_F(ConsistencyTwoNodeClusterTests, SimpleLocalQuorum) 
  */
 CASSANDRA_INTEGRATION_TEST_F(ConsistencyTwoNodeClusterTests, SimpleEachQuorum) {
   CHECK_FAILURE;
-  CHECK_VERSION(3.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.0.0);
 
   // Assign the consistency level for the test
   insert_.set_consistency(CASS_CONSISTENCY_EACH_QUORUM);

--- a/tests/src/integration/tests/test_custom_payload.cpp
+++ b/tests/src/integration/tests/test_custom_payload.cpp
@@ -52,7 +52,7 @@ public:
  */
 CASSANDRA_INTEGRATION_TEST_F(CustomPayloadTests, Simple) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
 
   // Create the custom payload to be associated with the statement
   CustomPayload custom_payload;

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -341,7 +341,7 @@ CASSANDRA_INTEGRATION_TEST_F(ExecutionProfileTest, Consistency) {
  * @expected_result Execution profile will fail (invalid serial consistency)
  */
 CASSANDRA_INTEGRATION_TEST_F(ExecutionProfileTest, SerialConsistency) {
-  CHECK_VERSION(2.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.0.0);
   CHECK_FAILURE;
 
   // Execute a batched query with assigned profile (should fail
@@ -658,7 +658,7 @@ CASSANDRA_INTEGRATION_TEST_F(ExecutionProfileTest, RetryPolicy) {
  */
 CASSANDRA_INTEGRATION_TEST_F(ExecutionProfileTest, SpeculativeExecutionPolicy) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
 
   // Create the UDF timeout
   session_.execute("CREATE OR REPLACE FUNCTION timeout(arg int) "

--- a/tests/src/integration/tests/test_metrics.cpp
+++ b/tests/src/integration/tests/test_metrics.cpp
@@ -149,7 +149,7 @@ CASSANDRA_INTEGRATION_TEST_F(MetricsTests, Requests) {
  */
 CASSANDRA_INTEGRATION_TEST_F(MetricsTests, SpeculativeExecutionRequests) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
 
   Session session = default_cluster().with_constant_speculative_execution_policy(100, 10).connect();
 

--- a/tests/src/integration/tests/test_named_parameters.cpp
+++ b/tests/src/integration/tests/test_named_parameters.cpp
@@ -95,7 +95,7 @@ private:
  */
 CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, SimpleStatementInOrder) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
 
   Statement insert_statement = create_insert_statement();
   insert_statement.bind<Integer>("named_key", key_);
@@ -120,7 +120,7 @@ CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, SimpleStatementInOrder) {
  */
 CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, SimpleStatementAnyOrder) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
 
   Statement insert_statement = create_insert_statement();
   insert_statement.bind<Blob>("named_blob", value_blob_);
@@ -145,7 +145,7 @@ CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, SimpleStatementAnyOrder) {
  */
 CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, PreparedStatementInOrder) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
 
   Statement insert_statement = create_insert_statement(true);
   insert_statement.bind<Integer>("named_key", key_);
@@ -170,7 +170,7 @@ CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, PreparedStatementInOrder) {
  */
 CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, PreparedStatementAnyOrder) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
 
   Statement insert_statement = create_insert_statement(true);
   insert_statement.bind<Blob>("named_blob", value_blob_);
@@ -196,7 +196,7 @@ CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, PreparedStatementAnyOrder) {
  */
 CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, SimpleStatementInvalidName) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
 
   Statement insert_statement = create_insert_statement();
   insert_statement.bind<Integer>("invalid_named_key", key_);
@@ -218,7 +218,7 @@ CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, SimpleStatementInvalidName) {
  */
 CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, PreparedStatementInvalidName) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
 
   Statement insert_statement = create_insert_statement(true);
   EXPECT_EQ(

--- a/tests/src/integration/tests/test_null_string_params.cpp
+++ b/tests/src/integration/tests/test_null_string_params.cpp
@@ -58,7 +58,7 @@ public:
 class SchemaNullStringApiArgsTest : public NullStringApiArgsTest {
 public:
   void SetUp() {
-    CHECK_VERSION(2.2.0);
+    SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
     NullStringApiArgsTest::SetUp();
     populateSchema();
     schema_meta_ = session_.schema();
@@ -221,7 +221,7 @@ CASSANDRA_INTEGRATION_TEST_F(NullStringApiArgsTest, PrepareNullQuery) {
  * @expected_result Null for each lookup, since no object has a null name.
  */
 CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, KeyspaceMetaFunctions) {
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   const CassTableMeta* table_meta = cass_keyspace_meta_table_by_name(keyspace_meta_.get(), NULL);
   EXPECT_EQ(NULL, table_meta);
 
@@ -261,7 +261,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, KeyspaceMetaFunctions)
  * @expected_result Null for each lookup, since no object has a null name.
  */
 CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, TableMetaFunctions) {
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   const CassColumnMeta* column_meta = cass_table_meta_column_by_name(table_meta_.get(), NULL);
   EXPECT_EQ(NULL, column_meta);
 
@@ -296,7 +296,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, TableMetaFunctions) {
  * @expected_result Null for each lookup, since no object has a null name.
  */
 CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, MaterializedViewMetaFunctions) {
-  CHECK_VERSION(3.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.0.0);
 
   const CassMaterializedViewMeta* view_meta =
       cass_table_meta_materialized_view_by_name(table_meta_.get(), VIEW_NAME);
@@ -318,7 +318,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, MaterializedViewMetaFu
  * @expected_result Null for each lookup, since no object has a null name.
  */
 CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, FunctionAndAggregateMetaFunctions) {
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   // C* 3.x annotate collection columns as frozen.
   const CassFunctionMeta* function_meta =
       (schema_meta_.version().major_version == 3)
@@ -349,7 +349,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, FunctionAndAggregateMe
  * @expected_result Error out appropriately for invalid queries, succeed otherwise.
  */
 CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, StatementFunctions) {
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   Statement statement(NULL);
 
   statement = cass_statement_new(NULL, 0);
@@ -485,7 +485,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, StatementFunctions) {
  * @expected_result Null because no parameter in the statement has a null name.
  */
 CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, PreparedFunctions) {
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   Prepared prepared = session_.prepare(format_string("INSERT INTO %s (key, value) "
                                                      "VALUES ('42', :v)",
                                                      table_name_.c_str()));
@@ -504,7 +504,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, PreparedFunctions) {
  *   null).
  */
 CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, DataTypeFunctions) {
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   CassDataType* udt = cass_data_type_new(CASS_VALUE_TYPE_UDT);
   EXPECT_EQ(CASS_OK, cass_data_type_set_type_name(udt, NULL));
   EXPECT_EQ(NULL, cass_data_type_sub_data_type_by_name(udt, NULL));
@@ -527,7 +527,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, DataTypeFunctions) {
  * @expected_result Success; null strings are added/encoded in collections fine.
  */
 CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, CollectionFunctions) {
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   CassCollection* collection = cass_collection_new(CASS_COLLECTION_TYPE_SET, 2);
   EXPECT_EQ(CASS_OK, cass_collection_append_string(collection, NULL));
   EXPECT_EQ(CASS_OK, cass_collection_append_custom(collection, NULL,
@@ -550,7 +550,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, CollectionFunctions) {
  *   However, succeed in storing a null value in a udt field.
  */
 CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, UserTypeFunctions) {
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   const CassDataType* udt_address =
       cass_keyspace_meta_user_type_by_name(keyspace_meta_.get(), "address");
   ASSERT_NE(static_cast<CassDataType*>(NULL), udt_address);
@@ -646,7 +646,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, UserTypeFunctions) {
  *   though it will certainly fail when processing on a node.
  */
 // CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, MiscellaneousFunctions) {
-//   CHECK_VERSION(2.2.0);
+//   SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
 //   ResultResponse response;
 //   datastax::internal::core::Row r(&response);
 //   CassRow* row = CassRow::to(&r);

--- a/tests/src/integration/tests/test_prepare_on.cpp
+++ b/tests/src/integration/tests/test_prepare_on.cpp
@@ -25,7 +25,7 @@ class PrepareOn : public Integration {
 public:
   void SetUp() {
     Integration::SetUp();
-    CHECK_VERSION(3.10);
+    SKIP_IF_CASSANDRA_VERSION_LT(3.10);
     sessions_.reserve(number_dc1_nodes_ + 1);
     for (size_t node = 1; node <= number_dc1_nodes_; ++node) {
       truncate_prepared_statements(node);
@@ -186,7 +186,7 @@ private:
  */
 CASSANDRA_INTEGRATION_TEST_F(PrepareOnAllTests, SingleNodeWhenDisabled) {
   CHECK_FAILURE;
-  CHECK_VERSION(3.10);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.10);
 
   // Prepare on all hosts disabled
   Session session = cluster().with_prepare_on_all_hosts(false).connect();
@@ -203,7 +203,7 @@ CASSANDRA_INTEGRATION_TEST_F(PrepareOnAllTests, SingleNodeWhenDisabled) {
  */
 CASSANDRA_INTEGRATION_TEST_F(PrepareOnAllTests, AllNodesWhenEnabled) {
   CHECK_FAILURE;
-  CHECK_VERSION(3.10);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.10);
 
   // Prepare on all hosts enabled
   Session session = cluster().with_prepare_on_all_hosts(true).connect();
@@ -223,7 +223,7 @@ CASSANDRA_INTEGRATION_TEST_F(PrepareOnAllTests, AllNodesWhenEnabled) {
  */
 CASSANDRA_INTEGRATION_TEST_F(PrepareOnAllTests, NodeOutage) {
   CHECK_FAILURE;
-  CHECK_VERSION(3.10);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.10);
 
   // Ensure there are no existing prepared statements
   prepared_statements_is_empty_on_all_nodes();
@@ -346,7 +346,7 @@ private:
  */
 CASSANDRA_INTEGRATION_TEST_F(PrepareOnUpAndAddTests, NotPreparedOnUpWhenDisabled) {
   CHECK_FAILURE;
-  CHECK_VERSION(3.10);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.10);
 
   // Disable the prepare on up/add setting
   Session session = cluster().with_prepare_on_up_or_add_host(false).connect();
@@ -381,7 +381,7 @@ CASSANDRA_INTEGRATION_TEST_F(PrepareOnUpAndAddTests, NotPreparedOnUpWhenDisabled
  */
 CASSANDRA_INTEGRATION_TEST_F(PrepareOnUpAndAddTests, PreparedOnUpWhenEnabled) {
   CHECK_FAILURE;
-  CHECK_VERSION(3.10);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.10);
 
   // Enable the prepare on up/add setting
   Session session = cluster().with_prepare_on_up_or_add_host(true).connect();
@@ -416,7 +416,7 @@ CASSANDRA_INTEGRATION_TEST_F(PrepareOnUpAndAddTests, PreparedOnUpWhenEnabled) {
  */
 CASSANDRA_INTEGRATION_TEST_F(PrepareOnUpAndAddTests, NotPreparedOnAddWhenDisabled) {
   CHECK_FAILURE;
-  CHECK_VERSION(3.10);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.10);
   is_test_chaotic_ = true;
 
   // Disable the prepare on up/add setting
@@ -447,7 +447,7 @@ CASSANDRA_INTEGRATION_TEST_F(PrepareOnUpAndAddTests, NotPreparedOnAddWhenDisable
  */
 CASSANDRA_INTEGRATION_TEST_F(PrepareOnUpAndAddTests, PreparedOnAddWhenEnabled) {
   CHECK_FAILURE;
-  CHECK_VERSION(3.10);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.10);
   is_test_chaotic_ = true;
 
   // Enable the prepare on up/add setting

--- a/tests/src/integration/tests/test_prepared_metadata.cpp
+++ b/tests/src/integration/tests/test_prepared_metadata.cpp
@@ -87,7 +87,7 @@ CASSANDRA_INTEGRATION_TEST_F(PreparedMetadataTests, AlterDoesntUpdateColumnCount
  */
 CASSANDRA_INTEGRATION_TEST_F(PreparedMetadataTests, AlterProperlyUpdatesColumnCount) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   // Ensure protocol v5 or greater
   Session session = default_cluster().with_beta_protocol(true).connect(keyspace_name_);

--- a/tests/src/integration/tests/test_schema_metadata.cpp
+++ b/tests/src/integration/tests/test_schema_metadata.cpp
@@ -25,7 +25,7 @@ public:
   SchemaMetadataTest() { is_schema_metadata_ = true; }
 
   void SetUp() {
-    CHECK_VERSION(2.2.0);
+    SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
     Integration::SetUp();
     populateSchema();
     schema_meta_ = session_.schema();
@@ -87,7 +87,7 @@ protected:
 };
 
 CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, Views) {
-  CHECK_VERSION(3.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.0.0);
   Keyspace keyspace_meta = schema_meta_.keyspace(keyspace_name_);
   Table table_meta = keyspace_meta.table(table_name_);
 
@@ -120,7 +120,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, Views) {
 }
 
 CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, DropView) {
-  CHECK_VERSION(3.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(3.0.0);
   Table table_meta = schema_meta_.keyspace(keyspace_name_).table(table_name_);
 
   // Verify that the table contains the view
@@ -139,7 +139,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, DropView) {
 }
 
 CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, RegularMetadataNotMarkedVirtual) {
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   // Check non-virtual keyspace/table is correctly not set
   Keyspace keyspace_meta = schema_meta_.keyspace("system");
   ASSERT_TRUE(keyspace_meta);
@@ -151,7 +151,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, RegularMetadataNotMarkedVirtual
 }
 
 CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, VirtualMetadata) {
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   // Check virtual keyspace/table is correctly set
   Keyspace keyspace_meta = schema_meta_.keyspace("system_views");

--- a/tests/src/integration/tests/test_server_side_failure.cpp
+++ b/tests/src/integration/tests/test_server_side_failure.cpp
@@ -78,7 +78,7 @@ private:
  */
 CASSANDRA_INTEGRATION_TEST_F(ServerSideFailureTests, Warning) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2);
 
   logger_.add_critera("Server-side warning: Aggregation query used without partition key");
   session_.execute("SELECT sum(gossip_generation) FROM system.local");
@@ -97,7 +97,7 @@ CASSANDRA_INTEGRATION_TEST_F(ServerSideFailureTests, Warning) {
  */
 CASSANDRA_INTEGRATION_TEST_F(ServerSideFailureTests, ErrorFunctionFailure) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2);
 
   // Create the table and associated failing function
   session_.execute("CREATE TABLE server_function_failures (id int PRIMARY KEY, value double)");
@@ -149,7 +149,7 @@ CASSANDRA_INTEGRATION_TEST_F(ServerSideFailureTests, ErrorTableAlreadyExists) {
  */
 CASSANDRA_INTEGRATION_TEST_F(ServerSideFailureTests, ErrorFunctionAlreadyExists) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2);
 
   std::string create_function_query =
       "CREATE FUNCTION already_exists_function(value double) RETURNS NULL ON NULL INPUT "

--- a/tests/src/integration/tests/test_set_keyspace.cpp
+++ b/tests/src/integration/tests/test_set_keyspace.cpp
@@ -175,7 +175,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, QueryNotSupported) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, QueryWithNoSessionKeyspace) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   query_with_keyspace("");
 }
@@ -188,7 +188,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, QueryWithNoSessionKeyspace) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, QueryWithDifferentSessionKeyspace) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   query_with_keyspace(keyspace_name_other());
 }
@@ -201,7 +201,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, QueryWithDifferentSessionKeyspace
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, QueryWithSameSessionKeyspace) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   query_with_keyspace(keyspace_name());
 }
@@ -236,7 +236,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, PreparedNotSupported) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, ReprepareWithSameKeyspace) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   Session session = default_cluster().connect();
 
@@ -265,7 +265,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, ReprepareWithSameKeyspace) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, PreparedWithNoSessionKeyspace) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   prepared_query_with_keyspace("");
 }
@@ -278,7 +278,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, PreparedWithNoSessionKeyspace) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, PreparedWithDifferentSessionKeyspace) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   prepared_query_with_keyspace(keyspace_name_other());
 }
@@ -291,7 +291,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, PreparedWithDifferentSessionKeysp
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, PreparedWithSameSessionKeyspace) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   prepared_query_with_keyspace(keyspace_name());
 }
@@ -306,7 +306,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, PreparedWithSameSessionKeyspace) 
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, BatchWithKeyspaceFromSimple) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   Session session = default_cluster().connect();
 
@@ -333,7 +333,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, BatchWithKeyspaceFromSimple) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, BatchWithKeyspaceFromPrepared) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   Session session = default_cluster().connect();
 
@@ -377,7 +377,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, BatchNotSupported) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, BatchWithNoSessionKeyspace) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   batch_query_with_keyspace("");
 }
@@ -390,7 +390,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, BatchWithNoSessionKeyspace) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, BatchWithDifferentSessionKeyspace) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   batch_query_with_keyspace(keyspace_name_other());
 }
@@ -403,7 +403,7 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, BatchWithDifferentSessionKeyspace
  */
 CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, BatchWithSameSessionKeyspace) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
 
   batch_query_with_keyspace(keyspace_name());
 }

--- a/tests/src/integration/tests/test_speculative_execution.cpp
+++ b/tests/src/integration/tests/test_speculative_execution.cpp
@@ -32,7 +32,7 @@ public:
   SpeculativeExecutionTests() { number_dc1_nodes_ = 3; }
 
   void SetUp() {
-    CHECK_VERSION(2.2.0);
+    SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
     Integration::SetUp();
 
     session_.execute(
@@ -71,7 +71,7 @@ public:
  */
 CASSANDRA_INTEGRATION_TEST_F(SpeculativeExecutionTests, AttemptOnAllNodes) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   Session session =
       default_cluster().with_constant_speculative_execution_policy(100, 2).connect(keyspace_name_);
 
@@ -97,7 +97,7 @@ CASSANDRA_INTEGRATION_TEST_F(SpeculativeExecutionTests, AttemptOnAllNodes) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SpeculativeExecutionTests, LimitToTwoNodes) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   Session session =
       default_cluster().with_constant_speculative_execution_policy(100, 1).connect(keyspace_name_);
 
@@ -123,7 +123,7 @@ CASSANDRA_INTEGRATION_TEST_F(SpeculativeExecutionTests, LimitToTwoNodes) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SpeculativeExecutionTests, DelayIsNotReached) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   Session session =
       default_cluster().with_constant_speculative_execution_policy(5000, 2).connect(keyspace_name_);
 
@@ -144,7 +144,7 @@ CASSANDRA_INTEGRATION_TEST_F(SpeculativeExecutionTests, DelayIsNotReached) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SpeculativeExecutionTests, DisabledByDefault) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   Session session =
       default_cluster().with_constant_speculative_execution_policy(100, 2).connect(keyspace_name_);
 
@@ -170,7 +170,7 @@ CASSANDRA_INTEGRATION_TEST_F(SpeculativeExecutionTests, DisabledByDefault) {
  */
 CASSANDRA_INTEGRATION_TEST_F(SpeculativeExecutionTests, Timeout) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.2.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);
   Session session =
       default_cluster().with_constant_speculative_execution_policy(100, 2).connect(keyspace_name_);
 

--- a/tests/src/integration/tests/test_startup_options.cpp
+++ b/tests/src/integration/tests/test_startup_options.cpp
@@ -36,7 +36,7 @@ class StartupOptionsTests : public Integration {};
  */
 CASSANDRA_INTEGRATION_TEST_F(StartupOptionsTests, DriverOptions) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(4.0.0);
   if (!Options::is_cassandra()) {
     SKIP_TEST("Unsupported for DataStax Enterprise Version "
               << server_version_.to_string() << ": 'system_views.clients' is unavailable");

--- a/tests/src/integration/tests/test_timestamp.cpp
+++ b/tests/src/integration/tests/test_timestamp.cpp
@@ -110,7 +110,7 @@ private:
  */
 CASSANDRA_INTEGRATION_TEST_F(TimestampTests, Statement) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
 
   Text key(generate_key());
   Statement insert_statement(create_insert_statement(key));
@@ -129,7 +129,7 @@ CASSANDRA_INTEGRATION_TEST_F(TimestampTests, Statement) {
  */
 CASSANDRA_INTEGRATION_TEST_F(TimestampTests, BatchStatement) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
 
   Batch batch_statement;
   std::vector<Text> keys;
@@ -155,7 +155,7 @@ CASSANDRA_INTEGRATION_TEST_F(TimestampTests, BatchStatement) {
  */
 CASSANDRA_INTEGRATION_TEST_F(TimestampTests, ServerSideTimestampGeneratorStatement) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
   ServerSideTimestampGenerator generator;
   connect(default_cluster().with_timestamp_generator(generator));
 
@@ -178,7 +178,7 @@ CASSANDRA_INTEGRATION_TEST_F(TimestampTests, ServerSideTimestampGeneratorStateme
  */
 CASSANDRA_INTEGRATION_TEST_F(TimestampTests, ServerSideTimestampGeneratorBatchStatement) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
   ServerSideTimestampGenerator generator;
   connect(default_cluster().with_timestamp_generator(generator));
 
@@ -215,7 +215,7 @@ CASSANDRA_INTEGRATION_TEST_F(TimestampTests, ServerSideTimestampGeneratorBatchSt
  */
 CASSANDRA_INTEGRATION_TEST_F(TimestampTests, MonotonicTimestampGenerator) {
   CHECK_FAILURE;
-  CHECK_VERSION(2.1.0);
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
   connect(default_cluster().with_timestamp_generator(timestamp_generator()));
 
   BigInteger last_timestamp;


### PR DESCRIPTION
Fix: https://github.com/scylladb/cpp-rust-driver/issues/144

This PR addresses multiple issues:
## Skipped tests for scylla clusters
As linked issue mentions, `ccm <node> version` for scylla clusters always returns `3.0.8` version which I believe is hardcoded. Because of that, some tests were unnecessarily skipped. To retrieve scylla version, we should use `ccm <node> versionfrombuild`.

I adjusted the logic for retrieving the Scylla version. Apart from that, I skip the version checks for Scylla, since the feature to version mapping is not the same for Scylla and Cassandra. I left the checks for Cassandra. As of now, I don't think it's really important to check which features should be tested based on Scylla version, since we don't plan to test old Scylla versions. We will add such filters in the future, once they are needed.

## No compact test
Previously, this test was silently passing as it was skipped for both Scylla and Cassandra. However, the function `cass_cluster_set_no_compact` is not even implemented. I removed this test from CI (for both Scylla and Cassandra).

## Map collection iterator
cpp-rust-driver's implementation of `cass_iterator_from_collection` for maps was inconsistent with cpp-driver's implementation. This PR fixes it. I found this bug, because the test for a `map<int, duration>` type was handled a bit differently than for the other types (since apparently, `duration` cannot be used as a primary key). This test was failing due to the bug with map iterators.

## Collection objects in test framework
The `Collection` object was not initialized correctly when constructed from `CassValue`. An issue is described in detail in a corresponding commit.

## Modified tests for collections
Due to the two previous bugs, the tests for collections were modified a bit in the past. Since the issues are fixed, I reverted these changes and the tests now contain original logic from the upstream.

## Duration tests for cassandra
Enabled duration tests for cassandra.

## Scylla version in CI
Bumped Scylla version in CI to `6.0.0`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.