### PR TITLE
ci: use of ubuntu 22.04

### DIFF
--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build-lint-and-unit-test:
     name: Build, lint and run unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
 
   scylla-integration-tests:
     name: Scylla ITs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-lint-and-unit-test]
     timeout-minutes: 90
 
@@ -142,7 +142,7 @@ jobs:
           path: ${{ env.CCM_LOGS_PATTERN }}
 
   cassandra-integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-lint-and-unit-test]
 
     strategy:

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-rpm-pkgs:
     name: Build rpm packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: fedora:latest
       # Required by `mock`:
@@ -49,7 +49,7 @@ jobs:
   
   build-deb-pkgs:
     name: Build deb packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 endif
 
 ifndef CCM_COMMIT_ID
-	export CCM_COMMIT_ID := 81076bce792a0fb3f2050e4c209a93e4a62ab55f
+	export CCM_COMMIT_ID := master
 endif
 
 ifndef SCYLLA_VERSION


### PR DESCRIPTION
## Runner image regression (`ubuntu-latest`)
With recent update of `ubuntu-latest` pointing to `ubuntu-24.04`, multiple issues started to occur during CI. As a temporary measure, to make CI green again, let's keep on using ubuntu-22.04 (previously ubuntu-latest).

## Scylla-ccm
We will now fetch most recent version of `scylla-ccm` (master) during CI

Opened an issue to update runners to `ubuntu-latest` in the future: https://github.com/scylladb/cpp-rust-driver/issues/192

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~