### PR TITLE
result: small cleanups before bump to 0.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.InvalidName\
 :*NoCompactEnabledConnection\
 :PreparedMetadataTests.Integration_Cassandra_AlterDoesntUpdateColumnCount\
+:PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount\
 :UseKeyspaceCaseSensitiveTests.Integration_Cassandra_ConnectWithKeyspace)
 endif
 
@@ -57,6 +58,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.InvalidName\
 :*NoCompactEnabledConnection\
 :PreparedMetadataTests.Integration_Cassandra_AlterDoesntUpdateColumnCount\
+:PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount\
 :UseKeyspaceCaseSensitiveTests.Integration_Cassandra_ConnectWithKeyspace)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ExecutionProfileTest.InvalidName\
 :*NoCompactEnabledConnection\
-:PreparedMetadataTests.Integration_Cassandra_AlterDoesntUpdateColumnCount\
 :PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount\
 :UseKeyspaceCaseSensitiveTests.Integration_Cassandra_ConnectWithKeyspace)
 endif
@@ -57,7 +56,6 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
 :ExecutionProfileTest.InvalidName\
 :*NoCompactEnabledConnection\
-:PreparedMetadataTests.Integration_Cassandra_AlterDoesntUpdateColumnCount\
 :PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount\
 :UseKeyspaceCaseSensitiveTests.Integration_Cassandra_ConnectWithKeyspace)
 endif

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -138,6 +138,7 @@ pub enum MapDataType {
     KeyAndValue(Arc<CassDataType>, Arc<CassDataType>),
 }
 
