### PR TITLE
cluster: tracing config options

### DIFF
--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -855,6 +855,8 @@ impl TryFrom<CassConsistency> for Consistency {
             CassConsistency::CASS_CONSISTENCY_LOCAL_QUORUM => Ok(Consistency::LocalQuorum),
             CassConsistency::CASS_CONSISTENCY_EACH_QUORUM => Ok(Consistency::EachQuorum),
             CassConsistency::CASS_CONSISTENCY_LOCAL_ONE => Ok(Consistency::LocalOne),
+            CassConsistency::CASS_CONSISTENCY_LOCAL_SERIAL => Ok(Consistency::LocalSerial),
+            CassConsistency::CASS_CONSISTENCY_SERIAL => Ok(Consistency::Serial),
             _ => Err(()),
         }
     }

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -43,6 +43,8 @@ const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_millis(5000);
 const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
 // - keepalive timeout is 60 secs
 const DEFAULT_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(60);
+// - tracing info fetch interval is 3 millis
+const DEFAULT_TRACING_INFO_FETCH_INTERVAL: Duration = Duration::from_millis(3);
 // - tracing consistency is ONE
 const DEFAULT_TRACING_CONSISTENCY: Consistency = Consistency::One;
 
@@ -185,6 +187,7 @@ pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
             .connection_timeout(DEFAULT_CONNECT_TIMEOUT)
             .keepalive_interval(DEFAULT_KEEPALIVE_INTERVAL)
             .keepalive_timeout(DEFAULT_KEEPALIVE_TIMEOUT)
+            .tracing_info_fetch_interval(DEFAULT_TRACING_INFO_FETCH_INTERVAL)
             .tracing_info_fetch_consistency(DEFAULT_TRACING_CONSISTENCY)
     };
 
@@ -409,6 +412,17 @@ pub unsafe extern "C" fn cass_cluster_set_request_timeout(
         // 0 -> no timeout
         builder.request_timeout((timeout_ms > 0).then(|| Duration::from_millis(timeout_ms.into())))
     })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn cass_cluster_set_tracing_retry_wait_time(
+    cluster_raw: *mut CassCluster,
+    retry_wait_time_ms: c_uint,
+) {
+    let cluster = ptr_to_ref_mut(cluster_raw);
+
+    cluster.session_builder.config.tracing_info_fetch_interval =
+        Duration::from_millis(retry_wait_time_ms.into());
 }
 
 #[no_mangle]


### PR DESCRIPTION
Implemented:
- `cass_cluster_set_tracing_consistency`
- `cass_cluster_set_tracing_max_wait_time`
- `cass_cluster_set_tracing_retry_wait_time`

Set the defaults for this options as well.

Notice, that we needed to make use of a small hack, since rust-driver does not expose the option to set tracing info fetch timeout. Instead, it allows user to define maximum number of retries. This can be computed based on timeout and retry interval provided by user via cpp-rust-driver API.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.`~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~