### PR TITLE
ci: fix ConsistencyTwoNodeClusterTests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ifndef SCYLLA_TEST_FILTER
 SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :BasicsTests.*\
 :ConfigTests.*\
+:ConsistencyTwoNodeClusterTests.*\
 :ConsistencyThreeNodeClusterTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
@@ -29,6 +30,7 @@ ifndef CASSANDRA_TEST_FILTER
 CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :BasicsTests.*\
 :ConfigTests.*\
+:ConsistencyTwoNodeClusterTests.*\
 :ConsistencyThreeNodeClusterTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\

--- a/tests/src/integration/tests/test_consistency.cpp
+++ b/tests/src/integration/tests/test_consistency.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "integration.hpp"
+#include "options.hpp"
 
 /**
  * Consistency integration tests; two node cluster
@@ -227,7 +228,9 @@ CASSANDRA_INTEGRATION_TEST_F(ConsistencyTwoNodeClusterTests, SimpleEachQuorum) {
   session_.execute(insert_);
   // Handle `EACH_QUORUM` read support; added to C* v3.0.0
   // https://issues.apache.org/jira/browse/CASSANDRA-9602
-  if (server_version_ >= "3.0.0") {
+  //
+  // Scylla supports `EACH_QUORUM` for writes only.
+  if (!Options::is_scylla() && server_version_ >= "3.0.0") {
     session_.execute(select_);
   } else {
     ASSERT_EQ(CASS_ERROR_SERVER_INVALID_QUERY, session_.execute(select_, false).error_code());


### PR DESCRIPTION
## EACH_QUORUM for Scylla
Scylla does not support `EACH_QUORUM` reads. The integration tests code needed to be adjusted for it.

## ConsistencyTwoNodeClusterTests
Enabled this test suite (can do that thanks to the EACH_QUORUM fix).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.