### PR TITLE
integration: fix SerialConsistencyTests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ConfigTests.*\
 :ConsistencyTwoNodeClusterTests.*\
 :ConsistencyThreeNodeClusterTests.*\
+:SerialConsistencyTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :BatchSingleNodeClusterTests*:BatchCounterSingleNodeClusterTests*:BatchCounterThreeNodeClusterTests*\
@@ -32,6 +33,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ConfigTests.*\
 :ConsistencyTwoNodeClusterTests.*\
 :ConsistencyThreeNodeClusterTests.*\
+:SerialConsistencyTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :ErrorTests.*\


### PR DESCRIPTION
## Motivation

Original cpp-driver allows user to SET the invalid serial consistency.
Then, the request is sent with an invalid serial consistency, resulting in a server error.
However, rust-driver comes with a type safety in this matter, disallowing
the user to set invalid serial consistency, thus we are not able to mimic this behaviour in cpp-rust-driver.
We need to adjust the integration test, and assert that setting the invalid serial consistency fails with an error.

## Changes
Adjusted one test in `SerialConsistencyTests` suite, and enabled the test suite in CI.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.