### PR TITLE
cargo: update rust-driver to 0.14

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1027,9 +1027,8 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scylla"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20b46cf4ea921ba41121ba9ddf933185cd830cbe2c4fa6272a6e274a6b7368d"
+version = "0.14.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.14.0#0341198937871ea135fdca3ecfcea9a792ee9b18"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1085,9 +1084,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ea3cd3ff5bf9d7db7a6d65c54cecf52f7c40b8e3e32c8c2d6da84d23776ea4"
+version = "0.3.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.14.0#0341198937871ea135fdca3ecfcea9a792ee9b18"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1102,9 +1100,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50f3e2aec7ea9f495e029fb783eb34c64d26a8f2055e1d6b43d00e04d2fbda6"
+version = "0.6.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.14.0#0341198937871ea135fdca3ecfcea9a792ee9b18"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1114,9 +1111,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-proxy"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5b3907e01611b2c514fc7a5563be863814ed9f0034e7080a86515232c20433"
+version = "0.0.3"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.14.0#0341198937871ea135fdca3ecfcea9a792ee9b18"
 dependencies = [
  "bigdecimal",
  "byteorder",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -10,7 +10,9 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-scylla = { version = "0.13.1", features = ["ssl"] }
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v0.14.0", features = [
+    "ssl",
+] }
 tokio = { version = "1.27.0", features = ["full"] }
 lazy_static = "1.4.0"
 uuid = "1.1.2"
@@ -29,11 +31,11 @@ bindgen = "0.65"
 chrono = "0.4.20"
 
 [dev-dependencies]
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v0.14.0" }
+
 assert_matches = "1.5.0"
 ntest = "0.9.3"
 rusty-fork = "0.3.0"
-scylla-proxy = { version = "0.0.4" }
-
 [lib]
 name = "scylla_cpp_driver"
 crate-type = ["cdylib", "staticlib"]

--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -15,6 +15,7 @@ impl From<&QueryError> for CassError {
             QueryError::UnableToAllocStreamId => CassError::CASS_ERROR_LIB_NO_STREAMS,
             QueryError::RequestTimeout(_) => CassError::CASS_ERROR_LIB_REQUEST_TIMED_OUT,
             QueryError::TranslationError(_) => CassError::CASS_ERROR_LIB_HOST_RESOLUTION,
+            QueryError::CqlResponseParseError(_) => CassError::CASS_ERROR_LIB_UNEXPECTED_RESPONSE,
         }
     }
 }
@@ -83,6 +84,9 @@ impl From<&NewSessionError> for CassError {
             NewSessionError::UnableToAllocStreamId => CassError::CASS_ERROR_LAST_ENTRY,
             NewSessionError::RequestTimeout(_) => CassError::CASS_ERROR_LIB_REQUEST_TIMED_OUT,
             NewSessionError::TranslationError(_) => CassError::CASS_ERROR_LIB_HOST_RESOLUTION,
+            NewSessionError::CqlResponseParseError(_) => {
+                CassError::CASS_ERROR_LIB_UNEXPECTED_RESPONSE
+            }
         }
     }
 }

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -1,4 +1,4 @@
-use scylla::frame::value::MaybeUnset::Unset;
+use scylla::{frame::value::MaybeUnset::Unset, transport::PagingState};
 use std::sync::Arc;
 
 use crate::{
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn cass_prepared_bind(
     Box::into_raw(Box::new(CassStatement {
         statement,
         bound_values: vec![Unset; bound_values_size],
-        paging_state: None,
+        paging_state: PagingState::start(),
         request_timeout_ms: None,
         exec_profile: None,
     }))

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -29,6 +29,8 @@ pub unsafe extern "C" fn cass_prepared_bind(
         statement,
         bound_values: vec![Unset; bound_values_size],
         paging_state: PagingState::start(),
+        // Cpp driver disables paging by default.
+        paging_enabled: false,
         request_timeout_ms: None,
         exec_profile: None,
     }))

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -18,6 +18,7 @@ use scylla::frame::types::Consistency;
 use scylla::query::Query;
 use scylla::transport::errors::QueryError;
 use scylla::transport::execution_profile::ExecutionProfileHandle;
