### PR TITLE
bump version to 0.2.0

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-cpp-driver-rust"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_matches",
  "bindgen",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cpp-driver-rust"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"
 repository = "https://github.com/scylladb/scylla-rust-driver"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB Cpp-Rust-Driver 0.2.0!

## Changes
**Implemented API functions:**
- **CassFuture:**
    - `cass_future_wait_timed` ([#147](https://github.com/scylladb/cpp-rust-driver/pull/147))
- **CassDataType:**
    - `cass_data_type_is_frozen` ([#141](https://github.com/scylladb/cpp-rust-driver/pull/141))
- **CassExecProfile:**
    - `cass_execution_profile_set_no_speculative_execution_policy` ([#150](https://github.com/scylladb/cpp-rust-driver/pull/150))
- **CassCluster:**
    - `cass_cluster_set_request_timeout` ([#151](https://github.com/scylladb/cpp-rust-driver/pull/151))
    - `cass_cluster_set_tcp_keepalive` ([#169](https://github.com/scylladb/cpp-rust-driver/pull/169))
- **CassStatement:**
    - `cass_statement_reset_parameters` ([#171](https://github.com/scylladb/cpp-rust-driver/pull/171))
- **CassCollection:** ([#143](https://github.com/scylladb/cpp-rust-driver/pull/143))
    - `cass_collection_new_from_data_type`
    - `cass_collection_data_type`
- **Token awareness:** ([#170](https://github.com/scylladb/cpp-rust-driver/pull/170))
    - `cass_cluster_set_token_aware_routing_shuffle_replicas`
    - `cass_execution_profile_set_token_aware_routing_shuffle_replicas`
- **Client's identity:** ([#167](https://github.com/scylladb/cpp-rust-driver/pull/167))
    - `cass_cluster_set_application_name[_n]`
    - `cass_cluster_set_application_version[_n]`
    - `cass_cluster_set_client_id`
    - `cass_session_get_client_id`
    
- **Duration CQL type support:** ([#135](https://github.com/scylladb/cpp-rust-driver/pull/135))
    - `cass_statement_bind_duration_*`
    - `cass_user_type_set_duration_*`
    - `cass_tuple_set_duration`
    - `cass_value_get_duration`
    - `cass_value_is_duration`
    - `cass_collection_append_duration`
- **Decimal CQL type support:** ([#146](https://github.com/scylladb/cpp-rust-driver/pull/146))
    - `cass_statement_bind_decimal_*`
    - `cass_user_type_set_decimal_*`
    - `cass_tuple_set_decimal`
    - `cass_value_get_decimal`
    - `cass_value_is_decimal`
    - `cass_collection_append_decimal`
- **Misc:**
    - `cass_consistency_string` ([#165](https://github.com/scylladb/cpp-rust-driver/pull/165))
    - `cass_write_type_string` ([#166](https://github.com/scylladb/cpp-rust-driver/pull/166))


**New features / enhancements**
- Adjusted cpp-rust-driver to new serialization framework introduced in rust-driver 0.11.0. ([#138](https://github.com/scylladb/cpp-rust-driver/pull/138), [#152](https://github.com/scylladb/cpp-rust-driver/pull/152))
- Bumped rust-driver dependency version to 0.14.0. ([#160](https://github.com/scylladb/cpp-rust-driver/pull/160))
- Introduced typechecks logic to the driver. ([#143](https://github.com/scylladb/cpp-rust-driver/pull/143))

**Bug fixes:**
- Bumped `ntest` dependency version to 0.9.3, so `rust-analyzer` is not confused for functions marked with both `#[tokio::test]` and `#[ntest::timeout()]`. ([#137](https://github.com/scylladb/cpp-rust-driver/pull/137))
- Adjusted default default request client timeout according to `cassandra.h` documentation: ([#151](https://github.com/scylladb/cpp-rust-driver/pull/151))

**CI / developer tool improvements:**
- Extended cmake file, so now it can build packages next to the regular builds. ([#129](https://github.com/scylladb/cpp-rust-driver/pull/129))
- Introduced top-level `Makefile` that can be used to mimic CI behaviour locally. ([#159](https://github.com/scylladb/cpp-rust-driver/pull/159), [#174](https://github.com/scylladb/cpp-rust-driver/pull/174))
- Enabled tests against multiple Scylla/Cassandra versions in CI. ([#159](https://github.com/scylladb/cpp-rust-driver/pull/159), [#168](https://github.com/scylladb/cpp-rust-driver/pull/168))
- Fixed clippy lints. ([#145](https://github.com/scylladb/cpp-rust-driver/pull/145)) 
- Fixed an issue that caused some tests against Scylla be unnecessarily skipped. ([#155](https://github.com/scylladb/cpp-rust-driver/pull/155))
- Removed some implemented functions from `testing_unimplemented.cpp` ([#161](https://github.com/scylladb/cpp-rust-driver/pull/161))
- Fixed and enabled `ConfigTests` suite. ([#163](https://github.com/scylladb/cpp-rust-driver/pull/163))
- Added a CI step that updates rust toolchain. ([#175](https://github.com/scylladb/cpp-rust-driver/pull/175))
- Adjusted integration tests logic to `scylla-ccm` which does not support `--force` flag for `ccm <node> decommission command`. Enabled the tests fixed due to this change. ([#180](https://github.com/scylladb/cpp-rust-driver/pull/180))
- Fixed and enabled `ConsistencyTwoNodeClusterTests` suite. ([#181](https://github.com/scylladb/cpp-rust-driver/pull/181))
- Introduced CI workflows responsible for verifying that package builds work as expected. ([#183](https://github.com/scylladb/cpp-rust-driver/pull/183))
- Extended CI by `clang-format` checks for integration tests directory (`src`). ([#176](https://github.com/scylladb/cpp-rust-driver/pull/176))

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/cpp-rust-driver/](https://github.com/scylladb/cpp-rust-driver/)
Contributions are most welcome!

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:
| commits | author              |
|---------|---------------------|
| 124     | Mikołaj Uzarski     |
| 17      | Dmitry Kropachev    |
| 7       | Karol Baryła        |
| 3       | Takuya ASADA        |
| 2       | Wojciech Przytuła   |
