### PR TITLE
cluster: schema agreement interval (extension) and timeout

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -2068,6 +2068,20 @@ CASS_EXPORT void
 cass_cluster_set_max_schema_wait_time(CassCluster* cluster,
                                       unsigned wait_time_ms);
 
+/**
+ * Set the delay for schema agreement check after a schema change.
+ * How often driver should ask if schema is in agreement.
+ *
+ * <b>Default:</b> 200 milliseconds
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] interval_ms Interval in milliseconds
+ */
+CASS_EXPORT void
+cass_cluster_set_schema_agreement_interval(CassCluster* cluster,
+                                           unsigned interval_ms);
 
 /**
  * Sets the maximum time to wait for tracing data to become available.

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -35,6 +35,8 @@ const DEFAULT_CONSISTENCY: Consistency = Consistency::LocalOne;
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(12000);
 // - fetching schema metadata is true
 const DEFAULT_DO_FETCH_SCHEMA_METADATA: bool = true;
+// - schema agreement timeout is 10000 millis,
+const DEFAULT_MAX_SCHEMA_WAIT_TIME: Duration = Duration::from_millis(10000);
 // - setting TCP_NODELAY is true
 const DEFAULT_SET_TCP_NO_DELAY: bool = true;
 // - connect timeout is 5000 millis
@@ -179,6 +181,7 @@ pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
         SessionBuilder::new()
             .custom_identity(custom_identity)
             .fetch_schema_metadata(DEFAULT_DO_FETCH_SCHEMA_METADATA)
+            .schema_agreement_timeout(DEFAULT_MAX_SCHEMA_WAIT_TIME)
             .tcp_nodelay(DEFAULT_SET_TCP_NO_DELAY)
             .connection_timeout(DEFAULT_CONNECT_TIMEOUT)
             .keepalive_interval(DEFAULT_KEEPALIVE_INTERVAL)
@@ -406,6 +409,17 @@ pub unsafe extern "C" fn cass_cluster_set_request_timeout(
         // 0 -> no timeout
         builder.request_timeout((timeout_ms > 0).then(|| Duration::from_millis(timeout_ms.into())))
     })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_max_schema_wait_time(
+    cluster_raw: *mut CassCluster,
+    wait_time_ms: c_uint,
+) {
+    let cluster = ptr_to_ref_mut(cluster_raw);
+
+    cluster.session_builder.config.schema_agreement_timeout =
+        Duration::from_millis(wait_time_ms.into());
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -37,6 +37,9 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(12000);
 const DEFAULT_DO_FETCH_SCHEMA_METADATA: bool = true;
 // - schema agreement timeout is 10000 millis,
 const DEFAULT_MAX_SCHEMA_WAIT_TIME: Duration = Duration::from_millis(10000);
+// - schema agreement interval is 200 millis.
+// This default is taken from rust-driver, since this option is an extension to cpp-rust-driver.
+const DEFAULT_SCHEMA_AGREEMENT_INTERVAL: Duration = Duration::from_millis(200);
 // - setting TCP_NODELAY is true
 const DEFAULT_SET_TCP_NO_DELAY: bool = true;
 // - connect timeout is 5000 millis
@@ -182,6 +185,7 @@ pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
             .custom_identity(custom_identity)
             .fetch_schema_metadata(DEFAULT_DO_FETCH_SCHEMA_METADATA)
             .schema_agreement_timeout(DEFAULT_MAX_SCHEMA_WAIT_TIME)
+            .schema_agreement_interval(DEFAULT_SCHEMA_AGREEMENT_INTERVAL)
             .tcp_nodelay(DEFAULT_SET_TCP_NO_DELAY)
             .connection_timeout(DEFAULT_CONNECT_TIMEOUT)
             .keepalive_interval(DEFAULT_KEEPALIVE_INTERVAL)
@@ -420,6 +424,17 @@ pub unsafe extern "C" fn cass_cluster_set_max_schema_wait_time(
 
     cluster.session_builder.config.schema_agreement_timeout =
         Duration::from_millis(wait_time_ms.into());
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_schema_agreement_interval(
+    cluster_raw: *mut CassCluster,
+    interval_ms: c_uint,
+) {
+    let cluster = ptr_to_ref_mut(cluster_raw);
+
+    cluster.session_builder.config.schema_agreement_interval =
+        Duration::from_millis(interval_ms.into());
 }
 
 #[no_mangle]


### PR DESCRIPTION
Implemented `cass_cluster_set_max_schema_wait_time` which corresponds to `schema_agreement_timeout` option in rust-driver.

Defined and implemented `cass_cluster_set_schema_agreement_interval` which corresponds to `schema_agreement_interval` option in rust-driver. This is an extension.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~