### PR TITLE
ci: enable NullStringApiArgsTest suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ifndef SCYLLA_TEST_FILTER
 SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :BasicsTests.*\
 :ConfigTests.*\
+:NullStringApiArgsTest.*\
 :ConsistencyTwoNodeClusterTests.*\
 :ConsistencyThreeNodeClusterTests.*\
 :SerialConsistencyTests.*\
@@ -31,6 +32,7 @@ ifndef CASSANDRA_TEST_FILTER
 CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :BasicsTests.*\
 :ConfigTests.*\
+:NullStringApiArgsTest.*\
 :ConsistencyTwoNodeClusterTests.*\
 :ConsistencyThreeNodeClusterTests.*\
 :SerialConsistencyTests.*\


### PR DESCRIPTION
Makes `cass_session_prepare` logic consistent with cpp-driver (even though, I am not a fan of it) and enables `NullStringApiArgsTest` test suite.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.