### PR TITLE
makefile: fix rebuild IT binary condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,6 @@ ifndef CASSANDRA_VERSION
 	CASSANDRA_VERSION := 3.11.17
 endif
 
-ifndef DONT_REBUILD_INTEGRATION_BIN
-	DONT_REBUILD_INTEGRATION_BIN := ${EMPTY}
-endif
-
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 BUILD_DIR := "${CURRENT_DIR}build"
 INTEGRATION_TEST_BIN := ${BUILD_DIR}/cassandra-integration-tests
@@ -171,7 +167,7 @@ download-ccm-cassandra-image: install-ccm-if-missing
 	@rm -rf /tmp/download-cassandra.ccm
 
 run-test-integration-scylla: prepare-integration-test download-ccm-scylla-image
-ifeq ($(DONT_REBUILD_INTEGRATION_BIN), $(EMPTY))
+ifdef DONT_REBUILD_INTEGRATION_BIN
 run-test-integration-scylla: build-integration-test-bin-if-missing
 else
 run-test-integration-scylla: build-integration-test-bin
@@ -180,7 +176,7 @@ endif
 	valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite build/cassandra-integration-tests --scylla --version=${SCYLLA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${SCYLLA_TEST_FILTER}"
 
 run-test-integration-cassandra: prepare-integration-test download-ccm-cassandra-image install-java8-if-missing
-ifeq ($(DONT_REBUILD_INTEGRATION_BIN), $(EMPTY))
+ifdef DONT_REBUILD_INTEGRATION_BIN
 run-test-integration-cassandra: build-integration-test-bin-if-missing
 else
 run-test-integration-cassandra: build-integration-test-bin


### PR DESCRIPTION
Currently, we rebuild (even if it exists) IT binary if DONT_REBUILD_INTEGRATION_BIN env var is non-empty. I believe it should be the opposite.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~