### PR TITLE
lbp: rack awareness

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -2233,6 +2233,46 @@ cass_cluster_set_load_balance_dc_aware_n(CassCluster* cluster,
                                          unsigned used_hosts_per_remote_dc,
                                          cass_bool_t allow_remote_dcs_for_local_cl);
 
+
+/**
+ * Configures the cluster to use Rack-aware load balancing.
+ * For each query, all live nodes in a primary 'local' rack are tried first,
+ * followed by nodes from local DC and then nodes from other DCs.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] local_dc The primary data center to try first
+ * @param[in] local_rack The primary rack to try first
+ * @return CASS_OK if successful, otherwise an error occurred
+ */
+CASS_EXPORT CassError
+cass_cluster_set_load_balance_rack_aware(CassCluster* cluster,
+                                       const char* local_dc,
+                                       const char* local_rack);
+
+
+/**
+ * Same as cass_cluster_set_load_balance_rack_aware(), but with lengths for string
+ * parameters.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] local_dc
+ * @param[in] local_dc_length
+ * @return same as cass_cluster_set_load_balance_dc_aware()
+ *
+ * @see cass_cluster_set_load_balance_dc_aware()
+ */
+CASS_EXPORT CassError
+cass_cluster_set_load_balance_rack_aware_n(CassCluster* cluster,
+                                         const char* local_dc,
+                                         size_t local_dc_length,
+                                         const char* local_rack,
+                                         size_t local_rack_length);
+
+
 /**
  * Configures the cluster to use token-aware request routing or not.
  *

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -1087,6 +1087,50 @@ cass_execution_profile_set_load_balance_dc_aware_n(CassExecProfile* profile,
                                                    unsigned used_hosts_per_remote_dc,
                                                    cass_bool_t allow_remote_dcs_for_local_cl);
 
+
+/**
+ * Configures the execution profile to use Rack-aware load balancing.
+ * For each query, all live nodes in a primary 'local' rack are tried first,
+ * followed by nodes from local DC and then nodes from other DCs.
+ *
+ * <b>Note:</b> Profile-based load balancing policy is disabled by default.
+ * cluster load balancing policy is used when profile does not contain a policy.
+ *
+ * @public @memberof CassExecProfile
+ *
+ * @param[in] profile
+ * @param[in] local_dc The primary data center to try first
+ * @param[in] local_rack The primary rack to try first
+ * @return CASS_OK if successful, otherwise an error occurred
+ */
+CASS_EXPORT CassError
+cass_execution_profile_set_load_balance_rack_aware(CassExecProfile* profile,
+                                                   const char* local_dc,
+                                                   const char* local_rack);
+
+
+/**
+ * Same as cass_execution_profile_set_load_balance_rack_aware(), but with lengths for string
+ * parameters.
+ *
+ * @public @memberof CassExecProfile
+ *
+ * @param[in] profile
+ * @param[in] local_dc
+ * @param[in] local_dc_length
+ * @return same cass_execution_profile_set_load_balance_rack_aware()
+ *
+ * @see cass_execution_profile_set_load_balance_rack_aware()
+ * @see cass_cluster_set_load_balance_rack_aware_n()
+ */
+CASS_EXPORT CassError
+cass_execution_profile_set_load_balance_rack_aware_n(CassExecProfile* profile,
+                                                     const char* local_dc,
+                                                     size_t local_dc_length,
+                                                     const char* local_rack,
+                                                     size_t local_rack_length);
+
+
 /**
  * Configures the execution profile to use token-aware request routing or not.
  *

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -2220,13 +2220,6 @@ cass_cluster_set_load_balance_round_robin(CassCluster* cluster);
  * For each query, all live nodes in a primary 'local' DC are tried first,
  * followed by any node from other DCs.
  *
- * <b>Note:</b> This is the default, and does not need to be called unless
- * switching an existing from another policy or changing settings.
- * Without further configuration, a default local_dc is chosen from the
- * first connected contact point, and no remote hosts are considered in
- * query plans. If relying on this mechanism, be sure to use only contact
- * points from the local DC.
- *
  * @deprecated The remote DC settings for DC-aware are not suitable for most
  * scenarios that require DC failover. There is also unhandled gap between
  * replication factor number of nodes failing and the full cluster failing. Only

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -75,9 +75,22 @@ impl LoadBalancingConfig {
             builder =
                 builder.enable_shuffling_replicas(self.token_aware_shuffling_replicas_enabled);
         }
-        if let LoadBalancingKind::DcAware { local_dc } = load_balancing_kind {
-            builder = builder.prefer_datacenter(local_dc).permit_dc_failover(true)
+
+        match load_balancing_kind {
+            LoadBalancingKind::DcAware { local_dc } => {
+                builder = builder.prefer_datacenter(local_dc).permit_dc_failover(true)
+            }
+            LoadBalancingKind::RackAware {
+                local_dc,
+                local_rack,
+            } => {
+                builder = builder
+                    .prefer_datacenter_and_rack(local_dc, local_rack)
+                    .permit_dc_failover(true)
+            }
+            LoadBalancingKind::RoundRobin => {}
         }
+
         if self.latency_awareness_enabled {
             builder = builder.latency_awareness(self.latency_awareness_builder);
         }
@@ -99,7 +112,13 @@ impl Default for LoadBalancingConfig {
 #[derive(Clone, Debug)]
 pub(crate) enum LoadBalancingKind {
     RoundRobin,
-    DcAware { local_dc: String },
+    DcAware {
+        local_dc: String,
+    },
+    RackAware {
+        local_dc: String,
+        local_rack: String,
+    },
 }
 
 #[derive(Clone)]
@@ -551,6 +570,68 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
         used_hosts_per_remote_dc,
         allow_remote_dcs_for_local_cl,
     )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware(
+    cluster_raw: *mut CassCluster,
+    local_dc_raw: *const c_char,
+    local_rack_raw: *const c_char,
+) -> CassError {
+    cass_cluster_set_load_balance_rack_aware_n(
+        cluster_raw,
+        local_dc_raw,
+        strlen(local_dc_raw),
+        local_rack_raw,
+        strlen(local_rack_raw),
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware_n(
+    cluster_raw: *mut CassCluster,
+    local_dc_raw: *const c_char,
+    local_dc_length: size_t,
+    local_rack_raw: *const c_char,
+    local_rack_length: size_t,
+) -> CassError {
+    let cluster = ptr_to_ref_mut(cluster_raw);
+
+    set_load_balance_rack_aware_n(
+        &mut cluster.load_balancing_config,
+        local_dc_raw,
+        local_dc_length,
+        local_rack_raw,
+        local_rack_length,
+    )
+}
+
+unsafe fn set_load_balance_rack_aware_n(
+    load_balancing_config: &mut LoadBalancingConfig,
+    local_dc_raw: *const c_char,
+    local_dc_length: size_t,
+    local_rack_raw: *const c_char,
+    local_rack_length: size_t,
+) -> CassError {
+    let (local_dc, local_rack) = match (
+        ptr_to_cstr_n(local_dc_raw, local_dc_length),
+        ptr_to_cstr_n(local_rack_raw, local_rack_length),
+    ) {
+        (Some(local_dc_str), Some(local_rack_str))
+            if local_dc_length > 0 && local_rack_length > 0 =>
+        {
+            (local_dc_str.to_owned(), local_rack_str.to_owned())
+        }
+        // One of them either is a null pointer, is an empty string or is not a proper utf-8.
+        _ => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
+    };
+
+    load_balancing_config.load_balancing_kind = Some(LoadBalancingKind::RackAware {
+        local_dc,
+        local_rack,
+    });
+
+    CassError::CASS_OK
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -606,7 +606,7 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware_n(
     )
 }
 
-unsafe fn set_load_balance_rack_aware_n(
+pub(crate) unsafe fn set_load_balance_rack_aware_n(
     load_balancing_config: &mut LoadBalancingConfig,
     local_dc_raw: *const c_char,
     local_dc_length: size_t,

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -17,7 +17,10 @@ use crate::argconv::{free_boxed, ptr_to_cstr_n, ptr_to_ref, ptr_to_ref_mut, strl
 use crate::batch::CassBatch;
 use crate::cass_error::CassError;
 use crate::cass_types::CassConsistency;
-use crate::cluster::{set_load_balance_dc_aware_n, LoadBalancingConfig, LoadBalancingKind};
+use crate::cluster::{
+    set_load_balance_dc_aware_n, set_load_balance_rack_aware_n, LoadBalancingConfig,
+    LoadBalancingKind,
+};
 use crate::retry_policy::CassRetryPolicy;
 use crate::retry_policy::RetryPolicy::{
     DefaultRetryPolicy, DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy,
@@ -354,6 +357,40 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware_n(
         local_dc_length,
         used_hosts_per_remote_dc,
         allow_remote_dcs_for_local_cl,
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware(
+    profile: *mut CassExecProfile,
+    local_dc_raw: *const c_char,
+    local_rack_raw: *const c_char,
+) -> CassError {
+    cass_execution_profile_set_load_balance_rack_aware_n(
+        profile,
+        local_dc_raw,
+        strlen(local_dc_raw),
+        local_rack_raw,
+        strlen(local_rack_raw),
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware_n(
+    profile: *mut CassExecProfile,
+    local_dc_raw: *const c_char,
+    local_dc_length: size_t,
+    local_rack_raw: *const c_char,
+    local_rack_length: size_t,
+) -> CassError {
+    let profile_builder = ptr_to_ref_mut(profile);
+
+    set_load_balance_rack_aware_n(
+        &mut profile_builder.load_balancing_config,
+        local_dc_raw,
+        local_dc_length,
+        local_rack_raw,
+        local_rack_length,
     )
 }
 


### PR DESCRIPTION
Fix: https://github.com/scylladb/cpp-rust-driver/issues/156
See: https://github.com/scylladb/cpp-driver/pull/73

## Changes
Implemented `cass_[cluster/exeuction_profile]_set_load_balance_rack_aware[_n]`. Adjusted the documentation, and extended unit tests for API related to LBP.

## Important note about documentation and default behaviour of rack aware policy
I removed this part of the docstring:
```
 * With empty local_rack and local_dc,  default local_dc and local_rack
 * is chosen from the first connected contact point,
 * and no remote hosts are considered in query plans.
 * If relying on this mechanism, be sure to use only contact
 * points from the local rack.
```

There are multiple reasons for this:
- this behaviour does not make much sense, and we should not mimic it IMO
- rust-driver does not behave like this
- this is not even true for cpp-driver

Why it's not true for cpp-driver:
If you carefully study the changes introduced to cpp-driver in the aforementioned
commit, you will notice that it's not possible for the driver to use rack aware
policy with an empty strings. This is because API functions reject
empty string, thus RackAwarePolicy object is never constructed in such case.
```cpp
CassError cass_cluster_set_load_balance_rack_aware_n(CassCluster* cluster, const char* local_dc,
                                                   size_t local_dc_length,
                                                   const char* local_rack,
                                                   size_t local_rack_length) {
  if (local_dc == NULL || local_dc_length == 0 || local_rack == NULL || local_rack_length == 0) {
    return CASS_ERROR_LIB_BAD_PARAMS;
  }
  cluster->config().set_load_balancing_policy(new RackAwarePolicy(
      String(local_dc, local_dc_length), String(local_rack, local_rack_length)));
  return CASS_OK;
}
```

Why is this part of docstring included in cpp-driver then? No idea. Maybe,
because `cass_cluster_set_load_balance_dc_aware` mentions something similar
for empty (non-specified) dc. However, in this case it's true, since dc awareness is enabled
by default in cpp-driver. See the docstring:
```
 * Configures the cluster to use DC-aware load balancing.
 * For each query, all live nodes in a primary 'local' DC are tried first,
 * followed by any node from other DCs.
 *
 * <b>Note:</b> This is the default, and does not need to be called unless
 * switching an existing from another policy or changing settings.
 * Without further configuration, a default local_dc is chosen from the
 * first connected contact point, and no remote hosts are considered in
 * query plans. If relying on this mechanism, be sure to use only contact
 * points from the local DC.
```

## Default node location preference
Cpp-driver, is dc-aware by default. This is not true for rust-driver, and probably will never be. In rust-driver, by default there are no node location preferences. I adjusted the documentation of `cass_cluster_set_load_balance_dc_aware` by removing the mention of dc awareness being enabled by default.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~