+use scylla::transport::PagingStateResponse;
 use scylla::{QueryResult, Session, SessionBuilder};
 use std::collections::HashMap;
 use std::future::Future;
@@ -205,7 +206,7 @@ pub unsafe extern "C" fn cass_session_execute_batch(
             Ok(_result) => Ok(CassResultValue::QueryResult(Arc::new(CassResult {
                 rows: None,
                 metadata: Arc::new(CassResultData {
-                    paging_state: None,
+                    paging_state_response: PagingStateResponse::NoMorePages,
                     col_specs: vec![],
                     tracing_id: None,
                 }),
@@ -274,24 +275,24 @@ pub unsafe extern "C" fn cass_session_execute(
             }
         }
 
-        let query_res: Result<QueryResult, QueryError> = match statement {
+        let query_res: Result<(QueryResult, PagingStateResponse), QueryError> = match statement {
             Statement::Simple(query) => {
                 session
-                    .query_paged(query.query, bound_values, paging_state)
+                    .query_single_page(query.query, bound_values, paging_state)
                     .await
             }
             Statement::Prepared(prepared) => {
                 session
-                    .execute_paged(&prepared, bound_values, paging_state)
+                    .execute_single_page(&prepared, bound_values, paging_state)
                     .await
             }
         };
 
         match query_res {
-            Ok(result) => {
+            Ok((result, paging_state_response)) => {
                 let metadata = Arc::new(CassResultData {
-                    paging_state: result.paging_state,
-                    col_specs: result.col_specs,
+                    paging_state_response,
+                    col_specs: result.col_specs().to_vec(),
                     tracing_id: result.tracing_id,
                 });
                 let cass_rows = create_cass_rows_from_rows(result.rows, &metadata);
@@ -516,7 +517,8 @@ pub unsafe extern "C" fn cass_session_prepare_n(
             .map_err(|err| (CassError::from(&err), err.msg()))?;
 
         // Set Cpp Driver default configuration for queries:
-        prepared.disable_paging();
+        // FIXME: DISABLE PAGING
+        // prepared.disable_paging();
         prepared.set_consistency(Consistency::One);
 
         Ok(CassResultValue::Prepared(Arc::new(prepared)))

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -191,9 +191,9 @@ pub unsafe extern "C" fn cass_statement_set_paging_size(
     statement_raw: *mut CassStatement,
     page_size: c_int,
 ) -> CassError {
-    // TODO: validate page_size
     let statement = ptr_to_ref_mut(statement_raw);
-    if page_size == -1 {
+    if page_size <= 0 {
+        // Cpp driver sets the page size flag only for positive page size provided by user.
         statement.paging_enabled = false;
     } else {
         statement.paging_enabled = true;

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -7,7 +7,7 @@ use scylla::{
     },
     serialize::{
         value::{
-            BuiltinSerializationErrorKind, MapSerializationErrorKind, SerializeCql,
+            BuiltinSerializationErrorKind, MapSerializationErrorKind, SerializeValue,
             SetOrListSerializationErrorKind, TupleSerializationErrorKind,
             UdtSerializationErrorKind,
         },
@@ -60,7 +60,7 @@ pub enum CassCqlValue {
     // TODO: custom (?), duration and decimal
 }
 
-impl SerializeCql for CassCqlValue {
+impl SerializeValue for CassCqlValue {
     fn serialize<'b>(
         &self,
         _typ: &ColumnType,
@@ -89,44 +89,44 @@ impl CassCqlValue {
             // will never fail. Thanks to that, we do not have to reimplement low-level serialization
             // for each type.
             CassCqlValue::TinyInt(v) => {
-                <i8 as SerializeCql>::serialize(v, &ColumnType::TinyInt, writer)
+                <i8 as SerializeValue>::serialize(v, &ColumnType::TinyInt, writer)
             }
             CassCqlValue::SmallInt(v) => {
-                <i16 as SerializeCql>::serialize(v, &ColumnType::SmallInt, writer)
+                <i16 as SerializeValue>::serialize(v, &ColumnType::SmallInt, writer)
             }
-            CassCqlValue::Int(v) => <i32 as SerializeCql>::serialize(v, &ColumnType::Int, writer),
+            CassCqlValue::Int(v) => <i32 as SerializeValue>::serialize(v, &ColumnType::Int, writer),
             CassCqlValue::BigInt(v) => {
-                <i64 as SerializeCql>::serialize(v, &ColumnType::BigInt, writer)
+                <i64 as SerializeValue>::serialize(v, &ColumnType::BigInt, writer)
             }
             CassCqlValue::Float(v) => {
-                <f32 as SerializeCql>::serialize(v, &ColumnType::Float, writer)
+                <f32 as SerializeValue>::serialize(v, &ColumnType::Float, writer)
             }
             CassCqlValue::Double(v) => {
-                <f64 as SerializeCql>::serialize(v, &ColumnType::Double, writer)
+                <f64 as SerializeValue>::serialize(v, &ColumnType::Double, writer)
             }
             CassCqlValue::Boolean(v) => {
-                <bool as SerializeCql>::serialize(v, &ColumnType::Boolean, writer)
+                <bool as SerializeValue>::serialize(v, &ColumnType::Boolean, writer)
             }
             CassCqlValue::Text(v) => {
-                <String as SerializeCql>::serialize(v, &ColumnType::Text, writer)
+                <String as SerializeValue>::serialize(v, &ColumnType::Text, writer)
             }
             CassCqlValue::Blob(v) => {
-                <Vec<u8> as SerializeCql>::serialize(v, &ColumnType::Blob, writer)
+                <Vec<u8> as SerializeValue>::serialize(v, &ColumnType::Blob, writer)
             }
             CassCqlValue::Uuid(v) => {
-                <Uuid as SerializeCql>::serialize(v, &ColumnType::Uuid, writer)
+                <Uuid as SerializeValue>::serialize(v, &ColumnType::Uuid, writer)
             }
             CassCqlValue::Date(v) => {
-                <CqlDate as SerializeCql>::serialize(v, &ColumnType::Date, writer)
+                <CqlDate as SerializeValue>::serialize(v, &ColumnType::Date, writer)
             }
             CassCqlValue::Inet(v) => {
-                <IpAddr as SerializeCql>::serialize(v, &ColumnType::Inet, writer)
+                <IpAddr as SerializeValue>::serialize(v, &ColumnType::Inet, writer)
             }
             CassCqlValue::Duration(v) => {
-                <CqlDuration as SerializeCql>::serialize(v, &ColumnType::Duration, writer)
+                <CqlDuration as SerializeValue>::serialize(v, &ColumnType::Duration, writer)
             }
             CassCqlValue::Decimal(v) => {
-                <CqlDecimal as SerializeCql>::serialize(v, &ColumnType::Decimal, writer)
+                <CqlDecimal as SerializeValue>::serialize(v, &ColumnType::Decimal, writer)
             }
             CassCqlValue::Tuple(fields) => serialize_tuple_like(fields.iter(), writer),
             CassCqlValue::List(l) => serialize_sequence(l.len(), l.iter(), writer),


### PR DESCRIPTION
This PR updates the rust-driver dependency to 0.14.

There were some minor API breaking changes such as renaming `SerializeCql` to `SerializeValue`.

The most troublesome matter were paging changes in rust driver. We needed to adjust cpp-rust-driver to new paging API introduced in rust-driver:
- change paging state type from `Bytes` to `PagingState`
- contain a `PagingStateResponse` in `CassResult` instead of `Bytes`.
- handle disabling paging on a cpp-rust-driver layer. The `Query/PreparedStatement::disable_paging()` methods were removed. As a replacement, `query/execute_single_page` and `query/execute_unpaged` session methods were introduced. We needed to adjust the cpp-rust-driver to this change by introducing a `paging_enabled` flag in `CassStatement`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~