+#[derive(Debug)]
 pub struct CassColumnSpec {
     pub name: String,
     pub data_type: Arc<CassDataType>,

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -138,6 +138,11 @@ pub enum MapDataType {
     KeyAndValue(Arc<CassDataType>, Arc<CassDataType>),
 }
 
+pub struct CassColumnSpec {
+    pub name: String,
+    pub data_type: Arc<CassDataType>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CassDataType {
     Value(CassValueType),

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -398,7 +398,7 @@ pub unsafe extern "C" fn cass_future_tracing_id(
     tracing_id: *mut CassUuid,
 ) -> CassError {
     ptr_to_ref(future).with_waited_result(|r: &mut CassFutureResult| match r {
-        Ok(CassResultValue::QueryResult(result)) => match result.metadata.tracing_id {
+        Ok(CassResultValue::QueryResult(result)) => match result.tracing_id {
             Some(id) => {
                 *tracing_id = CassUuid::from(id);
                 CassError::CASS_OK

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -5,7 +5,7 @@ use crate::{
     argconv::*,
     cass_error::CassError,
     cass_types::{get_column_type, CassDataType},
-    query_result::CassResultData,
+    query_result::CassResultMetadata,
     statement::{CassStatement, Statement},
     types::size_t,
 };
@@ -18,7 +18,7 @@ pub struct CassPrepared {
 
     // Cached result metadata. Arc'ed since we want to share it
     // with result metadata after execution.
-    pub result_metadata: Arc<CassResultData>,
+    pub result_metadata: Arc<CassResultMetadata>,
     pub statement: PreparedStatement,
 }
 
@@ -30,7 +30,7 @@ impl CassPrepared {
             .map(|col_spec| Arc::new(get_column_type(col_spec.typ())))
             .collect();
 
-        let result_metadata = Arc::new(CassResultData::from_column_specs(
+        let result_metadata = Arc::new(CassResultMetadata::from_column_specs(
             statement.get_result_set_col_specs(),
         ));
 

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -5,6 +5,7 @@ use crate::{
     argconv::*,
     cass_error::CassError,
     cass_types::{get_column_type, CassDataType},
+    query_result::CassResultData,
     statement::{CassStatement, Statement},
     types::size_t,
 };
@@ -14,11 +15,10 @@ use scylla::prepared_statement::PreparedStatement;
 pub struct CassPrepared {
     // Data types of columns from PreparedMetadata.
     pub variable_col_data_types: Vec<Arc<CassDataType>>,
-    // Data types of columns from ResultMetadata.
-    //
-    // Arc<CassDataType> -> to share each data type with other structs such as `CassValue`
-    // Arc<Vec<...>> -> to share the whole vector with `CassResultData`.
-    pub result_col_data_types: Arc<Vec<Arc<CassDataType>>>,
+
+    // Cached result metadata. Arc'ed since we want to share it
+    // with result metadata after execution.
+    pub result_metadata: Arc<CassResultData>,
     pub statement: PreparedStatement,
 }
 
@@ -30,17 +30,13 @@ impl CassPrepared {
             .map(|col_spec| Arc::new(get_column_type(col_spec.typ())))
             .collect();
 
-        let result_col_data_types: Arc<Vec<Arc<CassDataType>>> = Arc::new(
-            statement
-                .get_result_set_col_specs()
-                .iter()
-                .map(|col_spec| Arc::new(get_column_type(col_spec.typ())))
-                .collect(),
-        );
+        let result_metadata = Arc::new(CassResultData::from_column_specs(
+            statement.get_result_set_col_specs(),
+        ));
 
         Self {
             variable_col_data_types,
-            result_col_data_types,
+            result_metadata,
             statement,
         }
     }

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -23,6 +23,7 @@ pub struct CassResult {
     pub paging_state_response: PagingStateResponse,
 }
 
+#[derive(Debug)]
 pub struct CassResultData {
     pub col_specs: Vec<CassColumnSpec>,
 }

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -18,18 +18,18 @@ use uuid::Uuid;
 
 pub struct CassResult {
     pub rows: Option<Vec<CassRow>>,
-    pub metadata: Arc<CassResultData>,
+    pub metadata: Arc<CassResultMetadata>,
     pub tracing_id: Option<Uuid>,
     pub paging_state_response: PagingStateResponse,
 }
 
 #[derive(Debug)]
-pub struct CassResultData {
+pub struct CassResultMetadata {
     pub col_specs: Vec<CassColumnSpec>,
 }
 
-impl CassResultData {
-    pub fn from_column_specs(col_specs: &[ColumnSpec<'_>]) -> CassResultData {
+impl CassResultMetadata {
+    pub fn from_column_specs(col_specs: &[ColumnSpec<'_>]) -> CassResultMetadata {
         let col_specs = col_specs
             .iter()
             .map(|col_spec| {
@@ -40,7 +40,7 @@ impl CassResultData {
             })
             .collect();
 
-        CassResultData { col_specs }
+        CassResultMetadata { col_specs }
     }
 }
 
@@ -48,7 +48,7 @@ impl CassResultData {
 /// It will be freed, when CassResult is freed.(see #[cass_result_free])
 pub struct CassRow {
     pub columns: Vec<CassValue>,
-    pub result_metadata: Arc<CassResultData>,
+    pub result_metadata: Arc<CassResultMetadata>,
 }
 
 pub enum Value {
@@ -1395,7 +1395,9 @@ mod tests {
         session::create_cass_rows_from_rows,
     };
 
-    use super::{cass_result_column_count, cass_result_column_type, CassResult, CassResultData};
+    use super::{
+        cass_result_column_count, cass_result_column_type, CassResult, CassResultMetadata,
+    };
 
     fn col_spec(name: &'static str, typ: ColumnType<'static>) -> ColumnSpec<'static> {
         ColumnSpec::borrowed(name, typ, TableSpec::borrowed("ks", "tbl"))
@@ -1405,7 +1407,7 @@ mod tests {
     const SECOND_COLUMN_NAME: &str = "varint_col";
     const THIRD_COLUMN_NAME: &str = "list_double_col";
     fn create_cass_rows_result() -> CassResult {
-        let metadata = Arc::new(CassResultData::from_column_specs(&[
+        let metadata = Arc::new(CassResultMetadata::from_column_specs(&[
             col_spec(FIRST_COLUMN_NAME, ColumnType::BigInt),
             col_spec(SECOND_COLUMN_NAME, ColumnType::Varint),
             col_spec(
@@ -1520,7 +1522,7 @@ mod tests {
     }
 
     fn create_non_rows_cass_result() -> CassResult {
-        let metadata = Arc::new(CassResultData::from_column_specs(&[]));
+        let metadata = Arc::new(CassResultMetadata::from_column_specs(&[]));
         CassResult {
             rows: None,
             metadata,

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -19,13 +19,13 @@ use uuid::Uuid;
 pub struct CassResult {
     pub rows: Option<Vec<CassRow>>,
     pub metadata: Arc<CassResultData>,
+    pub tracing_id: Option<Uuid>,
 }
 
 pub struct CassResultData {
     pub paging_state_response: PagingStateResponse,
     pub col_specs: Vec<ColumnSpec<'static>>,
     pub col_data_types: Arc<Vec<Arc<CassDataType>>>,
-    pub tracing_id: Option<Uuid>,
 }
 
 impl CassResultData {
@@ -33,7 +33,6 @@ impl CassResultData {
         paging_state_response: PagingStateResponse,
         col_specs: Vec<ColumnSpec<'static>>,
         maybe_col_data_types: Option<Arc<Vec<Arc<CassDataType>>>>,
-        tracing_id: Option<Uuid>,
     ) -> CassResultData {
         // `maybe_col_data_types` is:
         // - Some(_) for prepared statements executions
@@ -52,7 +51,6 @@ impl CassResultData {
             paging_state_response,
             col_specs,
             col_data_types,
-            tracing_id,
         }
     }
 }
@@ -1425,7 +1423,6 @@ mod tests {
                 ),
             ],
             None,
-            None,
         ));
 
         let rows = create_cass_rows_from_rows(
@@ -1446,6 +1443,7 @@ mod tests {
         CassResult {
             rows: Some(rows),
             metadata,
+            tracing_id: None,
         }
     }
 
@@ -1536,11 +1534,11 @@ mod tests {
             PagingStateResponse::NoMorePages,
             vec![],
             None,
-            None,
         ));
         CassResult {
             rows: None,
             metadata,
+            tracing_id: None,
         }
     }
 

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -220,7 +220,7 @@ pub unsafe extern "C" fn cass_session_execute_batch(
         match query_res {
             Ok(_result) => Ok(CassResultValue::QueryResult(Arc::new(CassResult {
                 rows: None,
-                metadata: Arc::new(CassResultData::from_result_payload(vec![], None)),
+                metadata: Arc::new(CassResultData::from_result_payload(&[], None)),
                 tracing_id: None,
                 paging_state_response: PagingStateResponse::NoMorePages,
             }))),
@@ -355,7 +355,7 @@ pub unsafe extern "C" fn cass_session_execute(
         match query_res {
             Ok((result, paging_state_response, maybe_col_data_types)) => {
                 let metadata = Arc::new(CassResultData::from_result_payload(
-                    result.col_specs().to_vec(),
+                    result.col_specs(),
                     maybe_col_data_types,
                 ));
                 let cass_rows = result

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -220,12 +220,9 @@ pub unsafe extern "C" fn cass_session_execute_batch(
         match query_res {
             Ok(_result) => Ok(CassResultValue::QueryResult(Arc::new(CassResult {
                 rows: None,
-                metadata: Arc::new(CassResultData::from_result_payload(
-                    PagingStateResponse::NoMorePages,
-                    vec![],
-                    None,
-                )),
+                metadata: Arc::new(CassResultData::from_result_payload(vec![], None)),
                 tracing_id: None,
+                paging_state_response: PagingStateResponse::NoMorePages,
             }))),
             Err(err) => Ok(CassResultValue::QueryError(Arc::new(err))),
         }
@@ -358,7 +355,6 @@ pub unsafe extern "C" fn cass_session_execute(
         match query_res {
             Ok((result, paging_state_response, maybe_col_data_types)) => {
                 let metadata = Arc::new(CassResultData::from_result_payload(
-                    paging_state_response,
                     result.col_specs().to_vec(),
                     maybe_col_data_types,
                 ));
@@ -369,6 +365,7 @@ pub unsafe extern "C" fn cass_session_execute(
                     rows: cass_rows,
                     metadata,
                     tracing_id: result.tracing_id,
+                    paging_state_response,
                 });
 
                 Ok(CassResultValue::QueryResult(cass_result))

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -224,8 +224,8 @@ pub unsafe extern "C" fn cass_session_execute_batch(
                     PagingStateResponse::NoMorePages,
                     vec![],
                     None,
-                    None,
                 )),
+                tracing_id: None,
             }))),
             Err(err) => Ok(CassResultValue::QueryError(Arc::new(err))),
         }
@@ -361,7 +361,6 @@ pub unsafe extern "C" fn cass_session_execute(
                     paging_state_response,
                     result.col_specs().to_vec(),
                     maybe_col_data_types,
-                    result.tracing_id,
                 ));
                 let cass_rows = result
                     .rows
@@ -369,6 +368,7 @@ pub unsafe extern "C" fn cass_session_execute(
                 let cass_result = Arc::new(CassResult {
                     rows: cass_rows,
                     metadata,
+                    tracing_id: result.tracing_id,
                 });
 
                 Ok(CassResultValue::QueryResult(cass_result))

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -245,7 +245,7 @@ pub unsafe extern "C" fn cass_statement_set_paging_state(
     let statement = ptr_to_ref_mut(statement);
     let result = ptr_to_ref(result);
 
-    match &result.metadata.paging_state_response {
+    match &result.paging_state_response {
         PagingStateResponse::HasMorePages { state } => statement.paging_state.clone_from(state),
         PagingStateResponse::NoMorePages => statement.paging_state = PagingState::start(),
     }


### PR DESCRIPTION
## Tracing id and paging state response
These were moved from `CassResultData` to `CassResult`.

## CassResultData
### AlterProperlyUpdatesColumnCount test
This test should not be enabled. It expects that prepared statement's result metadata was updated after table schema was altered. It worked only because of a driver bug described later. I disabled this test. It's expected to be working for CQL protocol v5 and above. I think it can be addressed later.

### Driver bug
Before this PR, there was an inconsistency of metadata stored in `CassResultData`:
- `column_specs: Vec<ColumnSpec<'static>>` was obtained from a query result
- `col_data_types: Arc<Vec<Arc<CassDataType>>>` was obtained from the prepared statement's cached result metadata

Because of this, these vector could be of a different length when table schema was altered - query result provided the updated metadata, while prepared statement still held an outdated metadata.

Why was the aforementioned test working?
It's because `cass_result_column_count` would return the size of `column_specs` (i.e. updated metadata).

This PR fixes the issue by unifying these two vectors into a single one. `CassColumnSpec` was introduced to address it. It holds a column name (`String`) and a column data type (`Arc<CassDataType`).

### AlterDoesntUpdateColumnCount
On the other hand, this test should be enabled. It expects, that for protocol version 4 or less, the prepared statement's metadata is not updated after table schema was altered. It's enabled at the end of PR, once the bug mentioned above is fixed.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.