### PR TITLE
cargo: point to rust-driver 64b4afcd

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1028,7 +1028,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "scylla"
 version = "0.14.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.14.0#0341198937871ea135fdca3ecfcea9a792ee9b18"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=64b4afcd#64b4afcdb4286b21f6cc1acb55266d6607f250e0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "scylla-cql"
 version = "0.3.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.14.0#0341198937871ea135fdca3ecfcea9a792ee9b18"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=64b4afcd#64b4afcdb4286b21f6cc1acb55266d6607f250e0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1102,7 +1102,7 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "0.6.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.14.0#0341198937871ea135fdca3ecfcea9a792ee9b18"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=64b4afcd#64b4afcdb4286b21f6cc1acb55266d6607f250e0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "scylla-proxy"
 version = "0.0.3"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.14.0#0341198937871ea135fdca3ecfcea9a792ee9b18"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=64b4afcd#64b4afcdb4286b21f6cc1acb55266d6607f250e0"
 dependencies = [
  "bigdecimal",
  "byteorder",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v0.14.0", features = [
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "64b4afcd", features = [
     "ssl",
 ] }
 tokio = { version = "1.27.0", features = ["full"] }
@@ -32,7 +32,7 @@ bindgen = "0.65"
 chrono = "0.4.20"
 
 [dev-dependencies]
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v0.14.0" }
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "64b4afcd" }
 
 assert_matches = "1.5.0"
 ntest = "0.9.3"

--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -8,15 +8,26 @@ impl From<&QueryError> for CassError {
         match error {
             QueryError::DbError(db_error, _string) => CassError::from(db_error),
             QueryError::BadQuery(bad_query) => CassError::from(bad_query),
-            QueryError::IoError(_io_error) => CassError::CASS_ERROR_LIB_UNABLE_TO_CONNECT,
             QueryError::ProtocolError(_str) => CassError::CASS_ERROR_SERVER_PROTOCOL_ERROR,
-            QueryError::InvalidMessage(_string) => CassError::CASS_ERROR_SERVER_INVALID_QUERY,
             QueryError::TimeoutError => CassError::CASS_ERROR_LIB_REQUEST_TIMED_OUT, // This may be either read or write timeout error
-            QueryError::TooManyOrphanedStreamIds(_) => CassError::CASS_ERROR_LIB_INVALID_STATE,
             QueryError::UnableToAllocStreamId => CassError::CASS_ERROR_LIB_NO_STREAMS,
             QueryError::RequestTimeout(_) => CassError::CASS_ERROR_LIB_REQUEST_TIMED_OUT,
-            QueryError::TranslationError(_) => CassError::CASS_ERROR_LIB_HOST_RESOLUTION,
-            QueryError::CqlResponseParseError(_) => CassError::CASS_ERROR_LIB_UNEXPECTED_RESPONSE,
+            QueryError::CqlRequestSerialization(_) => CassError::CASS_ERROR_LIB_MESSAGE_ENCODE,
+            QueryError::BodyExtensionsParseError(_) => {
+                CassError::CASS_ERROR_LIB_UNEXPECTED_RESPONSE
+            }
+            QueryError::EmptyPlan => CassError::CASS_ERROR_LIB_INVALID_STATE,
+            QueryError::CqlResultParseError(_) => CassError::CASS_ERROR_LIB_UNEXPECTED_RESPONSE,
+            QueryError::CqlErrorParseError(_) => CassError::CASS_ERROR_LIB_UNEXPECTED_RESPONSE,
+            QueryError::MetadataError(_) => CassError::CASS_ERROR_LIB_INVALID_STATE,
+            // I know that TranslationError (corresponding to CASS_ERROR_LIB_HOST_RESOLUTION)
+            // is hidden under the ConnectionPoolError.
+            // However, we still have a lot work to do when it comes to error conversion.
+            // I will address it, once we start resolving all issues related to error conversion.
+            QueryError::ConnectionPoolError(_) => CassError::CASS_ERROR_LIB_UNABLE_TO_CONNECT,
+            QueryError::BrokenConnection(_) => CassError::CASS_ERROR_LIB_UNABLE_TO_CONNECT,
+            // QueryError is non_exhaustive
+            _ => CassError::CASS_ERROR_LAST_ENTRY,
         }
     }
 }
@@ -62,6 +73,10 @@ impl From<&BadQuery> for CassError {
             BadQuery::Other(_other_query) => CassError::CASS_ERROR_LAST_ENTRY,
             BadQuery::SerializationError(_) => CassError::CASS_ERROR_LAST_ENTRY,
             BadQuery::TooManyQueriesInBatchStatement(_) => CassError::CASS_ERROR_LAST_ENTRY,
+            // BadQuery is non_exhaustive
+            // For now, since all other variants return LAST_ENTRY,
+            // let's do it here as well.
+            _ => CassError::CASS_ERROR_LAST_ENTRY,
         }
     }
 }
