### PR TITLE
ci: enable `ConfigTests`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
 #        Ignored tests are added in the end, after the "-" sign.
         Tests: "ClusterTests.*\
 :BasicsTests.*\
+:ConfigTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :BatchSingleNodeClusterTests*:BatchCounterSingleNodeClusterTests*:BatchCounterThreeNodeClusterTests*\

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -42,6 +42,7 @@ jobs:
           #        Ignored tests are added in the end, after the "-" sign.
           Tests: "ClusterTests.*\
 :BasicsTests.*\
+:ConfigTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :ErrorTests.*\

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -189,9 +189,10 @@ unsafe fn cluster_set_contact_points(
     let mut contact_points = ptr_to_cstr_n(contact_points_raw, contact_points_length)
         .ok_or(CassError::CASS_ERROR_LIB_BAD_PARAMS)?
         .split(',')
+        .filter(|s| !s.is_empty()) // Extra commas should be ignored.
         .peekable();
 
-    if contact_points.peek().is_none() {
+    if contact_points.peek().is_none() || contact_points.peek().unwrap().is_empty() {
         // If cass_cluster_set_contact_points() is called with empty
         // set of contact points, the contact points should be cleared.
         cluster.contact_points.clear();

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -16,7 +16,7 @@ use scylla::load_balancing::{DefaultPolicyBuilder, LoadBalancingPolicy};
 use scylla::retry_policy::RetryPolicy;
 use scylla::speculative_execution::SimpleSpeculativeExecutionPolicy;
 use scylla::statement::{Consistency, SerialConsistency};
-use scylla::SessionBuilder;
+use scylla::{SessionBuilder, SessionConfig};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::future::Future;
@@ -90,6 +90,21 @@ pub struct CassCluster {
 impl CassCluster {
     pub(crate) fn execution_profile_map(&self) -> &HashMap<ExecProfileName, CassExecProfile> {
         &self.execution_profile_map
+    }
+
+    #[inline]
+    pub(crate) fn get_session_config(&self) -> &SessionConfig {
+        &self.session_builder.config
+    }
+
+    #[inline]
+    pub(crate) fn get_port(&self) -> u16 {
+        self.port
+    }
+
+    #[inline]
+    pub(crate) fn get_contact_points(&self) -> &[String] {
+        &self.contact_points
     }
 }
 

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -1,0 +1,52 @@
+use std::ffi::{c_char, CString};
+
+use crate::{
+    argconv::ptr_to_ref,
+    cluster::CassCluster,
+    types::{cass_int32_t, cass_uint16_t, size_t},
+};
+
+#[no_mangle]
+pub unsafe extern "C" fn testing_cluster_get_connect_timeout(
+    cluster_raw: *const CassCluster,
+) -> cass_uint16_t {
+    let cluster = ptr_to_ref(cluster_raw);
+
+    cluster.get_session_config().connect_timeout.as_millis() as cass_uint16_t
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn testing_cluster_get_port(cluster_raw: *const CassCluster) -> cass_int32_t {
+    let cluster = ptr_to_ref(cluster_raw);
+
+    cluster.get_port() as cass_int32_t
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn testing_cluster_get_contact_points(
+    cluster_raw: *const CassCluster,
+    contact_points: *mut *mut c_char,
+    contact_points_length: *mut size_t,
+) {
+    let cluster = ptr_to_ref(cluster_raw);
+
+    let contact_points_string = cluster.get_contact_points().join(",");
+    let length = contact_points_string.len();
+
+    match CString::new(contact_points_string) {
+        Ok(cstring) => {
+            *contact_points = cstring.into_raw();
+            *contact_points_length = length as size_t;
+        }
+        Err(_) => {
+            // The contact points string contained a nul byte in the middle.
+            *contact_points = std::ptr::null_mut();
+            *contact_points_length = 0;
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn testing_free_contact_points(contact_points: *mut c_char) {
+    let _ = CString::from_raw(contact_points);
+}

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -18,6 +18,7 @@ pub mod exec_profile;
 mod external;
 pub mod future;
 pub mod inet;
+pub mod integration_testing;
 mod logging;
 pub mod metadata;
 pub mod prepared;

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -21,6 +21,11 @@
 #include "get_time.hpp"
 #include "logger.hpp"
 #include "murmur3.hpp"
+#include <iostream>
+
+extern "C" {
+  #include "testing_rust_impls.h"
+}
 
 namespace datastax { namespace internal { namespace testing {
 
@@ -35,15 +40,30 @@ StringVec get_attempted_hosts_from_future(CassFuture* future) {
 }
 
 unsigned get_connect_timeout_from_cluster(CassCluster* cluster) {
-  throw std::runtime_error("Unimplemented 'get_connect_timeout_from_cluster'!");
+  return testing_cluster_get_connect_timeout(cluster);
 }
 
 int get_port_from_cluster(CassCluster* cluster) {
-  throw std::runtime_error("Unimplemented 'get_port_from_cluster'!");
+  return testing_cluster_get_port(cluster);
 }
 
 String get_contact_points_from_cluster(CassCluster* cluster) {
-  throw std::runtime_error("Unimplemented 'get_contact_points_from_cluster'!");
+  char* contact_points;
+  size_t contact_points_length;
+  testing_cluster_get_contact_points(cluster, &contact_points, &contact_points_length);
+
+  if (contact_points == nullptr) {
+    throw std::runtime_error("CassCluster returned a null contact points string.\
+                              This means that one of the contact points contained a nul byte in it.");
+  }
+
+  std::string contact_points_str(contact_points, contact_points_length);
+  OStringStream ss;
+  ss << contact_points_str;
+
+  testing_free_contact_points(contact_points);
+
+  return ss.str();
 }
 
 int64_t create_murmur3_hash_from_string(const String& value) {

--- a/src/testing_rust_impls.h
+++ b/src/testing_rust_impls.h
@@ -1,0 +1,25 @@
+#ifndef CPP_RUST_DRIVER_TESTING_RUST_IMPLS_HPP
+#define CPP_RUST_DRIVER_TESTING_RUST_IMPLS_HPP
+
+#include "cassandra.h"
+
+extern "C" {
+    // Retrieves a connect timeout from cluster config.
+    CASS_EXPORT cass_uint16_t testing_cluster_get_connect_timeout(CassCluster *cluster);
+
+    // Retrieves a CQL connection port from cluster config.
+    CASS_EXPORT cass_int32_t testing_cluster_get_port(CassCluster* cluster);
+
+    // Retrieves a contact points string. The contact points are delimited with ','.
+    //
+    // This function can fail, if any of the contact points contains a nul byte.
+    // Then, the resulting pointer is set to null.
+    //
+    // On success, this function allocates a contact points string, which needs to be then
+    // freed with `testing_free_contact_points`.
+    CASS_EXPORT void testing_cluster_get_contact_points(CassCluster *cluster, char **contact_points, size_t *contact_points_length);
+
+    CASS_EXPORT void testing_free_contact_points(char *contact_points);
+}
+
+#endif


### PR DESCRIPTION
This PR implements necessary utility functions to enable `ConfigTests` suite.

## Changes
- implemented following util functions in Rust:
  - `testing_cluster_get_port` -> retrieves CQL port from cluster config
  - `testing_cluster_get_connect_timeout` -> retrieves connect timeout from cluster config
  - `testing_cluster_get_contact_points` -> returns a contact points string. Contact points are delimited with `,`. If any of the contact points contained a `nul` byte, a null pointer is returned signifying an error appeared
  - `testing_free_contact_points` -> previous function allocates a string on the heap, and gives the ownership to the user. The user can free resources with this function.
- Adjusted cluster logic, when creating a contact points vector:
  - extra commas provided by user should be ignored
  - if user provided an empty string (after ignoring extra commas), the internal contact points vector should be cleared
- enabled `ConfigTests` test suite

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.