### PR TITLE
ci: adjust and enable heartbeat tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ConsistencyTwoNodeClusterTests.*\
 :ConsistencyThreeNodeClusterTests.*\
 :SerialConsistencyTests.*\
+:HeartbeatTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :BatchSingleNodeClusterTests*:BatchCounterSingleNodeClusterTests*:BatchCounterThreeNodeClusterTests*\
@@ -22,6 +23,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
+:HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ExecutionProfileTest.InvalidName\
 :*NoCompactEnabledConnection\
 :PreparedMetadataTests.Integration_Cassandra_AlterDoesntUpdateColumnCount\
@@ -36,6 +38,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ConsistencyTwoNodeClusterTests.*\
 :ConsistencyThreeNodeClusterTests.*\
 :SerialConsistencyTests.*\
+:HeartbeatTests.*\
 :PreparedTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :ErrorTests.*\
@@ -49,6 +52,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
+:HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
 :ExecutionProfileTest.InvalidName\
 :*NoCompactEnabledConnection\

--- a/tests/src/integration/tests/test_heartbeat.cpp
+++ b/tests/src/integration/tests/test_heartbeat.cpp
@@ -36,7 +36,7 @@ public:
 CASSANDRA_INTEGRATION_TEST_F(HeartbeatTests, HeartbeatEnabled) {
   CHECK_FAILURE;
 
-  logger_.add_critera("Heartbeat completed on host " + ccm_->get_ip_prefix());
+  logger_.add_critera("Keepalive request successful on connection to node " + ccm_->get_ip_prefix());
   Cluster cluster = default_cluster().with_connection_heartbeat_interval(1); // Quick heartbeat
   connect(cluster);
 
@@ -59,7 +59,7 @@ CASSANDRA_INTEGRATION_TEST_F(HeartbeatTests, HeartbeatEnabled) {
 CASSANDRA_INTEGRATION_TEST_F(HeartbeatTests, HeartbeatDisabled) {
   CHECK_FAILURE;
 
-  logger_.add_critera("Heartbeat completed on host " + ccm_->get_ip_prefix());
+  logger_.add_critera("Keepalive request successful on connection to node " + ccm_->get_ip_prefix());
   Cluster cluster = default_cluster().with_connection_heartbeat_interval(0);
   connect(cluster);
 


### PR DESCRIPTION
depends on: https://github.com/scylladb/cpp-rust-driver/pull/200

Enabled:
- HeartbeatTests.Integration_Cassandra_HeartbeatEnabled
- HeartbeatTests.Integration_Cassandra_HeartbeatDisabled

HeartbeatTests.Integration_Cassandra_HeartbeatFailed is still disabled, since it requires `cass_session_get_metrics` to be implemented.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.