### PR TITLE
exec_profile: Use cluster lbp for exec profiles by default

### DIFF
--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -65,9 +65,9 @@ impl LoadBalancingConfig {
             builder =
                 builder.enable_shuffling_replicas(self.token_aware_shuffling_replicas_enabled);
         }
-        if let Some(dc_awareness) = self.dc_awareness.as_ref() {
+        if let Some(dc_awareness) = self.dc_awareness {
             builder = builder
-                .prefer_datacenter(dc_awareness.local_dc.clone())
+                .prefer_datacenter(dc_awareness.local_dc)
                 .permit_dc_failover(true)
         }
         if self.latency_awareness_enabled {

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -109,12 +109,18 @@ impl CassSessionInner {
                 "Already connecting, closing, or connected".msg(),
             ));
         }
-        let mut exec_profile_map = HashMap::with_capacity(exec_profile_builder_map.len());
-        for (name, builder) in exec_profile_builder_map {
-            exec_profile_map.insert(name, builder.build().await.into_handle());
-        }
 
         let mut session_builder = session_builder_fut.await;
+        let default_profile = session_builder
+            .config
+            .default_execution_profile_handle
+            .to_profile();
+
+        let mut exec_profile_map = HashMap::with_capacity(exec_profile_builder_map.len());
+        for (name, builder) in exec_profile_builder_map {
+            exec_profile_map.insert(name, builder.build(&default_profile).await.into_handle());
+        }
+
         if let Some(keyspace) = keyspace {
             session_builder = session_builder.use_keyspace(keyspace, false);
         }


### PR DESCRIPTION
The documentation of `cass_execution_profile_set_load_balance_...` functions states:
```
 <b>Note:</b> Profile-based load balancing policy is disabled by default.
 cluster load balancing policy is used when profile does not contain a policy.
```
It seems to be true, see: https://github.com/scylladb/cpp-driver/blob/master/src/request_processor.cpp#L196-L209.

We should adjust cpp-rust-driver so it behaves the same way.

This PR consist mostly of some refactor commits that prepare for the logic change in the last commit.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~