### PR TITLE
cluster: cass_cluster_set_tcp_keepalive

### DIFF
--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -324,6 +324,19 @@ pub unsafe extern "C" fn cass_cluster_set_tcp_nodelay(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_tcp_keepalive(
+    cluster_raw: *mut CassCluster,
+    enabled: cass_bool_t,
+    delay_secs: c_uint,
+) {
+    let cluster = ptr_to_ref_mut(cluster_raw);
+    let enabled = enabled != 0;
+    let tcp_keepalive_interval = enabled.then(|| Duration::from_secs(delay_secs as u64));
+
+    cluster.session_builder.config.tcp_keepalive_interval = tcp_keepalive_interval;
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_connect_timeout(
     cluster_raw: *mut CassCluster,
     timeout_ms: c_uint,


### PR DESCRIPTION
Implementation of `cass_cluster_set_tcp_keepalive`. In cpp-driver, by default, this is disabled - same is true for rust-driver.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~