### PR TITLE
exec_profile: token aware routing with shuffling setting

### DIFF
--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -421,6 +421,19 @@ pub unsafe extern "C" fn cass_execution_profile_set_token_aware_routing(
     CassError::CASS_OK
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_token_aware_routing_shuffle_replicas(
+    profile: *mut CassExecProfile,
+    enabled: cass_bool_t,
+) -> CassError {
+    let profile_builder = ptr_to_ref_mut(profile);
+    profile_builder
+        .load_balancing_config
+        .token_aware_shuffling_replicas_enabled = enabled != 0;
+
+    CassError::CASS_OK
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Implemented:
- `cass_cluster_set_token_aware_routing_shuffle_replicas`
- `cass_execution_profile_set_token_aware_routing_shuffle_replicas`

Notice, that this setting (replica shuffling) is only applicable, if token aware routing is enabled (which is, by default).

This setting is `true` by default.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~