### PR TITLE
prepared: CassPrepared api

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,8 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
             <td colspan=2 align="center" style="font-weight:bold">Prepared</td>
         </tr>
         <tr>
-            <td>cass_prepared_parameter_name</td>
-            <td rowspan="2">Unimplemented</td>
-        </tr>
-        <tr>
             <td>cass_prepared_parameter_data_type[by_name]</td>
+            <td>Unimplemented</td>
         </tr>
         <tr>
             <td colspan=2 align="center" style="font-weight:bold">Statement</td>

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
             <td colspan=2 align="center" style="font-weight:bold">Prepared</td>
         </tr>
         <tr>
-            <td>cass_prepared_parameter_data_type[by_name]</td>
+            <td>cass_prepared_parameter_data_type_by_name_[n]</td>
             <td>Unimplemented</td>
         </tr>
         <tr>

--- a/README.md
+++ b/README.md
@@ -146,13 +146,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
     </thead>
     <tbody>
         <tr>
-            <td colspan=2 align="center" style="font-weight:bold">Prepared</td>
-        </tr>
-        <tr>
-            <td>cass_prepared_parameter_data_type_by_name_[n]</td>
-            <td>Unimplemented</td>
-        </tr>
-        <tr>
             <td colspan=2 align="center" style="font-weight:bold">Statement</td>
         </tr>
         <tr>

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -80,3 +80,16 @@ pub unsafe extern "C" fn cass_prepared_parameter_name(
         None => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
     }
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_prepared_parameter_data_type(
+    prepared_raw: *const CassPrepared,
+    index: size_t,
+) -> *const CassDataType {
+    let prepared = ptr_to_ref(prepared_raw);
+
+    match prepared.variable_col_data_types.get(index as usize) {
+        Some(dt) => Arc::as_ptr(dt),
+        None => std::ptr::null(),
+    }
+}

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -210,10 +210,6 @@ cass_materialized_view_meta_field_by_name(const CassMaterializedViewMeta* view_m
                                           const char* name) {
   throw std::runtime_error("UNIMPLEMENTED cass_materialized_view_meta_field_by_name\n");
 }
-CASS_EXPORT const CassDataType*
-cass_prepared_parameter_data_type_by_name(const CassPrepared* prepared, const char* name) {
-  throw std::runtime_error("UNIMPLEMENTED cass_prepared_parameter_data_type_by_name\n");
-}
 CASS_EXPORT CassRetryPolicy* cass_retry_policy_logging_new(CassRetryPolicy* child_retry_policy) {
   throw std::runtime_error("UNIMPLEMENTED cass_retry_policy_logging_new\n");
 }


### PR DESCRIPTION
fix: https://github.com/scylladb/cpp-rust-driver/issues/54

This PR implements following API functions:
- `cass_prepared_parameter_name`
- `cass_prepared_parameter_data_type`
- `cass_prepared_parameter_data_type_by_name`
- `cass_prepared_parameter_data_type_by_name_n`

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~ -> unable to implement unit tests, since there is no way to mock `PreparedStatement` struct from rust-driver
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~