### PR TITLE
statement: reset parameters

### DIFF
--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -125,6 +125,12 @@ impl CassStatement {
 
         CassError::CASS_OK
     }
+
+    fn reset_bound_values(&mut self, count: usize) {
+        // Clear bound values and resize the vector - all values should be unset.
+        self.bound_values.clear();
+        self.bound_values.resize(count, Unset);
+    }
 }
 
 #[no_mangle]
@@ -364,6 +370,17 @@ pub unsafe extern "C" fn cass_statement_set_request_timeout(
 
     let statement_from_raw = ptr_to_ref_mut(statement);
     statement_from_raw.request_timeout_ms = Some(timeout_ms);
+
+    CassError::CASS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_statement_reset_parameters(
+    statement_raw: *mut CassStatement,
+    count: size_t,
+) -> CassError {
+    let statement = ptr_to_ref_mut(statement_raw);
+    statement.reset_bound_values(count as usize);
 
     CassError::CASS_OK
 }


### PR DESCRIPTION
Implemented cass_statement_reset_parameters.
It should clear a vector of bound values, and resize it, filling it with Unset values.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~