@@ -75,19 +90,29 @@ impl From<&NewSessionError> for CassError {
             NewSessionError::EmptyKnownNodesList => CassError::CASS_ERROR_LIB_NO_HOSTS_AVAILABLE,
             NewSessionError::DbError(_db_error, _string) => CassError::CASS_ERROR_LAST_ENTRY,
             NewSessionError::BadQuery(_bad_query) => CassError::CASS_ERROR_LAST_ENTRY,
-            NewSessionError::IoError(_io_error) => CassError::CASS_ERROR_LAST_ENTRY,
             NewSessionError::ProtocolError(_str) => {
                 CassError::CASS_ERROR_LIB_UNABLE_TO_DETERMINE_PROTOCOL
             }
-            NewSessionError::InvalidMessage(_string) => CassError::CASS_ERROR_LAST_ENTRY,
-            NewSessionError::TimeoutError => CassError::CASS_ERROR_LAST_ENTRY,
-            NewSessionError::TooManyOrphanedStreamIds(_) => CassError::CASS_ERROR_LAST_ENTRY,
             NewSessionError::UnableToAllocStreamId => CassError::CASS_ERROR_LAST_ENTRY,
             NewSessionError::RequestTimeout(_) => CassError::CASS_ERROR_LIB_REQUEST_TIMED_OUT,
-            NewSessionError::TranslationError(_) => CassError::CASS_ERROR_LIB_HOST_RESOLUTION,
-            NewSessionError::CqlResponseParseError(_) => {
+            NewSessionError::CqlRequestSerialization(_) => CassError::CASS_ERROR_LIB_MESSAGE_ENCODE,
+            NewSessionError::BodyExtensionsParseError(_) => {
                 CassError::CASS_ERROR_LIB_UNEXPECTED_RESPONSE
             }
+            NewSessionError::EmptyPlan => CassError::CASS_ERROR_LIB_INVALID_STATE,
+            NewSessionError::CqlResultParseError(_) => {
+                CassError::CASS_ERROR_LIB_UNEXPECTED_RESPONSE
+            }
+            NewSessionError::CqlErrorParseError(_) => CassError::CASS_ERROR_LIB_UNEXPECTED_RESPONSE,
+            NewSessionError::MetadataError(_) => CassError::CASS_ERROR_LIB_INVALID_STATE,
+            // I know that TranslationError (corresponding to CASS_ERROR_LIB_HOST_RESOLUTION)
+            // is hidden under the ConnectionPoolError.
+            // However, we still have a lot work to do when it comes to error conversion.
+            // I will address it, once we start resolving all issues related to error conversion.
+            NewSessionError::ConnectionPoolError(_) => CassError::CASS_ERROR_LIB_UNABLE_TO_CONNECT,
+            NewSessionError::BrokenConnection(_) => CassError::CASS_ERROR_LIB_UNABLE_TO_CONNECT,
+            // NS error is non_exhaustive
+            _ => CassError::CASS_ERROR_LAST_ENTRY,
         }
     }
 }
@@ -98,6 +123,8 @@ impl From<&BadKeyspaceName> for CassError {
             BadKeyspaceName::Empty => CassError::CASS_ERROR_LAST_ENTRY,
             BadKeyspaceName::TooLong(_string, _usize) => CassError::CASS_ERROR_LAST_ENTRY,
             BadKeyspaceName::IllegalCharacter(_string, _char) => CassError::CASS_ERROR_LAST_ENTRY,
+            // non_exhaustive
+            _ => CassError::CASS_ERROR_LAST_ENTRY,
         }
     }
 }

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -422,7 +422,7 @@ impl CassDataType {
 
 pub fn get_column_type(column_type: &ColumnType) -> CassDataType {
     match column_type {
-        ColumnType::Custom(s) => CassDataType::Custom((*s).clone()),
+        ColumnType::Custom(s) => CassDataType::Custom(s.clone().into_owned()),
         ColumnType::Ascii => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_ASCII),
         ColumnType::Boolean => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_BOOLEAN),
         ColumnType::Blob => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_BLOB),
