### PR TITLE
cluster: keepalive config options

### DIFF
--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -159,13 +159,17 @@ pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
         .consistency(DEFAULT_CONSISTENCY)
         .request_timeout(Some(Duration::from_millis(DEFAULT_REQUEST_TIMEOUT_MILLIS)));
 
-    // Set DRIVER_NAME and DRIVER_VERSION of cpp-rust driver.
-    let custom_identity = SelfIdentity::new()
-        .with_custom_driver_name(DRIVER_NAME)
-        .with_custom_driver_version(DRIVER_VERSION);
+    let default_session_builder = {
+        // Set DRIVER_NAME and DRIVER_VERSION of cpp-rust driver.
+        let custom_identity = SelfIdentity::new()
+            .with_custom_driver_name(DRIVER_NAME)
+            .with_custom_driver_version(DRIVER_VERSION);
+
+        SessionBuilder::new().custom_identity(custom_identity)
+    };
 
     Box::into_raw(Box::new(CassCluster {
-        session_builder: SessionBuilder::new().custom_identity(custom_identity),
+        session_builder: default_session_builder,
         port: 9042,
         contact_points: Vec::new(),
         // Per DataStax documentation: Without additional configuration the C/C++ driver

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -62,14 +62,6 @@ CASS_EXPORT CassError cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib
   throw std::runtime_error(
       "UNIMPLEMENTED cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init\n");
 }
-CASS_EXPORT void cass_cluster_set_connection_heartbeat_interval(CassCluster* cluster,
-                                                                unsigned interval_secs) {
-  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_connection_heartbeat_interval\n");
-}
-CASS_EXPORT void cass_cluster_set_connection_idle_timeout(CassCluster* cluster,
-                                                          unsigned timeout_secs) {
-  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_connection_idle_timeout\n");
-}
 CASS_EXPORT void cass_cluster_set_constant_reconnect(CassCluster* cluster, cass_uint64_t delay_ms) {
   throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_constant_reconnect\n");
 }


### PR DESCRIPTION
## Config defaults
Adjusted the config defaults for some options that were already supported by cpp-rust-driver.

## keepalive
Implemented `cass_cluster_set_connection_heartbeat_interval` and `cass_cluster_set_connection_idle_timeout`.
Set the defaults for these options.

## HeartbeatTests
HeartbeastTests suite unfortunately cannot be enabled yet. It depends on logs emitted by the driver. However, we will be able to enable most of them, see https://github.com/scylladb/scylla-rust-driver/pull/1092. The only exception is `HeartbeatTests.Integration_Cassandra_HeartbeatFailed` since it requires metrics support as well.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~