### PR TITLE
integration: ccm decommission fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ifndef SCYLLA_TEST_FILTER
 SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :BasicsTests.*\
 :ConfigTests.*\
+:ConsistencyThreeNodeClusterTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :BatchSingleNodeClusterTests*:BatchCounterSingleNodeClusterTests*:BatchCounterThreeNodeClusterTests*\
@@ -28,6 +29,7 @@ ifndef CASSANDRA_TEST_FILTER
 CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :BasicsTests.*\
 :ConfigTests.*\
+:ConsistencyThreeNodeClusterTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :ErrorTests.*\

--- a/tests/src/integration/tests/test_consistency.cpp
+++ b/tests/src/integration/tests/test_consistency.cpp
@@ -259,7 +259,7 @@ CASSANDRA_INTEGRATION_TEST_F(ConsistencyThreeNodeClusterTests, OneNodeDecommissi
   session_.execute(select_);
 
   // Decommission node two
-  force_decommission_node(2);
+  decommission_node(2);
 
   // Perform a check using consistency `QUORUM` (N=2, RF=3)
   insert_.set_consistency(CASS_CONSISTENCY_QUORUM);
@@ -317,8 +317,8 @@ CASSANDRA_INTEGRATION_TEST_F(ConsistencyThreeNodeClusterTests, TwoNodesDecommiss
   session_.execute(select_);
 
   // Decommission node two and three
-  force_decommission_node(2);
-  force_decommission_node(3);
+  decommission_node(2);
+  decommission_node(3);
 
   // Perform a check using consistency `ONE` (N=1, RF=3)
   insert_.set_consistency(CASS_CONSISTENCY_ONE);

--- a/tests/src/integration/tests/test_control_connection.cpp
+++ b/tests/src/integration/tests/test_control_connection.cpp
@@ -332,7 +332,7 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests, TopologyChange) {
    * Decommission the bootstrapped node and ensure only the first node is
    * actively used
    */
-  force_decommission_node(2); // Triggers a `REMOVE_NODE` event
+  decommission_node(2); // Triggers a `REMOVE_NODE` event
   expected_nodes.erase(2);
   check_hosts(session, expected_nodes);
 }
@@ -613,7 +613,7 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTwoNodeClusterTests, NodeDecommiss
    */
   logger_.reset();
   logger_.add_critera("Spawning new connection to host " + ccm_->get_ip_prefix() + "1");
-  force_decommission_node(1);
+  decommission_node(1);
   TEST_LOG("Node Decommissioned [" << ccm_->get_ip_prefix() << "1]: Sleeping "
                                    << "for 30 seconds");
   msleep(30000u);

--- a/tests/src/integration/tests/test_session.cpp
+++ b/tests/src/integration/tests/test_session.cpp
@@ -153,7 +153,7 @@ CASSANDRA_INTEGRATION_TEST_F(SessionTest, ExternalHostListener) {
   check_event(CASS_HOST_LISTENER_EVENT_UP, 1);
 
   // Decomission node 1 (down and remove events)
-  force_decommission_node(1);
+  decommission_node(1);
   ASSERT_TRUE(wait_for_event(1u));
   check_event(CASS_HOST_LISTENER_EVENT_DOWN, 1);
   check_event(CASS_HOST_LISTENER_EVENT_REMOVE, 1);


### PR DESCRIPTION
## ccm <node> decommission
Scylla's fork of ccm does not recognize `--force` flag
for `decommission` command. `force_decommission_node` function
appends such flag to the ccm command.

Replaced occurrences of `force_decommission_node` with
`decommission_node` throughout the tests.

## Test filter
Since we fixed the usage of ccm in integration tests regarding
the decommission, we can enable `ConsistencyThreeNodeCluster` test suite.

Unfortunately, other test suites (`SessionTests` and `ControlConnectionTests`)
affected by this change still need some driver's features to be implemented.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.