### PR TITLE
binding: fix by-name parameter binding and enable corresponding IT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :SerialConsistencyTests.*\
 :HeartbeatTests.*\
 :PreparedTests.*\
+:NamedParametersTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :BatchSingleNodeClusterTests*:BatchCounterSingleNodeClusterTests*:BatchCounterThreeNodeClusterTests*\
 :ErrorTests.*\
@@ -40,6 +41,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :SerialConsistencyTests.*\
 :HeartbeatTests.*\
 :PreparedTests.*\
+:NamedParametersTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :ErrorTests.*\
 :SslClientAuthenticationTests*:SslNoClusterTests*:SslNoSslOnClusterTests*:SslTests*\

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -6,7 +6,7 @@ use crate::{
     cass_error::CassError,
     cass_types::{get_column_type, CassDataType},
     query_result::CassResultMetadata,
-    statement::{CassStatement, Statement},
+    statement::{BoundPreparedStatement, BoundStatement, CassStatement},
     types::size_t,
 };
 use scylla::prepared_statement::PreparedStatement;
@@ -88,11 +88,14 @@ pub unsafe extern "C" fn cass_prepared_bind(
 
     // cloning prepared statement's arc, because creating CassStatement should not invalidate
     // the CassPrepared argument
-    let statement = Statement::Prepared(prepared);
+
+    let statement = BoundStatement::Prepared(BoundPreparedStatement {
+        statement: prepared,
+        bound_values: vec![Unset; bound_values_size],
+    });
 
     BoxFFI::into_ptr(Box::new(CassStatement {
         statement,
-        bound_values: vec![Unset; bound_values_size],
         paging_state: PagingState::start(),
         // Cpp driver disables paging by default.
         paging_enabled: false,

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -124,7 +124,7 @@ impl BoundSimpleQuery {
         let index = self.name_to_bound_index.get(name);
 
         if let Some(idx) = index {
-            return self.bind_cql_value(*idx, value);
+            self.bind_cql_value(*idx, value)
         } else {
             // Find first free index, i.e. index where value at this index is Unset.
             let free_index = self.bound_values.iter().position(|v| matches!(v, Unset));
@@ -132,11 +132,12 @@ impl BoundSimpleQuery {
             if let Some(index) = free_index {
                 self.name_to_bound_index.insert(name.to_string(), index);
 
-                return self.bind_cql_value(index, value);
+                self.bind_cql_value(index, value)
+            } else {
+                // No free index for a given name. Cpp-driver returns this error in such case.
+                CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST
             }
         }
-
-        CassError::CASS_OK
     }
 }
 

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -20,61 +20,71 @@ use std::slice;
 use std::sync::Arc;
 
 #[derive(Clone)]
-pub enum Statement {
-    Simple(SimpleQuery),
-    // Arc is needed, because PreparedStatement is passed by reference to session.execute
-    Prepared(Arc<CassPrepared>),
+pub enum BoundStatement {
+    Simple(BoundSimpleQuery),
+    Prepared(BoundPreparedStatement),
 }
 
 #[derive(Clone)]
-pub struct SimpleQuery {
-    pub query: Query,
-    pub name_to_bound_index: HashMap<String, usize>,
-}
-
-pub struct CassStatement {
-    pub statement: Statement,
+pub struct BoundPreparedStatement {
+    // Arc is needed, because PreparedStatement is passed by reference to session.execute
+    pub statement: Arc<CassPrepared>,
     pub bound_values: Vec<MaybeUnset<Option<CassCqlValue>>>,
-    pub paging_state: PagingState,
-    pub paging_enabled: bool,
-    pub request_timeout_ms: Option<cass_uint64_t>,
-
-    pub(crate) exec_profile: Option<PerStatementExecProfile>,
 }
 
-impl BoxFFI for CassStatement {}
-
-impl CassStatement {
+impl BoundPreparedStatement {
     fn bind_cql_value(&mut self, index: usize, value: Option<CassCqlValue>) -> CassError {
-        let (bound_value, maybe_data_type) = match &self.statement {
-            Statement::Simple(_) => match self.bound_values.get_mut(index) {
-                Some(v) => (v, None),
-                None => return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
-            },
-            Statement::Prepared(p) => match (
-                self.bound_values.get_mut(index),
-                p.variable_col_data_types.get(index),
-            ) {
-                (Some(v), Some(dt)) => (v, Some(dt)),
-                (None, None) => return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
-                // This indicates a length mismatch between col specs table and self.bound_values.
-                //
-                // It can only occur when user provides bad `count` value in `cass_statement_reset_parameters`.
-                // Cpp-driver does not verify that both of these values are equal.
-                // I believe returning CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS is best we can do here.
-                _ => return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
-            },
-        };
+        match (
+            self.bound_values.get_mut(index),
+            self.statement.variable_col_data_types.get(index),
+        ) {
+            (Some(v), Some(dt)) => {
+                // Perform the typecheck.
+                if !value::is_type_compatible(&value, dt) {
+                    return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
+                }
 
-        // Perform the typecheck.
-        if let Some(dt) = maybe_data_type {
-            if !value::is_type_compatible(&value, dt) {
-                return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
+                *v = Set(value);
+                CassError::CASS_OK
             }
+            (None, None) => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
+            // This indicates a length mismatch between col specs table and self.bound_values.
+            //
+            // It can only occur when user provides bad `count` value in `cass_statement_reset_parameters`.
+            // Cpp-driver does not verify that both of these values are equal.
+            // I believe returning CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS is best we can do here.
+            _ => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
+        }
+    }
+
+    fn bind_cql_value_by_name(&mut self, name: &str, value: Option<CassCqlValue>) -> CassError {
+        let mut name_str = name;
+        let mut is_case_sensitive = false;
+
+        if name_str.starts_with('\"') && name_str.ends_with('\"') {
+            name_str = name_str.strip_prefix('\"').unwrap();
+            name_str = name_str.strip_suffix('\"').unwrap();
+            is_case_sensitive = true;
         }
 
-        *bound_value = Set(value);
-        CassError::CASS_OK
+        let indices: Vec<usize> = self
+            .statement
+            .statement
+            .get_variable_col_specs()
+            .iter()
+            .enumerate()
+            .filter(|(_, col)| {
+                is_case_sensitive && col.name() == name_str
+                    || !is_case_sensitive && col.name().eq_ignore_ascii_case(name_str)
+            })
+            .map(|(i, _)| i)
+            .collect();
+
+        if indices.is_empty() {
+            return CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST;
+        }
+
+        self.bind_multiple_values_by_name(&indices, value)
     }
 
     fn bind_multiple_values_by_name(
@@ -92,69 +102,89 @@ impl CassStatement {
 
         CassError::CASS_OK
     }
+}
+
+#[derive(Clone)]
+pub struct BoundSimpleQuery {
+    pub query: Query,
+    pub bound_values: Vec<MaybeUnset<Option<CassCqlValue>>>,
+    pub name_to_bound_index: HashMap<String, usize>,
+}
+
+impl BoundSimpleQuery {
+    fn bind_cql_value(&mut self, index: usize, value: Option<CassCqlValue>) -> CassError {
+        match self.bound_values.get_mut(index) {
+            Some(v) => {
+                *v = Set(value);
+                CassError::CASS_OK
+            }
+            None => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
+        }
+    }
 
     fn bind_cql_value_by_name(&mut self, name: &str, value: Option<CassCqlValue>) -> CassError {
         let mut set_bound_val_index: Option<usize> = None;
-        let mut name_str = name;
-        let mut is_case_sensitive = false;
 
-        if name_str.starts_with('\"') && name_str.ends_with('\"') {
-            name_str = name_str.strip_prefix('\"').unwrap();
-            name_str = name_str.strip_suffix('\"').unwrap();
-            is_case_sensitive = true;
-        }
-
-        match &self.statement {
-            Statement::Prepared(prepared) => {
-                let indices: Vec<usize> = prepared
-                    .statement
-                    .get_variable_col_specs()
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, col)| {
-                        is_case_sensitive && col.name() == name_str
-                            || !is_case_sensitive && col.name().eq_ignore_ascii_case(name_str)
-                    })
-                    .map(|(i, _)| i)
-                    .collect();
-
-                if indices.is_empty() {
-                    return CassError::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST;
-                }
-
-                return self.bind_multiple_values_by_name(&indices, value);
-            }
-            Statement::Simple(query) => {
-                let index = query.name_to_bound_index.get(name);
-
-                if let Some(idx) = index {
-                    return self.bind_cql_value(*idx, value);
-                } else {
-                    for (index, bound_val) in self.bound_values.iter().enumerate() {
-                        if let Unset = bound_val {
-                            set_bound_val_index = Some(index);
-                            break;
-                        }
-                    }
+        let index = self.name_to_bound_index.get(name);
+        if let Some(idx) = index {
+            return self.bind_cql_value(*idx, value);
+        } else {
+            for (index, bound_val) in self.bound_values.iter().enumerate() {
+                if let Unset = bound_val {
+                    set_bound_val_index = Some(index);
+                    break;
                 }
             }
         }
 
         if let Some(index) = set_bound_val_index {
-            if let Statement::Simple(query) = &mut self.statement {
-                query.name_to_bound_index.insert(name.to_string(), index);
-            }
+            self.name_to_bound_index.insert(name.to_string(), index);
 
             return self.bind_cql_value(index, value);
         }
 
         CassError::CASS_OK
     }
+}
+
+pub struct CassStatement {
+    pub statement: BoundStatement,
+    pub paging_state: PagingState,
+    pub paging_enabled: bool,
+    pub request_timeout_ms: Option<cass_uint64_t>,
+
+    pub(crate) exec_profile: Option<PerStatementExecProfile>,
+}
+
+impl BoxFFI for CassStatement {}
+
+impl CassStatement {
+    fn bind_cql_value(&mut self, index: usize, value: Option<CassCqlValue>) -> CassError {
+        match &mut self.statement {
+            BoundStatement::Simple(simple) => simple.bind_cql_value(index, value),
+            BoundStatement::Prepared(prepared) => prepared.bind_cql_value(index, value),
+        }
+    }
+
+    fn bind_cql_value_by_name(&mut self, name: &str, value: Option<CassCqlValue>) -> CassError {
+        match &mut self.statement {
+            BoundStatement::Simple(simple) => simple.bind_cql_value_by_name(name, value),
+            BoundStatement::Prepared(prepared) => prepared.bind_cql_value_by_name(name, value),
+        }
+    }
 
     fn reset_bound_values(&mut self, count: usize) {
         // Clear bound values and resize the vector - all values should be unset.
-        self.bound_values.clear();
-        self.bound_values.resize(count, Unset);
+        match &mut self.statement {
+            BoundStatement::Simple(simple) => {
+                simple.bound_values.clear();
+                simple.bound_values.resize(count, Unset);
+            }
+            BoundStatement::Prepared(prepared) => {
+                prepared.bound_values.clear();
+                prepared.bound_values.resize(count, Unset);
+            }
+        }
     }
 }
 
@@ -179,14 +209,14 @@ pub unsafe extern "C" fn cass_statement_new_n(
 
     let query = Query::new(query_str.to_string());
 
-    let simple_query = SimpleQuery {
+    let simple_query = BoundSimpleQuery {
         query,
+        bound_values: vec![Unset; parameter_count as usize],
         name_to_bound_index: HashMap::with_capacity(parameter_count as usize),
     };
 
     BoxFFI::into_ptr(Box::new(CassStatement {
-        statement: Statement::Simple(simple_query),
-        bound_values: vec![Unset; parameter_count as usize],
+        statement: BoundStatement::Simple(simple_query),
         paging_state: PagingState::start(),
         // Cpp driver disables paging by default.
         paging_enabled: false,
@@ -209,10 +239,10 @@ pub unsafe extern "C" fn cass_statement_set_consistency(
 
     if let Some(consistency) = consistency_opt {
         match &mut BoxFFI::as_mut_ref(statement).statement {
-            Statement::Simple(inner) => inner.query.set_consistency(consistency),
-            Statement::Prepared(inner) => {
-                Arc::make_mut(inner).statement.set_consistency(consistency)
-            }
+            BoundStatement::Simple(inner) => inner.query.set_consistency(consistency),
+            BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
+                .statement
+                .set_consistency(consistency),
         }
     }
 
@@ -231,8 +261,10 @@ pub unsafe extern "C" fn cass_statement_set_paging_size(
     } else {
         statement.paging_enabled = true;
         match &mut statement.statement {
-            Statement::Simple(inner) => inner.query.set_page_size(page_size),
-            Statement::Prepared(inner) => Arc::make_mut(inner).statement.set_page_size(page_size),
+            BoundStatement::Simple(inner) => inner.query.set_page_size(page_size),
+            BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
+                .statement
+                .set_page_size(page_size),
         }
     }
 
@@ -279,8 +311,8 @@ pub unsafe extern "C" fn cass_statement_set_is_idempotent(
     is_idempotent: cass_bool_t,
 ) -> CassError {
     match &mut BoxFFI::as_mut_ref(statement_raw).statement {
-        Statement::Simple(inner) => inner.query.set_is_idempotent(is_idempotent != 0),
-        Statement::Prepared(inner) => Arc::make_mut(inner)
+        BoundStatement::Simple(inner) => inner.query.set_is_idempotent(is_idempotent != 0),
+        BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
             .statement
             .set_is_idempotent(is_idempotent != 0),
     }
@@ -294,8 +326,10 @@ pub unsafe extern "C" fn cass_statement_set_tracing(
     enabled: cass_bool_t,
 ) -> CassError {
     match &mut BoxFFI::as_mut_ref(statement_raw).statement {
-        Statement::Simple(inner) => inner.query.set_tracing(enabled != 0),
-        Statement::Prepared(inner) => Arc::make_mut(inner).statement.set_tracing(enabled != 0),
+        BoundStatement::Simple(inner) => inner.query.set_tracing(enabled != 0),
+        BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
+            .statement
+            .set_tracing(enabled != 0),
     }
 
     CassError::CASS_OK
@@ -316,8 +350,8 @@ pub unsafe extern "C" fn cass_statement_set_retry_policy(
         });
 
     match &mut BoxFFI::as_mut_ref(statement).statement {
-        Statement::Simple(inner) => inner.query.set_retry_policy(maybe_arced_retry_policy),
-        Statement::Prepared(inner) => Arc::make_mut(inner)
+        BoundStatement::Simple(inner) => inner.query.set_retry_policy(maybe_arced_retry_policy),
+        BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
             .statement
             .set_retry_policy(maybe_arced_retry_policy),
     }
@@ -345,8 +379,8 @@ pub unsafe extern "C" fn cass_statement_set_serial_consistency(
     };
 
     match &mut BoxFFI::as_mut_ref(statement).statement {
-        Statement::Simple(inner) => inner.query.set_serial_consistency(Some(consistency)),
-        Statement::Prepared(inner) => Arc::make_mut(inner)
+        BoundStatement::Simple(inner) => inner.query.set_serial_consistency(Some(consistency)),
+        BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
             .statement
             .set_serial_consistency(Some(consistency)),
     }
@@ -377,8 +411,8 @@ pub unsafe extern "C" fn cass_statement_set_timestamp(
     timestamp: cass_int64_t,
 ) -> CassError {
     match &mut BoxFFI::as_mut_ref(statement).statement {
-        Statement::Simple(inner) => inner.query.set_timestamp(Some(timestamp)),
-        Statement::Prepared(inner) => Arc::make_mut(inner)
+        BoundStatement::Simple(inner) => inner.query.set_timestamp(Some(timestamp)),
+        BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
             .statement
             .set_timestamp(Some(timestamp)),
     }

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -179,6 +179,7 @@ impl CassStatement {
             BoundStatement::Simple(simple) => {
                 simple.bound_values.clear();
                 simple.bound_values.resize(count, Unset);
+                simple.name_to_bound_index.clear();
             }
             BoundStatement::Prepared(prepared) => {
                 prepared.bound_values.clear();

--- a/tests/src/integration/tests/test_by_name.cpp
+++ b/tests/src/integration/tests/test_by_name.cpp
@@ -37,6 +37,10 @@
   "INSERT INTO %s "                  \
   "(key, abc, \"ABC\", \"aBc\") "    \
   "VALUES (?, ?, ?, ?)"
+#define INSERT_SAME_MARKER_FORMAT \
+  "INSERT INTO %s "                  \
+  "(key, abc, \"ABC\", \"aBc\") "    \
+  "VALUES (:key, :abc, :abc, :abc)"
 #define INSERT_ALL_FORMAT                  \
   "INSERT INTO %s "                        \
   "(key, a, b, c, abc, \"ABC\", \"aBc\") " \
@@ -174,6 +178,28 @@ protected:
     ASSERT_TRUE(row.column_by_name<Float>("\"ABC\"").is_null());
     ASSERT_TRUE(row.column_by_name<Float>("\"aBc\"").is_null());
   }
+
+  /**
+   * Insert non-pk values using same bind marker
+   *
+   * @param statement Insert statement to use
+   */
+  void insert_and_validate_multiple_binds(Statement statement) {
+    TimeUuid key = uuid_generator_.generate_timeuuid();
+    statement.bind<TimeUuid>("key", key);
+    statement.bind<Float>("abc", Float(1.23f)); // This should bind to columns `abc`, `ABC`, and `aBc`
+    session_.execute(statement);
+
+    // Validate the inserts to multiple binded columns
+    Result result = session_.execute(default_select_all());
+    ASSERT_EQ(1u, result.row_count());
+    ASSERT_EQ(7u, result.column_count());
+    Row row = result.first_row();
+    ASSERT_EQ(key, row.column_by_name<TimeUuid>("key"));
+    ASSERT_EQ(Float(1.23f), row.column_by_name<Float>("\"abc\""));
+    ASSERT_EQ(Float(1.23f), row.column_by_name<Float>("\"ABC\""));
+    ASSERT_EQ(Float(1.23f), row.column_by_name<Float>("\"aBc\""));
+  }
 };
 
 /**
@@ -287,20 +313,50 @@ CASSANDRA_INTEGRATION_TEST_F(ByNameTests, MultipleBinds) {
   Prepared prepared =
       session_.prepare(format_string(INSERT_CASE_SENSITIVE_FORMAT, table_name_.c_str()));
   Statement statement = prepared.bind();
-  TimeUuid key = uuid_generator_.generate_timeuuid();
-  statement.bind<TimeUuid>("key", key);
-  statement.bind<Float>("abc", Float(1.23f)); // This should bind to columns `abc`, `ABC`, and `aBc`
-  session_.execute(statement);
+  insert_and_validate_multiple_binds(statement);
+}
 
-  // Validate the inserts to multiple binded columns
-  Result result = session_.execute(default_select_all());
-  ASSERT_EQ(1u, result.row_count());
-  ASSERT_EQ(7u, result.column_count());
-  Row row = result.first_row();
-  ASSERT_EQ(key, row.column_by_name<TimeUuid>("key"));
-  ASSERT_EQ(Float(1.23f), row.column_by_name<Float>("\"abc\""));
-  ASSERT_EQ(Float(1.23f), row.column_by_name<Float>("\"ABC\""));
-  ASSERT_EQ(Float(1.23f), row.column_by_name<Float>("\"aBc\""));
+/**
+ * Perform `by name` references using a prepared statement to insert multiple
+ * values using same bind marker and validate.
+ *
+ * This test will perform bindings of a value to multiple columns `by name` 
+ * using same bind marker, insert using a prepared statement 
+ * and validate the results on a single node cluster.
+ *
+ * @test_category queries:prepared
+ * @since core:1.0.0
+ * @expected_result Cassandra values are inserted and validated by name
+ */
+CASSANDRA_INTEGRATION_TEST_F(ByNameTests, PreparedMultipleBindsSameMarker) {
+  CHECK_FAILURE;
+
+  // Prepare, bind, and insert the values into the table
+  Prepared prepared =
+      session_.prepare(format_string(INSERT_SAME_MARKER_FORMAT, table_name_.c_str()));
+  Statement statement = prepared.bind();
+  insert_and_validate_multiple_binds(statement);
+}
+
+/**
+ * Perform `by name` references using a simple statement to insert multiple
+ * values using same bind marker and validate
+ *
+ * This test will perform bindings of a value to multiple columns `by name` 
+ * using same bind marker, insert using a simple statement 
+ * and validate the results on a single node cluster.
+ *
+ * @test_category queries:basic
+ * @cassandra_version 2.1.0
+ * @expected_result Cassandra values are inserted and validated by name
+ */
+CASSANDRA_INTEGRATION_TEST_F(ByNameTests, SimpleMultipleBindsSameMarker) {
+  CHECK_FAILURE;
+  SKIP_IF_CASSANDRA_VERSION_LT(2.1.0);
+
+  // Prepare, create, insert and validate
+  Statement statement(format_string(INSERT_SAME_MARKER_FORMAT, table_name_.c_str()), 4);
+  insert_and_validate_multiple_binds(statement);
 }
 
 /**

--- a/tests/src/integration/tests/test_named_parameters.cpp
+++ b/tests/src/integration/tests/test_named_parameters.cpp
@@ -204,7 +204,7 @@ CASSANDRA_INTEGRATION_TEST_F(NamedParametersTests, SimpleStatementInvalidName) {
   insert_statement.bind<Uuid>("named_uuid", value_uuid_);
   insert_statement.bind<Blob>("named_blob", value_blob_);
   insert_statement.bind<List<Float> >("named_list_floats", value_list_floats_);
-  EXPECT_EQ(CASS_ERROR_SERVER_INVALID_QUERY,
+  EXPECT_EQ(CASS_ERROR_LIB_NAME_DOES_NOT_EXIST,
             session_.execute(insert_statement, false).error_code());
 }
 


### PR DESCRIPTION
## Motivation
Before this PR, binding values by name to unprepared queries was buggy:
- Main issue was that we were not even reading name-to-index mapping (`SimpleQuery::name_to_bound_index`) - only writing to it. In result, we were not really binding by name, but rather by position, in the same order as `cass_statement_bind_*` calls appeared. The `bound_values` vector was directly passed to `Session::query_*` calls.
- `CassStatement::bind_cql_value` would return `CASS_OK` when size of `SimpleQuery::name_to_bound_index` map exceeded the declared size of parameters (`CassStatement::bound_values.len()`)
- We wouldn't unquote the parameter names for unprepared queries in `CassStatement::bind_cql_value`

This PR solves this issue, and enables another integration test suite - `NamedParametersTests`.

## Changes
Apart from the fixes to `CassStatement::bind_cql_value`, I also introduced a custom implementation of `SerializeRow` for unprepared queries execution. I created a `SimpleQueryRowSerializer` struct which holds necessary information to perform serialization. Now, with following context:
- `bound_values` vector - directly taken from `CassStatement::bound_values`
- an optional name-to-index mapping (from `SimpleQuery::name_to_bound_index`) - if it's non-empty, it means that we bind by names, otherwise we preserve the original order of `bound_values`.
- column specs from `RowSerializationContext`

we are able to serialize values in correct order for unprepared queries.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.