### PR TITLE
pkg: fix deb package building and extend CI

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -1,0 +1,64 @@
+name: Build packages
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLORS: always
+
+jobs:
+  build-rpm-pkgs:
+    name: Build rpm packages
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+      # Required by `mock`:
+      ### INFO: It seems that you run Mock in a Docker container.
+      ### Mock though uses container tooling itself (namely Podman) for downloading bootstrap image.
+      ### This might require you to run Mock in 'docker run --privileged'.
+      options: --privileged
+      # It does not seem to be necessary (CI run without it was successful).
+      # However, without it, there appear some errors during `mock` execution.
+      # I've found the solution to these errors here: https://github.com/containers/buildah/issues/3666.
+      # They are related to podman, which is used by `mock` under the hood.
+      volumes:
+        - /var/lib/containers:/var/lib/containers
+
+    strategy:
+      matrix:
+        dist-version: [rocky-9-x86_64, fedora-40-x86_64]
+      fail-fast: false
+    
+    steps:
+      # See: https://github.com/actions/checkout/issues/363
+      # An issue related to GH actions containers
+      - name: Install git and update safe directory
+        run: |
+          dnf update -y
+          dnf install -y git
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Build rpm package for ${{ matrix.dist-version }}
+        run: ./dist/redhat/build_rpm.sh --target ${{ matrix.dist-version }}
+  
+  build-deb-pkgs:
+    name: Build deb packages
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        dist-version: [jammy, noble]
+      fail-fast: false
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Build deb package for ${{ matrix.dist-version }}
+        run: ./dist/debian/build_deb.sh --target ${{ matrix.dist-version }}

--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -14,7 +14,7 @@ export CARGO_HOME
 export RUSTUP_HOME
 
 %:
-	dh $@
+	dh $@ --buildsystem=cmake
 
 override_dh_auto_clean:
 	rm -rf scylla-rust-wrapper/.cargo


### PR DESCRIPTION
Fixed an issue that occurred during deb packages build.

Extended CI by pkg build checks - after future changes, we want to make sure that building packages still works as expected.
In CI, I included builds for 4 distributions (that we've chosen for recent release):
- fedora 40 (rpm)
- rocky 9 (rpm)
- ubuntu jammy (deb)
- ubuntu noble (deb)

Please, let me know if I should include builds for some other distros as well.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~