@@ -459,10 +459,15 @@ pub fn get_column_type(column_type: &ColumnType) -> CassDataType {
         } => CassDataType::UDT(UDTDataType {
             field_types: field_types
                 .iter()
-                .map(|(name, col_type)| ((*name).clone(), Arc::new(get_column_type(col_type))))
+                .map(|(name, col_type)| {
+                    (
+                        name.clone().into_owned(),
+                        Arc::new(get_column_type(col_type)),
+                    )
+                })
                 .collect(),
-            keyspace: (*keyspace).clone(),
-            name: (*type_name).clone(),
+            keyspace: keyspace.clone().into_owned(),
+            name: type_name.clone().into_owned(),
             frozen: false,
         }),
         ColumnType::SmallInt => CassDataType::Value(CassValueType::CASS_VALUE_TYPE_SMALL_INT),

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -689,13 +689,13 @@ pub unsafe extern "C" fn cass_cluster_set_retry_policy(
     let cluster = ptr_to_ref_mut(cluster_raw);
 
     let retry_policy: Arc<dyn RetryPolicy> = match ptr_to_ref(retry_policy) {
-        DefaultRetryPolicy(default) => default.clone(),
-        FallthroughRetryPolicy(fallthrough) => fallthrough.clone(),
-        DowngradingConsistencyRetryPolicy(downgrading) => downgrading.clone(),
+        DefaultRetryPolicy(default) => Arc::clone(default) as _,
+        FallthroughRetryPolicy(fallthrough) => Arc::clone(fallthrough) as _,
+        DowngradingConsistencyRetryPolicy(downgrading) => Arc::clone(downgrading) as _,
     };
 
     exec_profile_builder_modify(&mut cluster.default_execution_profile_builder, |builder| {
-        builder.retry_policy(retry_policy.clone_boxed())
+        builder.retry_policy(retry_policy)
     });
 }
 

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -376,13 +376,13 @@ pub unsafe extern "C" fn cass_execution_profile_set_retry_policy(
     profile: *mut CassExecProfile,
     retry_policy: *const CassRetryPolicy,
 ) -> CassError {
-    let retry_policy: &dyn RetryPolicy = match ptr_to_ref(retry_policy) {
-        DefaultRetryPolicy(default) => default.as_ref(),
-        FallthroughRetryPolicy(fallthrough) => fallthrough.as_ref(),
-        DowngradingConsistencyRetryPolicy(downgrading) => downgrading.as_ref(),
+    let retry_policy: Arc<dyn RetryPolicy> = match ptr_to_ref(retry_policy) {
+        DefaultRetryPolicy(default) => Arc::clone(default) as _,
+        FallthroughRetryPolicy(fallthrough) => Arc::clone(fallthrough) as _,
+        DowngradingConsistencyRetryPolicy(downgrading) => Arc::clone(downgrading) as _,
     };
     let profile_builder = ptr_to_ref_mut(profile);
-    profile_builder.modify_in_place(|builder| builder.retry_policy(retry_policy.clone_boxed()));
+    profile_builder.modify_in_place(|builder| builder.retry_policy(retry_policy));
 
     CassError::CASS_OK
 }

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -27,14 +27,14 @@ impl CassPrepared {
         let variable_col_data_types = statement
             .get_variable_col_specs()
             .iter()
-            .map(|col_spec| Arc::new(get_column_type(&col_spec.typ)))
+            .map(|col_spec| Arc::new(get_column_type(col_spec.typ())))
             .collect();
 
         let result_col_data_types: Arc<Vec<Arc<CassDataType>>> = Arc::new(
             statement
                 .get_result_set_col_specs()
                 .iter()
-                .map(|col_spec| Arc::new(get_column_type(&col_spec.typ)))
+                .map(|col_spec| Arc::new(get_column_type(col_spec.typ())))
                 .collect(),
         );
 
@@ -50,7 +50,7 @@ impl CassPrepared {
             .statement
             .get_variable_col_specs()
             .iter()
-            .position(|col_spec| col_spec.name == name)?;
+            .position(|col_spec| col_spec.name() == name)?;
 
         match self.variable_col_data_types.get(index) {
             Some(dt) => Some(dt),
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn cass_prepared_parameter_name(
         .get(index as usize)
     {
         Some(col_spec) => {
-            write_str_to_c(&col_spec.name, name, name_length);
+            write_str_to_c(col_spec.name(), name, name_length);
             CassError::CASS_OK
         }
         None => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -110,8 +110,8 @@ impl CassStatement {
                     .iter()
                     .enumerate()
                     .filter(|(_, col)| {
-                        is_case_sensitive && col.name == name_str
-                            || !is_case_sensitive && col.name.eq_ignore_ascii_case(name_str)
+                        is_case_sensitive && col.name() == name_str
+                            || !is_case_sensitive && col.name().eq_ignore_ascii_case(name_str)
                     })
                     .map(|(i, _)| i)
                     .collect();

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -11,8 +11,8 @@ use scylla::{
             SetOrListSerializationErrorKind, TupleSerializationErrorKind,
             UdtSerializationErrorKind,
         },
-        writers::WrittenCellProof,
-        CellWriter, SerializationError,
+        writers::{CellWriter, WrittenCellProof},
+        SerializationError,
     },
 };
 use uuid::Uuid;

--- a/tests/src/integration/tests/test_prepared.cpp
+++ b/tests/src/integration/tests/test_prepared.cpp
@@ -67,7 +67,7 @@ CASSANDRA_INTEGRATION_TEST_F(PreparedTests, FailFastWhenPreparedIDChangesDuringR
   insert_statement.bind<Integer>(0, Integer(0));
   insert_statement.bind<Integer>(1, Integer(1));
   Result result = session_.execute(insert_statement, false);
-  EXPECT_TRUE(contains(result.error_message(), "Prepared statement Id changed"));
+  EXPECT_TRUE(contains(result.error_message(), "Prepared statement id changed after repreparation"));
 }
 
 /**


### PR DESCRIPTION
Currently, there are some open PRs that depend on changes recently introduced to rust-driver.
Let's bump the version of rust-driver dependency.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~