### PR TITLE
Makefile: add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+---
+BasedOnStyle: LLVM
+Language: Cpp
+Standard: Cpp03
+AccessModifierOffset: -2
+IndentWidth: 2
+TabWidth: 8
+ColumnLimit: 100
+UseTab: Never
+IndentCaseLabels: true
+AlignAfterOpenBracket: true
+AlignEscapedNewlines: Left
+BreakConstructorInitializers: BeforeComma
+AllowShortBlocksOnASingleLine: false
+DerivePointerAlignment: false
+PointerAlignment: Left
+BinPackParameters: true
+BinPackArguments: true
+AllowShortIfStatementsOnASingleLine: true
+CompactNamespaces: true
+AlignOperands: true
+SpacesInContainerLiterals: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+Cpp11BracedListStyle: false
+AlwaysBreakTemplateDeclarations: true
+BreakBeforeInheritanceComma: true
+...
+

--- a/src/driver_info.cpp
+++ b/src/driver_info.cpp
@@ -26,9 +26,7 @@
 
 namespace datastax { namespace internal {
 
-const char* driver_name() {
-  return "Scylla Shard-Aware C/C++ Driver";
-}
+const char* driver_name() { return "Scylla Shard-Aware C/C++ Driver"; }
 
 const char* driver_version() {
   if (strlen(CASS_VERSION_SUFFIX) == 0) {

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -52,7 +52,7 @@
         STATIC_ASSERT_CONCAT(STATIC_ASSERTION_FAILED_AT_LINE_, __LINE__);                       \
   };                                                                                            \
   typedef StaticAssertTest<sizeof(STATIC_ASSERT_CONCAT(__static_assertion_at_line_, __LINE__))> \
-      STATIC_ASSERT_CONCAT(__static_assertion_test_at_line_, __LINE__)
+  STATIC_ASSERT_CONCAT(__static_assertion_test_at_line_, __LINE__)
 
 template <bool>
 struct StaticAssert;

--- a/src/main.c
+++ b/src/main.c
@@ -1,221 +1,230 @@
-#include <stddef.h>
 #include <assert.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 #include "cassandra.h"
 
-void print_error_result(const CassErrorResult *err) {
-    printf("[error_result] code: %d\n", cass_error_result_code(err));
-    printf("[error_result] consistency: %d\n", cass_error_result_consistency(err));
-    printf("[error_result] responses received: %d\n", cass_error_result_responses_received(err));
-    printf("[error_result] responses required: %d\n", cass_error_result_responses_required(err));
-    printf("[error_result] num_failures: %d\n", cass_error_result_num_failures(err));
-    printf("[error_result] data_present: %d\n", cass_error_result_data_present(err));
-    printf("[error_result] write type: %d\n", cass_error_result_write_type(err));
-    const char *str;
-    size_t len;
-    cass_error_result_keyspace(err, &str, &len);
-    printf("[error_result] keyspace: %.*s\n", len, str);
-    cass_error_result_table(err, &str, &len);
-    printf("[error_result] table: %.*s\n", len, str);
-    cass_error_result_function(err, &str, &len);
-    printf("[error_result] function: %.*s\n", len, str);
-    printf("[error_result] num arg types: %d\n", cass_error_num_arg_types(err));
-    for(int i = 0; i < cass_error_num_arg_types(err); i++) {
-        cass_error_result_arg_type(err, i, &str, &len);
-        printf("[error_result] arg %d: %.*s\n", i, len, str);
-    }
+void print_error_result(const CassErrorResult* err) {
+  printf("[error_result] code: %d\n", cass_error_result_code(err));
+  printf("[error_result] consistency: %d\n", cass_error_result_consistency(err));
+  printf("[error_result] responses received: %d\n", cass_error_result_responses_received(err));
+  printf("[error_result] responses required: %d\n", cass_error_result_responses_required(err));
+  printf("[error_result] num_failures: %d\n", cass_error_result_num_failures(err));
+  printf("[error_result] data_present: %d\n", cass_error_result_data_present(err));
+  printf("[error_result] write type: %d\n", cass_error_result_write_type(err));
+  const char* str;
+  size_t len;
+  cass_error_result_keyspace(err, &str, &len);
+  printf("[error_result] keyspace: %.*s\n", len, str);
+  cass_error_result_table(err, &str, &len);
+  printf("[error_result] table: %.*s\n", len, str);
+  cass_error_result_function(err, &str, &len);
+  printf("[error_result] function: %.*s\n", len, str);
+  printf("[error_result] num arg types: %d\n", cass_error_num_arg_types(err));
+  for (int i = 0; i < cass_error_num_arg_types(err); i++) {
+    cass_error_result_arg_type(err, i, &str, &len);
+    printf("[error_result] arg %d: %.*s\n", i, len, str);
+  }
 }
 
 void do_prepared_query(CassSession* session, const char* query_text) {
-    CassFuture* prepare_future = cass_session_prepare(session, query_text);
-    const CassPrepared* prepared = cass_future_get_prepared(prepare_future);
-    CassStatement* statement = cass_prepared_bind(prepared);
-    CassFuture* statement_future = cass_session_execute(session, statement);
-    printf("prepared query code: %d\n", cass_future_error_code(statement_future));
-    const CassErrorResult *err = cass_future_get_error_result(statement_future);
-    if(err != NULL) {
-        print_error_result(err);
-    }
-    cass_error_result_free(err);
-    cass_future_free(statement_future);
-    cass_future_free(prepare_future);
-    cass_prepared_free(prepared);
-    cass_statement_free(statement);
+  CassFuture* prepare_future = cass_session_prepare(session, query_text);
+  const CassPrepared* prepared = cass_future_get_prepared(prepare_future);
+  CassStatement* statement = cass_prepared_bind(prepared);
+  CassFuture* statement_future = cass_session_execute(session, statement);
+  printf("prepared query code: %d\n", cass_future_error_code(statement_future));
+  const CassErrorResult* err = cass_future_get_error_result(statement_future);
+  if (err != NULL) {
+    print_error_result(err);
+  }
+  cass_error_result_free(err);
+  cass_future_free(statement_future);
+  cass_future_free(prepare_future);
+  cass_prepared_free(prepared);
+  cass_statement_free(statement);
 }
 
 void do_simple_query(CassSession* session, const char* query_text) {
-    CassStatement* statement = cass_statement_new(query_text, 0);
-    cass_statement_set_tracing(statement, 1);
+  CassStatement* statement = cass_statement_new(query_text, 0);
+  cass_statement_set_tracing(statement, 1);
 
-    CassFuture* statement_future = cass_session_execute(session, statement);
-    printf("simple query ready: %d\n", cass_future_ready(statement_future));
-    const char *msg;
-    size_t len;
-    cass_future_error_message(statement_future, &msg, &len);
-    const CassErrorResult *err = cass_future_get_error_result(statement_future);
-    if(err != NULL) {
-        print_error_result(err);
-    }
-    cass_error_result_free(err);
-    printf("simple query code: %d, message: %.*s\n", cass_future_error_code(statement_future), len, msg);
-    printf("simple query ready: %d\n", cass_future_ready(statement_future));
-    cass_future_free(statement_future);
-    cass_statement_free(statement);
+  CassFuture* statement_future = cass_session_execute(session, statement);
+  printf("simple query ready: %d\n", cass_future_ready(statement_future));
+  const char* msg;
+  size_t len;
+  cass_future_error_message(statement_future, &msg, &len);
+  const CassErrorResult* err = cass_future_get_error_result(statement_future);
+  if (err != NULL) {
+    print_error_result(err);
+  }
+  cass_error_result_free(err);
+  printf("simple query code: %d, message: %.*s\n", cass_future_error_code(statement_future), len,
+         msg);
+  printf("simple query ready: %d\n", cass_future_ready(statement_future));
+  cass_future_free(statement_future);
+  cass_statement_free(statement);
 }
 
 static void print_error_cb(CassFuture* future, void* data) {
-    printf("code: %d\n", cass_future_error_code(future));
-    if (cass_future_error_code(future) != 0) {
-        exit(cass_future_error_code(future));
-    }
+  printf("code: %d\n", cass_future_error_code(future));
+  if (cass_future_error_code(future) != 0) {
+    exit(cass_future_error_code(future));
+  }
 }
 
 int main() {
-    CassFuture* connect_future = NULL;
-    CassCluster* cluster = cass_cluster_new();
-    CassSession* session = cass_session_new();
+  CassFuture* connect_future = NULL;
+  CassCluster* cluster = cass_cluster_new();
+  CassSession* session = cass_session_new();
 
-    cass_cluster_set_contact_points(cluster, "127.0.1.1");
-    cass_cluster_set_load_balance_round_robin(cluster);
-    cass_cluster_set_token_aware_routing(cluster, 1);
-    connect_future = cass_session_connect(session, cluster);
-    cass_future_set_callback(connect_future, print_error_cb, NULL);
-    cass_future_wait(connect_future);
-    cass_future_free(connect_future);
+  cass_cluster_set_contact_points(cluster, "127.0.1.1");
+  cass_cluster_set_load_balance_round_robin(cluster);
+  cass_cluster_set_token_aware_routing(cluster, 1);
+  connect_future = cass_session_connect(session, cluster);
+  cass_future_set_callback(connect_future, print_error_cb, NULL);
+  cass_future_wait(connect_future);
+  cass_future_free(connect_future);
 
-    do_simple_query(session, "CREATE KEYSPACE IF NOT EXISTS ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
-    do_simple_query(session, "DROP TABLE IF EXISTS ks.t");
-    do_simple_query(session, "CREATE TABLE IF NOT EXISTS ks.t (pk int, ck int, v int, v2 text, primary key (pk, ck))");
-    do_simple_query(session, "INSERT INTO ks.t(pk, ck, v, v2) VALUES (7, 8, 9, 'hello world')");
-    do_prepared_query(session, "INSERT INTO ks.t(pk, ck, v, v2) VALUES (69, 69, 69, 'greetings from Rust!')");
+  do_simple_query(session, "CREATE KEYSPACE IF NOT EXISTS ks WITH replication = {'class': "
+                           "'SimpleStrategy', 'replication_factor': 1}");
+  do_simple_query(session, "DROP TABLE IF EXISTS ks.t");
+  do_simple_query(
+      session,
+      "CREATE TABLE IF NOT EXISTS ks.t (pk int, ck int, v int, v2 text, primary key (pk, ck))");
+  do_simple_query(session, "INSERT INTO ks.t(pk, ck, v, v2) VALUES (7, 8, 9, 'hello world')");
+  do_prepared_query(session,
+                    "INSERT INTO ks.t(pk, ck, v, v2) VALUES (69, 69, 69, 'greetings from Rust!')");
 
-    // Create already existing table
-    do_simple_query(session, "CREATE TABLE ks.t (pk int, ck int, v int, v2 text, primary key (pk, ck))");
-    // Some garbage as request
-    do_simple_query(session, "asdasdafdsdfguhvcsdrhjgvf");
+  // Create already existing table
+  do_simple_query(session,
+                  "CREATE TABLE ks.t (pk int, ck int, v int, v2 text, primary key (pk, ck))");
+  // Some garbage as request
+  do_simple_query(session, "asdasdafdsdfguhvcsdrhjgvf");
 
-    CassStatement* statement = cass_statement_new("INSERT INTO ks.t(pk, ck, v, v2) VALUES (?, ?, ?, ?)", 4);
-    cass_statement_bind_int32(statement, 0, 100);
-    cass_statement_bind_int32(statement, 1, 200);
-    cass_statement_bind_int32(statement, 2, 300);
-    cass_statement_bind_string(statement, 3, "We love Rust!");
+  CassStatement* statement =
+      cass_statement_new("INSERT INTO ks.t(pk, ck, v, v2) VALUES (?, ?, ?, ?)", 4);
+  cass_statement_bind_int32(statement, 0, 100);
+  cass_statement_bind_int32(statement, 1, 200);
+  cass_statement_bind_int32(statement, 2, 300);
+  cass_statement_bind_string(statement, 3, "We love Rust!");
 
-    CassFuture* statement_future = cass_session_execute(session, statement);
-    cass_future_set_callback(statement_future, print_error_cb, NULL);
-    cass_future_wait(statement_future);
-    cass_future_free(statement_future);
-    cass_statement_free(statement);
+  CassFuture* statement_future = cass_session_execute(session, statement);
+  cass_future_set_callback(statement_future, print_error_cb, NULL);
+  cass_future_wait(statement_future);
+  cass_future_free(statement_future);
+  cass_statement_free(statement);
 
-    do_simple_query(session, "DROP TABLE IF EXISTS ks.t2");
-    do_simple_query(session, "DROP TYPE IF EXISTS ks.my_type");
-    do_simple_query(session, "CREATE TYPE IF NOT EXISTS ks.my_type(c text, a int, b float)");
-    do_simple_query(session, "CREATE TABLE IF NOT EXISTS ks.t2 (pk int, ck int, v list<int>, v2 map<text, float>, v3 my_type, primary key (pk, ck))");
+  do_simple_query(session, "DROP TABLE IF EXISTS ks.t2");
+  do_simple_query(session, "DROP TYPE IF EXISTS ks.my_type");
+  do_simple_query(session, "CREATE TYPE IF NOT EXISTS ks.my_type(c text, a int, b float)");
+  do_simple_query(session, "CREATE TABLE IF NOT EXISTS ks.t2 (pk int, ck int, v list<int>, v2 "
+                           "map<text, float>, v3 my_type, primary key (pk, ck))");
 
-    CassCollection* list = cass_collection_new(CASS_COLLECTION_TYPE_LIST, 3);
-    cass_collection_append_int32(list, 123);
-    cass_collection_append_int32(list, 456);
-    cass_collection_append_int32(list, 789);
+  CassCollection* list = cass_collection_new(CASS_COLLECTION_TYPE_LIST, 3);
+  cass_collection_append_int32(list, 123);
+  cass_collection_append_int32(list, 456);
+  cass_collection_append_int32(list, 789);
 
-    CassCollection* map = cass_collection_new(CASS_COLLECTION_TYPE_MAP, 2);
-    cass_collection_append_string(map, "k1");
-    cass_collection_append_float(map, 10.0);
-    cass_collection_append_string(map, "k2");
-    cass_collection_append_float(map, 20.0);
+  CassCollection* map = cass_collection_new(CASS_COLLECTION_TYPE_MAP, 2);
+  cass_collection_append_string(map, "k1");
+  cass_collection_append_float(map, 10.0);
+  cass_collection_append_string(map, "k2");
+  cass_collection_append_float(map, 20.0);
 
-    CassDataType* udt_type = cass_data_type_new_udt(3);
-    cass_data_type_add_sub_value_type_by_name(udt_type, "c", CASS_VALUE_TYPE_TEXT);
-    cass_data_type_add_sub_value_type_by_name(udt_type, "a", CASS_VALUE_TYPE_INT);
-    cass_data_type_add_sub_value_type_by_name(udt_type, "b", CASS_VALUE_TYPE_FLOAT);
+  CassDataType* udt_type = cass_data_type_new_udt(3);
+  cass_data_type_add_sub_value_type_by_name(udt_type, "c", CASS_VALUE_TYPE_TEXT);
+  cass_data_type_add_sub_value_type_by_name(udt_type, "a", CASS_VALUE_TYPE_INT);
+  cass_data_type_add_sub_value_type_by_name(udt_type, "b", CASS_VALUE_TYPE_FLOAT);
 
-    CassUserType* user_type = cass_user_type_new_from_data_type(udt_type);
-    cass_data_type_free(udt_type);
-    cass_user_type_set_string_by_name(user_type, "c", "UDT!");
-    cass_user_type_set_int32_by_name(user_type, "a", 15);
-    cass_user_type_set_float_by_name(user_type, "b", 3.14);
+  CassUserType* user_type = cass_user_type_new_from_data_type(udt_type);
+  cass_data_type_free(udt_type);
+  cass_user_type_set_string_by_name(user_type, "c", "UDT!");
+  cass_user_type_set_int32_by_name(user_type, "a", 15);
+  cass_user_type_set_float_by_name(user_type, "b", 3.14);
 
-    CassStatement* collection_statement = cass_statement_new("INSERT INTO ks.t2(pk, ck, v, v2, v3) VALUES (?, ?, ?, ?, ?)", 5);
-    cass_statement_bind_int32(collection_statement, 0, 1);
-    cass_statement_bind_int32(collection_statement, 1, 2);
-    cass_statement_bind_collection(collection_statement, 2, list);
-    cass_statement_bind_collection(collection_statement, 3, map);
-    cass_statement_bind_user_type(collection_statement, 4, user_type);
-    cass_collection_free(list);
-    cass_collection_free(map);
-    cass_user_type_free(user_type);
+  CassStatement* collection_statement =
+      cass_statement_new("INSERT INTO ks.t2(pk, ck, v, v2, v3) VALUES (?, ?, ?, ?, ?)", 5);
+  cass_statement_bind_int32(collection_statement, 0, 1);
+  cass_statement_bind_int32(collection_statement, 1, 2);
+  cass_statement_bind_collection(collection_statement, 2, list);
+  cass_statement_bind_collection(collection_statement, 3, map);
+  cass_statement_bind_user_type(collection_statement, 4, user_type);
+  cass_collection_free(list);
+  cass_collection_free(map);
+  cass_user_type_free(user_type);
 
-    CassFuture* collection_statement_future = cass_session_execute(session, collection_statement);
-    cass_future_set_callback(collection_statement_future, print_error_cb, NULL);
-    cass_future_wait(collection_statement_future);
-    cass_future_free(collection_statement_future);
-    cass_statement_free(collection_statement);
+  CassFuture* collection_statement_future = cass_session_execute(session, collection_statement);
+  cass_future_set_callback(collection_statement_future, print_error_cb, NULL);
+  cass_future_wait(collection_statement_future);
+  cass_future_free(collection_statement_future);
+  cass_statement_free(collection_statement);
 
-    CassStatement* select_statement = cass_statement_new("SELECT pk, ck, v, v2 FROM ks.t", 0);
-    CassFuture* select_future = cass_session_execute(session, select_statement);
-    printf("select code: %d\n", cass_future_error_code(select_future));
-    
-    const CassResult* select_result = cass_future_get_result(select_future);
-    CassIterator* res_iterator = cass_iterator_from_result(select_result);
-    while (cass_iterator_next(res_iterator)) {
-        const CassRow* row = cass_iterator_get_row(res_iterator);
+  CassStatement* select_statement = cass_statement_new("SELECT pk, ck, v, v2 FROM ks.t", 0);
+  CassFuture* select_future = cass_session_execute(session, select_statement);
+  printf("select code: %d\n", cass_future_error_code(select_future));
 
-        int32_t pk, ck, v;
-        const char *s;
-        size_t s_len;
-        cass_value_get_int32(cass_row_get_column(row, 0), &pk);
-        cass_value_get_int32(cass_row_get_column(row, 1), &ck);
-        cass_value_get_int32(cass_row_get_column(row, 2), &v);
-        cass_value_get_string(cass_row_get_column(row, 3), &s, &s_len);
-        printf("pk: %d, ck: %d, v: %d, v2: %.*s\n", pk, ck, v, s_len, s);
+  const CassResult* select_result = cass_future_get_result(select_future);
+  CassIterator* res_iterator = cass_iterator_from_result(select_result);
+  while (cass_iterator_next(res_iterator)) {
+    const CassRow* row = cass_iterator_get_row(res_iterator);
+
+    int32_t pk, ck, v;
+    const char* s;
+    size_t s_len;
+    cass_value_get_int32(cass_row_get_column(row, 0), &pk);
+    cass_value_get_int32(cass_row_get_column(row, 1), &ck);
+    cass_value_get_int32(cass_row_get_column(row, 2), &v);
+    cass_value_get_string(cass_row_get_column(row, 3), &s, &s_len);
+    printf("pk: %d, ck: %d, v: %d, v2: %.*s\n", pk, ck, v, s_len, s);
+  }
+
+  cass_iterator_free(res_iterator);
+  cass_result_free(select_result);
+  cass_future_free(select_future);
+  cass_statement_free(select_statement);
+
+  CassStatement* select_paged_statement = cass_statement_new("SELECT pk, ck, v FROM ks.t", 0);
+  cass_statement_set_paging_size(select_paged_statement, 1);
+
+  puts("");
+
+  cass_bool_t has_more_pages = cass_true;
+  while (has_more_pages) {
+    CassFuture* page_future = cass_session_execute(session, select_paged_statement);
+
+    const CassResult* page_result = cass_future_get_result(page_future);
+
+    if (page_result == NULL) {
+      puts("Error!");
+      return 1;
     }
 
-    cass_iterator_free(res_iterator);
-    cass_result_free(select_result);
-    cass_future_free(select_future);
-    cass_statement_free(select_statement);
+    CassIterator* page_iterator = cass_iterator_from_result(page_result);
+    while (cass_iterator_next(page_iterator)) {
+      const CassRow* row = cass_iterator_get_row(page_iterator);
 
-    CassStatement* select_paged_statement = cass_statement_new("SELECT pk, ck, v FROM ks.t", 0);
-    cass_statement_set_paging_size(select_paged_statement, 1);
-
-    puts("");
-
-    cass_bool_t has_more_pages = cass_true;
-    while (has_more_pages) {
-        CassFuture* page_future = cass_session_execute(session, select_paged_statement);
-
-        const CassResult* page_result = cass_future_get_result(page_future);
-
-        if (page_result == NULL) {
-            puts("Error!");
-            return 1;
-        }
-
-        CassIterator* page_iterator = cass_iterator_from_result(page_result);
-        while (cass_iterator_next(page_iterator)) {
-            const CassRow* row = cass_iterator_get_row(page_iterator);
-
-            int32_t pk, ck, v;
-            cass_value_get_int32(cass_row_get_column(row, 0), &pk);
-            cass_value_get_int32(cass_row_get_column(row, 1), &ck);
-            cass_value_get_int32(cass_row_get_column(row, 2), &v);
-            printf("pk: %d, ck: %d, v: %d\n", pk, ck, v);
-        }
-
-        puts("[PAGE END]");
-
-        has_more_pages = cass_result_has_more_pages(page_result);
-
-        if (has_more_pages) {
-            cass_statement_set_paging_state(select_paged_statement, page_result);
-        }
-
-        cass_result_free(page_result);
-        cass_future_free(page_future);
+      int32_t pk, ck, v;
+      cass_value_get_int32(cass_row_get_column(row, 0), &pk);
+      cass_value_get_int32(cass_row_get_column(row, 1), &ck);
+      cass_value_get_int32(cass_row_get_column(row, 2), &v);
+      printf("pk: %d, ck: %d, v: %d\n", pk, ck, v);
     }
 
-    cass_statement_free(select_paged_statement);
+    puts("[PAGE END]");
 
-    cass_cluster_free(cluster);
-    cass_session_free(session);
+    has_more_pages = cass_result_has_more_pages(page_result);
+
+    if (has_more_pages) {
+      cass_statement_set_paging_state(select_paged_statement, page_result);
+    }
+
+    cass_result_free(page_result);
+    cass_future_free(page_future);
+  }
+
+  cass_statement_free(select_paged_statement);
+
+  cass_cluster_free(cluster);
+  cass_session_free(session);
 }

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -24,7 +24,7 @@
 #include <iostream>
 
 extern "C" {
-  #include "testing_rust_impls.h"
+#include "testing_rust_impls.h"
 }
 
 namespace datastax { namespace internal { namespace testing {
@@ -43,9 +43,7 @@ unsigned get_connect_timeout_from_cluster(CassCluster* cluster) {
   return testing_cluster_get_connect_timeout(cluster);
 }
 
-int get_port_from_cluster(CassCluster* cluster) {
-  return testing_cluster_get_port(cluster);
-}
+int get_port_from_cluster(CassCluster* cluster) { return testing_cluster_get_port(cluster); }
 
 String get_contact_points_from_cluster(CassCluster* cluster) {
   char* contact_points;

--- a/src/testing_rust_impls.h
+++ b/src/testing_rust_impls.h
@@ -4,22 +4,23 @@
 #include "cassandra.h"
 
 extern "C" {
-    // Retrieves a connect timeout from cluster config.
-    CASS_EXPORT cass_uint16_t testing_cluster_get_connect_timeout(CassCluster *cluster);
+// Retrieves a connect timeout from cluster config.
+CASS_EXPORT cass_uint16_t testing_cluster_get_connect_timeout(CassCluster* cluster);
 
-    // Retrieves a CQL connection port from cluster config.
-    CASS_EXPORT cass_int32_t testing_cluster_get_port(CassCluster* cluster);
+// Retrieves a CQL connection port from cluster config.
+CASS_EXPORT cass_int32_t testing_cluster_get_port(CassCluster* cluster);
 
-    // Retrieves a contact points string. The contact points are delimited with ','.
-    //
-    // This function can fail, if any of the contact points contains a nul byte.
-    // Then, the resulting pointer is set to null.
-    //
-    // On success, this function allocates a contact points string, which needs to be then
-    // freed with `testing_free_contact_points`.
-    CASS_EXPORT void testing_cluster_get_contact_points(CassCluster *cluster, char **contact_points, size_t *contact_points_length);
+// Retrieves a contact points string. The contact points are delimited with ','.
+//
+// This function can fail, if any of the contact points contains a nul byte.
+// Then, the resulting pointer is set to null.
+//
+// On success, this function allocates a contact points string, which needs to be then
+// freed with `testing_free_contact_points`.
+CASS_EXPORT void testing_cluster_get_contact_points(CassCluster* cluster, char** contact_points,
+                                                    size_t* contact_points_length);
 
-    CASS_EXPORT void testing_free_contact_points(char *contact_points);
+CASS_EXPORT void testing_free_contact_points(char* contact_points);
 }
 
 #endif

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -1,397 +1,295 @@
 #include "cassandra.h"
 #include <stdexcept>
 
-CASS_EXPORT size_t
-cass_aggregate_meta_argument_count(const CassAggregateMeta* aggregate_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_argument_count\n");
+CASS_EXPORT size_t cass_aggregate_meta_argument_count(const CassAggregateMeta* aggregate_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_argument_count\n");
 }
 CASS_EXPORT const CassDataType*
-cass_aggregate_meta_argument_type(const CassAggregateMeta* aggregate_meta,
-                                  size_t index){
-	throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_argument_type\n");
+cass_aggregate_meta_argument_type(const CassAggregateMeta* aggregate_meta, size_t index) {
+  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_argument_type\n");
 }
 CASS_EXPORT const CassValue*
-cass_aggregate_meta_field_by_name(const CassAggregateMeta* aggregate_meta,
-                                  const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_field_by_name\n");
+cass_aggregate_meta_field_by_name(const CassAggregateMeta* aggregate_meta, const char* name) {
+  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_field_by_name\n");
 }
 CASS_EXPORT const CassFunctionMeta*
-cass_aggregate_meta_final_func(const CassAggregateMeta* aggregate_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_final_func\n");
+cass_aggregate_meta_final_func(const CassAggregateMeta* aggregate_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_final_func\n");
 }
-CASS_EXPORT void
-cass_aggregate_meta_full_name(const CassAggregateMeta* aggregate_meta,
-                              const char** full_name,
-                              size_t* full_name_length){
-	throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_full_name\n");
+CASS_EXPORT void cass_aggregate_meta_full_name(const CassAggregateMeta* aggregate_meta,
+                                               const char** full_name, size_t* full_name_length) {
+  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_full_name\n");
 }
 CASS_EXPORT const CassValue*
-cass_aggregate_meta_init_cond(const CassAggregateMeta* aggregate_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_init_cond\n");
+cass_aggregate_meta_init_cond(const CassAggregateMeta* aggregate_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_init_cond\n");
 }
-CASS_EXPORT void
-cass_aggregate_meta_name(const CassAggregateMeta* aggregate_meta,
-                         const char** name,
-                         size_t* name_length){
-	throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_name\n");
+CASS_EXPORT void cass_aggregate_meta_name(const CassAggregateMeta* aggregate_meta,
+                                          const char** name, size_t* name_length) {
+  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_name\n");
 }
 CASS_EXPORT const CassDataType*
-cass_aggregate_meta_return_type(const CassAggregateMeta* aggregate_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_return_type\n");
+cass_aggregate_meta_return_type(const CassAggregateMeta* aggregate_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_return_type\n");
 }
 CASS_EXPORT const CassFunctionMeta*
-cass_aggregate_meta_state_func(const CassAggregateMeta* aggregate_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_state_func\n");
+cass_aggregate_meta_state_func(const CassAggregateMeta* aggregate_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_state_func\n");
 }
 CASS_EXPORT const CassDataType*
-cass_aggregate_meta_state_type(const CassAggregateMeta* aggregate_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_state_type\n");
+cass_aggregate_meta_state_type(const CassAggregateMeta* aggregate_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_state_type\n");
 }
-CASS_EXPORT void
-cass_authenticator_set_error(CassAuthenticator* auth,
-                             const char* message){
-	throw std::runtime_error("UNIMPLEMENTED cass_authenticator_set_error\n");
+CASS_EXPORT void cass_authenticator_set_error(CassAuthenticator* auth, const char* message) {
+  throw std::runtime_error("UNIMPLEMENTED cass_authenticator_set_error\n");
 }
-CASS_EXPORT CassError
-cass_batch_set_keyspace(CassBatch* batch,
-                        const char* keyspace){
-	throw std::runtime_error("UNIMPLEMENTED cass_batch_set_keyspace\n");
+CASS_EXPORT CassError cass_batch_set_keyspace(CassBatch* batch, const char* keyspace) {
+  throw std::runtime_error("UNIMPLEMENTED cass_batch_set_keyspace\n");
 }
-CASS_EXPORT CassError
-cass_cluster_set_authenticator_callbacks(CassCluster* cluster,
-                                         const CassAuthenticatorCallbacks* exchange_callbacks,
-                                         CassAuthenticatorDataCleanupCallback cleanup_callback,
-                                         void* data){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_authenticator_callbacks\n");
+CASS_EXPORT CassError cass_cluster_set_authenticator_callbacks(
+    CassCluster* cluster, const CassAuthenticatorCallbacks* exchange_callbacks,
+    CassAuthenticatorDataCleanupCallback cleanup_callback, void* data) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_authenticator_callbacks\n");
 }
-CASS_EXPORT void
-cass_cluster_set_blacklist_dc_filtering(CassCluster* cluster,
-                                        const char* dcs){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_blacklist_dc_filtering\n");
+CASS_EXPORT void cass_cluster_set_blacklist_dc_filtering(CassCluster* cluster, const char* dcs) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_blacklist_dc_filtering\n");
 }
-CASS_EXPORT void
-cass_cluster_set_blacklist_filtering(CassCluster* cluster,
-                                     const char* hosts){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_blacklist_filtering\n");
+CASS_EXPORT void cass_cluster_set_blacklist_filtering(CassCluster* cluster, const char* hosts) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_blacklist_filtering\n");
 }
-CASS_EXPORT CassError
-cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init(CassCluster* cluster,
-                                                                const char* path){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init\n");
+CASS_EXPORT CassError cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init(
+    CassCluster* cluster, const char* path) {
+  throw std::runtime_error(
+      "UNIMPLEMENTED cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init\n");
 }
-CASS_EXPORT void
-cass_cluster_set_connection_heartbeat_interval(CassCluster* cluster,
-                                               unsigned interval_secs){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_connection_heartbeat_interval\n");
+CASS_EXPORT void cass_cluster_set_connection_heartbeat_interval(CassCluster* cluster,
+                                                                unsigned interval_secs) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_connection_heartbeat_interval\n");
 }
-CASS_EXPORT void
-cass_cluster_set_connection_idle_timeout(CassCluster* cluster,
-                                         unsigned timeout_secs){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_connection_idle_timeout\n");
+CASS_EXPORT void cass_cluster_set_connection_idle_timeout(CassCluster* cluster,
+                                                          unsigned timeout_secs) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_connection_idle_timeout\n");
 }
-CASS_EXPORT void
-cass_cluster_set_constant_reconnect(CassCluster* cluster,
-                                    cass_uint64_t delay_ms){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_constant_reconnect\n");
+CASS_EXPORT void cass_cluster_set_constant_reconnect(CassCluster* cluster, cass_uint64_t delay_ms) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_constant_reconnect\n");
 }
-CASS_EXPORT CassError
-cass_cluster_set_core_connections_per_host(CassCluster* cluster,
-                                           unsigned num_connections){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_core_connections_per_host\n");
+CASS_EXPORT CassError cass_cluster_set_core_connections_per_host(CassCluster* cluster,
+                                                                 unsigned num_connections) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_core_connections_per_host\n");
 }
-CASS_EXPORT CassError
-cass_cluster_set_host_listener_callback(CassCluster* cluster,
-                                        CassHostListenerCallback callback,
-                                        void* data){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_host_listener_callback\n");
+CASS_EXPORT CassError cass_cluster_set_host_listener_callback(CassCluster* cluster,
+                                                              CassHostListenerCallback callback,
+                                                              void* data) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_host_listener_callback\n");
 }
-CASS_EXPORT CassError
-cass_cluster_set_local_address(CassCluster* cluster,
-                               const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_local_address\n");
+CASS_EXPORT CassError cass_cluster_set_local_address(CassCluster* cluster, const char* name) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_local_address\n");
 }
-CASS_EXPORT CassError
-cass_cluster_set_no_compact(CassCluster* cluster,
-                            cass_bool_t enabled){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_no_compact\n");
+CASS_EXPORT CassError cass_cluster_set_no_compact(CassCluster* cluster, cass_bool_t enabled) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_no_compact\n");
 }
-CASS_EXPORT CassError
-cass_cluster_set_num_threads_io(CassCluster* cluster,
-                                unsigned num_threads){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_num_threads_io\n");
+CASS_EXPORT CassError cass_cluster_set_num_threads_io(CassCluster* cluster, unsigned num_threads) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_num_threads_io\n");
 }
-CASS_EXPORT CassError
-cass_cluster_set_prepare_on_all_hosts(CassCluster* cluster,
-                                      cass_bool_t enabled){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_prepare_on_all_hosts\n");
+CASS_EXPORT CassError cass_cluster_set_prepare_on_all_hosts(CassCluster* cluster,
+                                                            cass_bool_t enabled) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_prepare_on_all_hosts\n");
 }
-CASS_EXPORT CassError
-cass_cluster_set_prepare_on_up_or_add_host(CassCluster* cluster,
-                                           cass_bool_t enabled){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_prepare_on_up_or_add_host\n");
+CASS_EXPORT CassError cass_cluster_set_prepare_on_up_or_add_host(CassCluster* cluster,
+                                                                 cass_bool_t enabled) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_prepare_on_up_or_add_host\n");
 }
-CASS_EXPORT void
-cass_cluster_set_timestamp_gen(CassCluster* cluster,
-                               CassTimestampGen* timestamp_gen){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_timestamp_gen\n");
+CASS_EXPORT void cass_cluster_set_timestamp_gen(CassCluster* cluster,
+                                                CassTimestampGen* timestamp_gen) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_timestamp_gen\n");
 }
-CASS_EXPORT void
-cass_cluster_set_whitelist_dc_filtering(CassCluster* cluster,
-                                        const char* dcs){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_whitelist_dc_filtering\n");
+CASS_EXPORT void cass_cluster_set_whitelist_dc_filtering(CassCluster* cluster, const char* dcs) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_whitelist_dc_filtering\n");
 }
-CASS_EXPORT void
-cass_cluster_set_whitelist_filtering(CassCluster* cluster,
-                                     const char* hosts){
-	throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_whitelist_filtering\n");
+CASS_EXPORT void cass_cluster_set_whitelist_filtering(CassCluster* cluster, const char* hosts) {
+  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_whitelist_filtering\n");
 }
-CASS_EXPORT CassError
-cass_collection_append_custom(CassCollection* collection,
-                              const char* class_name,
-                              const cass_byte_t* value,
-                              size_t value_size){
-	throw std::runtime_error("UNIMPLEMENTED cass_collection_append_custom\n");
+CASS_EXPORT CassError cass_collection_append_custom(CassCollection* collection,
+                                                    const char* class_name,
+                                                    const cass_byte_t* value, size_t value_size) {
+  throw std::runtime_error("UNIMPLEMENTED cass_collection_append_custom\n");
 }
-CASS_EXPORT const CassValue*
-cass_column_meta_field_by_name(const CassColumnMeta* column_meta,
-                               const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_column_meta_field_by_name\n");
+CASS_EXPORT const CassValue* cass_column_meta_field_by_name(const CassColumnMeta* column_meta,
+                                                            const char* name) {
+  throw std::runtime_error("UNIMPLEMENTED cass_column_meta_field_by_name\n");
 }
-CASS_EXPORT void
-cass_custom_payload_free(CassCustomPayload* payload){
-	throw std::runtime_error("UNIMPLEMENTED cass_custom_payload_free\n");
+CASS_EXPORT void cass_custom_payload_free(CassCustomPayload* payload) {
+  throw std::runtime_error("UNIMPLEMENTED cass_custom_payload_free\n");
 }
-CASS_EXPORT void
-cass_custom_payload_set(CassCustomPayload* payload,
-                        const char* name,
-                        const cass_byte_t* value,
-                        size_t value_size){
-	throw std::runtime_error("UNIMPLEMENTED cass_custom_payload_set\n");
+CASS_EXPORT void cass_custom_payload_set(CassCustomPayload* payload, const char* name,
+                                         const cass_byte_t* value, size_t value_size) {
+  throw std::runtime_error("UNIMPLEMENTED cass_custom_payload_set\n");
 }
-CASS_EXPORT CassError
-cass_execution_profile_set_blacklist_dc_filtering(CassExecProfile* profile,
-                                                  const char* dcs){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_blacklist_dc_filtering\n");
+CASS_EXPORT CassError cass_execution_profile_set_blacklist_dc_filtering(CassExecProfile* profile,
+                                                                        const char* dcs) {
+  throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_blacklist_dc_filtering\n");
 }
-CASS_EXPORT CassError
-cass_execution_profile_set_blacklist_filtering(CassExecProfile* profile,
-                                               const char* hosts){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_blacklist_filtering\n");
+CASS_EXPORT CassError cass_execution_profile_set_blacklist_filtering(CassExecProfile* profile,
+                                                                     const char* hosts) {
+  throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_blacklist_filtering\n");
 }
-CASS_EXPORT CassError
-cass_execution_profile_set_whitelist_dc_filtering(CassExecProfile* profile,
-                                                  const char* dcs){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_whitelist_dc_filtering\n");
+CASS_EXPORT CassError cass_execution_profile_set_whitelist_dc_filtering(CassExecProfile* profile,
+                                                                        const char* dcs) {
+  throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_whitelist_dc_filtering\n");
 }
-CASS_EXPORT CassError
-cass_execution_profile_set_whitelist_filtering(CassExecProfile* profile,
-                                               const char* hosts){
-	throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_whitelist_filtering\n");
+CASS_EXPORT CassError cass_execution_profile_set_whitelist_filtering(CassExecProfile* profile,
+                                                                     const char* hosts) {
+  throw std::runtime_error("UNIMPLEMENTED cass_execution_profile_set_whitelist_filtering\n");
 }
-CASS_EXPORT CassError
-cass_function_meta_argument(const CassFunctionMeta* function_meta,
-                            size_t index,
-                            const char** name,
-                            size_t* name_length,
-                            const CassDataType** type){
-	throw std::runtime_error("UNIMPLEMENTED cass_function_meta_argument\n");
+CASS_EXPORT CassError cass_function_meta_argument(const CassFunctionMeta* function_meta,
+                                                  size_t index, const char** name,
+                                                  size_t* name_length, const CassDataType** type) {
+  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_argument\n");
 }
-CASS_EXPORT size_t
-cass_function_meta_argument_count(const CassFunctionMeta* function_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_function_meta_argument_count\n");
+CASS_EXPORT size_t cass_function_meta_argument_count(const CassFunctionMeta* function_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_argument_count\n");
 }
 CASS_EXPORT const CassDataType*
-cass_function_meta_argument_type_by_name(const CassFunctionMeta* function_meta,
-                                         const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_function_meta_argument_type_by_name\n");
+cass_function_meta_argument_type_by_name(const CassFunctionMeta* function_meta, const char* name) {
+  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_argument_type_by_name\n");
 }
-CASS_EXPORT void
-cass_function_meta_body(const CassFunctionMeta* function_meta,
-                        const char** body,
-                        size_t* body_length){
-	throw std::runtime_error("UNIMPLEMENTED cass_function_meta_body\n");
+CASS_EXPORT void cass_function_meta_body(const CassFunctionMeta* function_meta, const char** body,
+                                         size_t* body_length) {
+  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_body\n");
 }
 CASS_EXPORT cass_bool_t
-cass_function_meta_called_on_null_input(const CassFunctionMeta* function_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_function_meta_called_on_null_input\n");
+cass_function_meta_called_on_null_input(const CassFunctionMeta* function_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_called_on_null_input\n");
 }
-CASS_EXPORT const CassValue*
-cass_function_meta_field_by_name(const CassFunctionMeta* function_meta,
-                                 const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_function_meta_field_by_name\n");
+CASS_EXPORT const CassValue* cass_function_meta_field_by_name(const CassFunctionMeta* function_meta,
+                                                              const char* name) {
+  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_field_by_name\n");
 }
-CASS_EXPORT void
-cass_function_meta_full_name(const CassFunctionMeta* function_meta,
-                             const char** full_name,
-                             size_t* full_name_length){
-	throw std::runtime_error("UNIMPLEMENTED cass_function_meta_full_name\n");
+CASS_EXPORT void cass_function_meta_full_name(const CassFunctionMeta* function_meta,
+                                              const char** full_name, size_t* full_name_length) {
+  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_full_name\n");
 }
-CASS_EXPORT void
-cass_function_meta_language(const CassFunctionMeta* function_meta,
-                            const char** language,
-                            size_t* language_length){
-	throw std::runtime_error("UNIMPLEMENTED cass_function_meta_language\n");
+CASS_EXPORT void cass_function_meta_language(const CassFunctionMeta* function_meta,
+                                             const char** language, size_t* language_length) {
+  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_language\n");
 }
-CASS_EXPORT void
-cass_function_meta_name(const CassFunctionMeta* function_meta,
-                        const char** name,
-                        size_t* name_length){
-	throw std::runtime_error("UNIMPLEMENTED cass_function_meta_name\n");
+CASS_EXPORT void cass_function_meta_name(const CassFunctionMeta* function_meta, const char** name,
+                                         size_t* name_length) {
+  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_name\n");
 }
 CASS_EXPORT const CassDataType*
-cass_function_meta_return_type(const CassFunctionMeta* function_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_function_meta_return_type\n");
+cass_function_meta_return_type(const CassFunctionMeta* function_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_return_type\n");
 }
-CASS_EXPORT const CassNode*
-cass_future_coordinator(CassFuture* future){
-	throw std::runtime_error("UNIMPLEMENTED cass_future_coordinator\n");
+CASS_EXPORT const CassNode* cass_future_coordinator(CassFuture* future) {
+  throw std::runtime_error("UNIMPLEMENTED cass_future_coordinator\n");
 }
-CASS_EXPORT const CassValue*
-cass_index_meta_field_by_name(const CassIndexMeta* index_meta,
-                               const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_index_meta_field_by_name\n");
+CASS_EXPORT const CassValue* cass_index_meta_field_by_name(const CassIndexMeta* index_meta,
+                                                           const char* name) {
+  throw std::runtime_error("UNIMPLEMENTED cass_index_meta_field_by_name\n");
 }
 CASS_EXPORT const CassAggregateMeta*
-cass_keyspace_meta_aggregate_by_name(const CassKeyspaceMeta* keyspace_meta,
-                                     const char* name,
-                                     const char* arguments){
-	throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_aggregate_by_name\n");
+cass_keyspace_meta_aggregate_by_name(const CassKeyspaceMeta* keyspace_meta, const char* name,
+                                     const char* arguments) {
+  throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_aggregate_by_name\n");
 }
-CASS_EXPORT const CassValue*
-cass_keyspace_meta_field_by_name(const CassKeyspaceMeta* keyspace_meta,
-                                 const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_field_by_name\n");
+CASS_EXPORT const CassValue* cass_keyspace_meta_field_by_name(const CassKeyspaceMeta* keyspace_meta,
+                                                              const char* name) {
+  throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_field_by_name\n");
 }
 CASS_EXPORT const CassFunctionMeta*
-cass_keyspace_meta_function_by_name(const CassKeyspaceMeta* keyspace_meta,
-                                    const char* name,
-                                    const char* arguments){
-	throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_function_by_name\n");
+cass_keyspace_meta_function_by_name(const CassKeyspaceMeta* keyspace_meta, const char* name,
+                                    const char* arguments) {
+  throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_function_by_name\n");
 }
-CASS_EXPORT cass_bool_t
-cass_keyspace_meta_is_virtual(const CassKeyspaceMeta* keyspace_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_is_virtual\n");
+CASS_EXPORT cass_bool_t cass_keyspace_meta_is_virtual(const CassKeyspaceMeta* keyspace_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_is_virtual\n");
 }
 CASS_EXPORT const CassValue*
 cass_materialized_view_meta_field_by_name(const CassMaterializedViewMeta* view_meta,
-                                          const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_materialized_view_meta_field_by_name\n");
+                                          const char* name) {
+  throw std::runtime_error("UNIMPLEMENTED cass_materialized_view_meta_field_by_name\n");
 }
 CASS_EXPORT const CassDataType*
-cass_prepared_parameter_data_type_by_name(const CassPrepared* prepared,
-                                          const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_prepared_parameter_data_type_by_name\n");
+cass_prepared_parameter_data_type_by_name(const CassPrepared* prepared, const char* name) {
+  throw std::runtime_error("UNIMPLEMENTED cass_prepared_parameter_data_type_by_name\n");
 }
-CASS_EXPORT CassRetryPolicy*
-cass_retry_policy_logging_new(CassRetryPolicy* child_retry_policy){
-	throw std::runtime_error("UNIMPLEMENTED cass_retry_policy_logging_new\n");
+CASS_EXPORT CassRetryPolicy* cass_retry_policy_logging_new(CassRetryPolicy* child_retry_policy) {
+  throw std::runtime_error("UNIMPLEMENTED cass_retry_policy_logging_new\n");
 }
-CASS_EXPORT CassVersion
-cass_schema_meta_version(const CassSchemaMeta* schema_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_schema_meta_version\n");
+CASS_EXPORT CassVersion cass_schema_meta_version(const CassSchemaMeta* schema_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_schema_meta_version\n");
 }
-CASS_EXPORT void
-cass_session_get_metrics(const CassSession* session,
-                         CassMetrics* output){
-	throw std::runtime_error("UNIMPLEMENTED cass_session_get_metrics\n");
+CASS_EXPORT void cass_session_get_metrics(const CassSession* session, CassMetrics* output) {
+  throw std::runtime_error("UNIMPLEMENTED cass_session_get_metrics\n");
 }
 CASS_EXPORT void
 cass_session_get_speculative_execution_metrics(const CassSession* session,
-                                               CassSpeculativeExecutionMetrics* output){
-	throw std::runtime_error("UNIMPLEMENTED cass_session_get_speculative_execution_metrics\n");
+                                               CassSpeculativeExecutionMetrics* output) {
+  throw std::runtime_error("UNIMPLEMENTED cass_session_get_speculative_execution_metrics\n");
 }
-CASS_EXPORT CassError
-cass_statement_add_key_index(CassStatement* statement,
-                             size_t index){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_add_key_index\n");
+CASS_EXPORT CassError cass_statement_add_key_index(CassStatement* statement, size_t index) {
+  throw std::runtime_error("UNIMPLEMENTED cass_statement_add_key_index\n");
 }
-CASS_EXPORT CassError
-cass_statement_bind_custom(CassStatement* statement,
-                           size_t index,
-                           const char* class_name,
-                           const cass_byte_t* value,
-                           size_t value_size){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_bind_custom\n");
+CASS_EXPORT CassError cass_statement_bind_custom(CassStatement* statement, size_t index,
+                                                 const char* class_name, const cass_byte_t* value,
+                                                 size_t value_size) {
+  throw std::runtime_error("UNIMPLEMENTED cass_statement_bind_custom\n");
 }
-CASS_EXPORT CassError
-cass_statement_bind_custom_by_name(CassStatement* statement,
-                                   const char* name,
-                                   const char* class_name,
-                                   const cass_byte_t* value,
-                                   size_t value_size){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_bind_custom_by_name\n");
+CASS_EXPORT CassError cass_statement_bind_custom_by_name(CassStatement* statement, const char* name,
+                                                         const char* class_name,
+                                                         const cass_byte_t* value,
+                                                         size_t value_size) {
+  throw std::runtime_error("UNIMPLEMENTED cass_statement_bind_custom_by_name\n");
 }
-CASS_EXPORT CassError
-cass_statement_set_custom_payload(CassStatement* statement,
-                                  const CassCustomPayload* payload){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_set_custom_payload\n");
+CASS_EXPORT CassError cass_statement_set_custom_payload(CassStatement* statement,
+                                                        const CassCustomPayload* payload) {
+  throw std::runtime_error("UNIMPLEMENTED cass_statement_set_custom_payload\n");
 }
-CASS_EXPORT CassError
-cass_statement_set_host(CassStatement* statement,
-                        const char* host,
-                        int port){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_set_host\n");
+CASS_EXPORT CassError cass_statement_set_host(CassStatement* statement, const char* host,
+                                              int port) {
+  throw std::runtime_error("UNIMPLEMENTED cass_statement_set_host\n");
 }
-CASS_EXPORT CassError
-cass_statement_set_host_inet(CassStatement* statement,
-                             const CassInet* host,
-                             int port){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_set_host_inet\n");
+CASS_EXPORT CassError cass_statement_set_host_inet(CassStatement* statement, const CassInet* host,
+                                                   int port) {
+  throw std::runtime_error("UNIMPLEMENTED cass_statement_set_host_inet\n");
 }
-CASS_EXPORT CassError
-cass_statement_set_keyspace(CassStatement* statement,
-                            const char* keyspace){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_set_keyspace\n");
+CASS_EXPORT CassError cass_statement_set_keyspace(CassStatement* statement, const char* keyspace) {
+  throw std::runtime_error("UNIMPLEMENTED cass_statement_set_keyspace\n");
 }
-CASS_EXPORT CassError
-cass_statement_set_node(CassStatement* statement,
-                        const CassNode* node){
-	throw std::runtime_error("UNIMPLEMENTED cass_statement_set_node\n");
+CASS_EXPORT CassError cass_statement_set_node(CassStatement* statement, const CassNode* node) {
+  throw std::runtime_error("UNIMPLEMENTED cass_statement_set_node\n");
 }
 CASS_EXPORT CassClusteringOrder
-cass_table_meta_clustering_key_order(const CassTableMeta* table_meta,
-                                     size_t index){
-	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_clustering_key_order\n");
+cass_table_meta_clustering_key_order(const CassTableMeta* table_meta, size_t index) {
+  throw std::runtime_error("UNIMPLEMENTED cass_table_meta_clustering_key_order\n");
 }
-CASS_EXPORT const CassValue*
-cass_table_meta_field_by_name(const CassTableMeta* table_meta,
-                              const char* name){
-	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_field_by_name\n");
+CASS_EXPORT const CassValue* cass_table_meta_field_by_name(const CassTableMeta* table_meta,
+                                                           const char* name) {
+  throw std::runtime_error("UNIMPLEMENTED cass_table_meta_field_by_name\n");
 }
-CASS_EXPORT const CassIndexMeta*
-cass_table_meta_index_by_name(const CassTableMeta* table_meta,
-                               const char* index){
-	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_index_by_name\n");
+CASS_EXPORT const CassIndexMeta* cass_table_meta_index_by_name(const CassTableMeta* table_meta,
+                                                               const char* index) {
+  throw std::runtime_error("UNIMPLEMENTED cass_table_meta_index_by_name\n");
 }
-CASS_EXPORT size_t
-cass_table_meta_index_count(const CassTableMeta* table_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_index_count\n");
+CASS_EXPORT size_t cass_table_meta_index_count(const CassTableMeta* table_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_table_meta_index_count\n");
 }
-CASS_EXPORT cass_bool_t
-cass_table_meta_is_virtual(const CassTableMeta* table_meta){
-	throw std::runtime_error("UNIMPLEMENTED cass_table_meta_is_virtual\n");
+CASS_EXPORT cass_bool_t cass_table_meta_is_virtual(const CassTableMeta* table_meta) {
+  throw std::runtime_error("UNIMPLEMENTED cass_table_meta_is_virtual\n");
 }
-CASS_EXPORT CassError
-cass_tuple_set_custom(CassTuple* tuple,
-                      size_t index,
-                      const char* class_name,
-                      const cass_byte_t* value,
-                      size_t value_size){
-	throw std::runtime_error("UNIMPLEMENTED cass_tuple_set_custom\n");
+CASS_EXPORT CassError cass_tuple_set_custom(CassTuple* tuple, size_t index, const char* class_name,
+                                            const cass_byte_t* value, size_t value_size) {
+  throw std::runtime_error("UNIMPLEMENTED cass_tuple_set_custom\n");
 }
-CASS_EXPORT CassError
-cass_user_type_set_custom(CassUserType* user_type,
-                          size_t index,
-                          const char* class_name,
-                          const cass_byte_t* value,
-                          size_t value_size){
-	throw std::runtime_error("UNIMPLEMENTED cass_user_type_set_custom\n");
+CASS_EXPORT CassError cass_user_type_set_custom(CassUserType* user_type, size_t index,
+                                                const char* class_name, const cass_byte_t* value,
+                                                size_t value_size) {
+  throw std::runtime_error("UNIMPLEMENTED cass_user_type_set_custom\n");
 }
-CASS_EXPORT CassError
-cass_user_type_set_custom_by_name(CassUserType* user_type,
-                                  const char* name,
-                                  const char* class_name,
-                                  const cass_byte_t* value,
-                                  size_t value_size){
-	throw std::runtime_error("UNIMPLEMENTED cass_user_type_set_custom_by_name\n");
+CASS_EXPORT CassError cass_user_type_set_custom_by_name(CassUserType* user_type, const char* name,
+                                                        const char* class_name,
+                                                        const cass_byte_t* value,
+                                                        size_t value_size) {
+  throw std::runtime_error("UNIMPLEMENTED cass_user_type_set_custom_by_name\n");
 }


### PR DESCRIPTION
It adds `clang-format` to the list of linters for c/cpp code.
Also it applies format changes suggested by `clang-format`

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.