### PR TITLE
bump rust-driver to 0.15 (with eager deserialization)

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
  "rusty-fork",
  "scylla",
  "scylla-proxy",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1027,8 +1027,8 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scylla"
-version = "0.14.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=64b4afcd#64b4afcdb4286b21f6cc1acb55266d6607f250e0"
+version = "0.15.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.15.0#f59908c54e6b6407112311a3745e32d4bd218d0c"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1086,8 +1086,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.3.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=64b4afcd#64b4afcdb4286b21f6cc1acb55266d6607f250e0"
+version = "0.4.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.15.0#f59908c54e6b6407112311a3745e32d4bd218d0c"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1095,15 +1095,17 @@ dependencies = [
  "lz4_flex",
  "scylla-macros",
  "snap",
+ "stable_deref_trait",
  "thiserror",
  "tokio",
  "uuid",
+ "yoke",
 ]
 
 [[package]]
 name = "scylla-macros"
-version = "0.6.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=64b4afcd#64b4afcdb4286b21f6cc1acb55266d6607f250e0"
+version = "0.7.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.15.0#f59908c54e6b6407112311a3745e32d4bd218d0c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1114,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "scylla-proxy"
 version = "0.0.3"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=64b4afcd#64b4afcdb4286b21f6cc1acb55266d6607f250e0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v0.15.0#f59908c54e6b6407112311a3745e32d4bd218d0c"
 dependencies = [
  "bigdecimal",
  "byteorder",
@@ -1192,6 +1194,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1231,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1783,6 +1802,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,4 +1843,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.61",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+ "synstructure",
 ]

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -26,6 +26,7 @@ openssl = "0.10.32"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing = "0.1.37"
 futures = "0.3"
+thiserror = "1.0"
 
 [build-dependencies]
 bindgen = "0.65"

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "64b4afcd", features = [
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v0.15.0", features = [
     "ssl",
 ] }
 tokio = { version = "1.27.0", features = ["full"] }
@@ -33,7 +33,7 @@ bindgen = "0.65"
 chrono = "0.4.20"
 
 [dev-dependencies]
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "64b4afcd" }
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v0.15.0" }
 
 assert_matches = "1.5.0"
 ntest = "0.9.3"

--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -2,6 +2,16 @@ use scylla::transport::errors::*;
 
 // Re-export error types.
 pub(crate) use crate::cass_error_types::{CassError, CassErrorSource};
+use crate::query_error::CassErrorResult;
+
+// TODO: From<ref> is bad practice. Will be replaced in the next commit.
+impl From<&CassErrorResult> for CassError {
+    fn from(error: &CassErrorResult) -> Self {
+        match error {
+            CassErrorResult::Query(query_error) => CassError::from(query_error),
+        }
+    }
+}
 
 impl From<&QueryError> for CassError {
     fn from(error: &QueryError) -> Self {
@@ -131,6 +141,12 @@ impl From<&BadKeyspaceName> for CassError {
 
 pub trait CassErrorMessage {
     fn msg(&self) -> String;
+}
+
+impl CassErrorMessage for CassErrorResult {
+    fn msg(&self) -> String {
+        self.to_string()
+    }
 }
 
 impl CassErrorMessage for QueryError {

--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -12,6 +12,16 @@ impl ToCassError for CassErrorResult {
     fn to_cass_error(&self) -> CassError {
         match self {
             CassErrorResult::Query(query_error) => query_error.to_cass_error(),
+
+            // TODO:
+            // For now let's leave these as LIB_INVALID_DATA.
+            // I don't see any variants that would make more sense.
+            // TBH, I'm almost sure that we should introduce additional enum variants
+            // of CassError in the future ~ muzarski.
+            CassErrorResult::ResultMetadataLazyDeserialization(_) => {
+                CassError::CASS_ERROR_LIB_INVALID_DATA
+            }
+            CassErrorResult::Deserialization(_) => CassError::CASS_ERROR_LIB_INVALID_DATA,
         }
     }
 }

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -1,6 +1,7 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::cass_error::CassErrorMessage;
+use crate::cass_error::ToCassError;
 use crate::prepared::CassPrepared;
 use crate::query_error::CassErrorResult;
 use crate::query_result::CassResult;
@@ -320,7 +321,7 @@ pub unsafe extern "C" fn cass_future_ready(future_raw: *const CassFuture) -> cas
 #[no_mangle]
 pub unsafe extern "C" fn cass_future_error_code(future_raw: *const CassFuture) -> CassError {
     ptr_to_ref(future_raw).with_waited_result(|r: &mut CassFutureResult| match r {
-        Ok(CassResultValue::QueryError(err)) => CassError::from(err.as_ref()),
+        Ok(CassResultValue::QueryError(err)) => err.to_cass_error(),
         Err((err, _)) => *err,
         _ => CassError::CASS_OK,
     })

--- a/scylla-rust-wrapper/src/query_error.rs
+++ b/scylla-rust-wrapper/src/query_error.rs
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn cass_error_result_free(error_result: *const CassErrorRe
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_code(error_result: *const CassErrorResult) -> CassError {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
-    CassError::from(error_result)
+    error_result.to_cass_error()
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/query_error.rs
+++ b/scylla-rust-wrapper/src/query_error.rs
@@ -5,8 +5,13 @@ use crate::cass_types::CassConsistency;
 use crate::types::*;
 use scylla::statement::Consistency;
 use scylla::transport::errors::*;
+use thiserror::Error;
 
-pub type CassErrorResult = QueryError;
+#[derive(Error, Debug)]
+pub enum CassErrorResult {
+    #[error(transparent)]
+    Query(#[from] QueryError),
+}
 
 impl From<Consistency> for CassConsistency {
     fn from(c: Consistency) -> CassConsistency {
@@ -59,21 +64,26 @@ pub unsafe extern "C" fn cass_error_result_consistency(
 ) -> CassConsistency {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::Unavailable { consistency, .. }, _) => {
-            CassConsistency::from(*consistency)
-        }
-        QueryError::DbError(DbError::ReadTimeout { consistency, .. }, _) => {
-            CassConsistency::from(*consistency)
-        }
-        QueryError::DbError(DbError::WriteTimeout { consistency, .. }, _) => {
-            CassConsistency::from(*consistency)
-        }
-        QueryError::DbError(DbError::ReadFailure { consistency, .. }, _) => {
-            CassConsistency::from(*consistency)
-        }
-        QueryError::DbError(DbError::WriteFailure { consistency, .. }, _) => {
-            CassConsistency::from(*consistency)
-        }
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::Unavailable { consistency, .. },
+            _,
+        )) => CassConsistency::from(*consistency),
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::ReadTimeout { consistency, .. },
+            _,
+        )) => CassConsistency::from(*consistency),
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::WriteTimeout { consistency, .. },
+            _,
+        )) => CassConsistency::from(*consistency),
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::ReadFailure { consistency, .. },
+            _,
+        )) => CassConsistency::from(*consistency),
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::WriteFailure { consistency, .. },
+            _,
+        )) => CassConsistency::from(*consistency),
         _ => CassConsistency::CASS_CONSISTENCY_UNKNOWN,
     }
 }
@@ -84,11 +94,21 @@ pub unsafe extern "C" fn cass_error_result_responses_received(
 ) -> cass_int32_t {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::Unavailable { alive, .. }, _) => *alive,
-        QueryError::DbError(DbError::ReadTimeout { received, .. }, _) => *received,
-        QueryError::DbError(DbError::WriteTimeout { received, .. }, _) => *received,
-        QueryError::DbError(DbError::ReadFailure { received, .. }, _) => *received,
-        QueryError::DbError(DbError::WriteFailure { received, .. }, _) => *received,
+        CassErrorResult::Query(QueryError::DbError(DbError::Unavailable { alive, .. }, _)) => {
+            *alive
+        }
+        CassErrorResult::Query(QueryError::DbError(DbError::ReadTimeout { received, .. }, _)) => {
+            *received
+        }
+        CassErrorResult::Query(QueryError::DbError(DbError::WriteTimeout { received, .. }, _)) => {
+            *received
+        }
+        CassErrorResult::Query(QueryError::DbError(DbError::ReadFailure { received, .. }, _)) => {
+            *received
+        }
+        CassErrorResult::Query(QueryError::DbError(DbError::WriteFailure { received, .. }, _)) => {
+            *received
+        }
         _ => -1,
     }
 }
@@ -99,11 +119,21 @@ pub unsafe extern "C" fn cass_error_result_responses_required(
 ) -> cass_int32_t {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::Unavailable { required, .. }, _) => *required,
-        QueryError::DbError(DbError::ReadTimeout { required, .. }, _) => *required,
-        QueryError::DbError(DbError::WriteTimeout { required, .. }, _) => *required,
-        QueryError::DbError(DbError::ReadFailure { required, .. }, _) => *required,
-        QueryError::DbError(DbError::WriteFailure { required, .. }, _) => *required,
+        CassErrorResult::Query(QueryError::DbError(DbError::Unavailable { required, .. }, _)) => {
+            *required
+        }
+        CassErrorResult::Query(QueryError::DbError(DbError::ReadTimeout { required, .. }, _)) => {
+            *required
+        }
+        CassErrorResult::Query(QueryError::DbError(DbError::WriteTimeout { required, .. }, _)) => {
+            *required
+        }
+        CassErrorResult::Query(QueryError::DbError(DbError::ReadFailure { required, .. }, _)) => {
+            *required
+        }
+        CassErrorResult::Query(QueryError::DbError(DbError::WriteFailure { required, .. }, _)) => {
+            *required
+        }
         _ => -1,
     }
 }
@@ -114,8 +144,14 @@ pub unsafe extern "C" fn cass_error_result_num_failures(
 ) -> cass_int32_t {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::ReadFailure { numfailures, .. }, _) => *numfailures,
-        QueryError::DbError(DbError::WriteFailure { numfailures, .. }, _) => *numfailures,
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::ReadFailure { numfailures, .. },
+            _,
+        )) => *numfailures,
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::WriteFailure { numfailures, .. },
+            _,
+        )) => *numfailures,
         _ => -1,
     }
 }
@@ -126,14 +162,20 @@ pub unsafe extern "C" fn cass_error_result_data_present(
 ) -> cass_bool_t {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::ReadTimeout { data_present, .. }, _) => {
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::ReadTimeout { data_present, .. },
+            _,
+        )) => {
             if *data_present {
                 cass_true
             } else {
                 cass_false
             }
         }
-        QueryError::DbError(DbError::ReadFailure { data_present, .. }, _) => {
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::ReadFailure { data_present, .. },
+            _,
+        )) => {
             if *data_present {
                 cass_true
             } else {
@@ -150,12 +192,14 @@ pub unsafe extern "C" fn cass_error_result_write_type(
 ) -> CassWriteType {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::WriteTimeout { write_type, .. }, _) => {
-            CassWriteType::from(write_type)
-        }
-        QueryError::DbError(DbError::WriteFailure { write_type, .. }, _) => {
-            CassWriteType::from(write_type)
-        }
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::WriteTimeout { write_type, .. },
+            _,
+        )) => CassWriteType::from(write_type),
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::WriteFailure { write_type, .. },
+            _,
+        )) => CassWriteType::from(write_type),
         _ => CassWriteType::CASS_WRITE_TYPE_UNKNOWN,
     }
 }
@@ -168,11 +212,14 @@ pub unsafe extern "C" fn cass_error_result_keyspace(
 ) -> CassError {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::AlreadyExists { keyspace, .. }, _) => {
+        CassErrorResult::Query(QueryError::DbError(DbError::AlreadyExists { keyspace, .. }, _)) => {
             write_str_to_c(keyspace.as_str(), c_keyspace, c_keyspace_len);
             CassError::CASS_OK
         }
-        QueryError::DbError(DbError::FunctionFailure { keyspace, .. }, _) => {
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::FunctionFailure { keyspace, .. },
+            _,
+        )) => {
             write_str_to_c(keyspace.as_str(), c_keyspace, c_keyspace_len);
             CassError::CASS_OK
         }
@@ -188,7 +235,7 @@ pub unsafe extern "C" fn cass_error_result_table(
 ) -> CassError {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::AlreadyExists { table, .. }, _) => {
+        CassErrorResult::Query(QueryError::DbError(DbError::AlreadyExists { table, .. }, _)) => {
             write_str_to_c(table.as_str(), c_table, c_table_len);
             CassError::CASS_OK
         }
@@ -204,7 +251,10 @@ pub unsafe extern "C" fn cass_error_result_function(
 ) -> CassError {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::FunctionFailure { function, .. }, _) => {
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::FunctionFailure { function, .. },
+            _,
+        )) => {
             write_str_to_c(function.as_str(), c_function, c_function_len);
             CassError::CASS_OK
         }
@@ -216,9 +266,10 @@ pub unsafe extern "C" fn cass_error_result_function(
 pub unsafe extern "C" fn cass_error_num_arg_types(error_result: *const CassErrorResult) -> size_t {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::FunctionFailure { arg_types, .. }, _) => {
-            arg_types.len() as size_t
-        }
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::FunctionFailure { arg_types, .. },
+            _,
+        )) => arg_types.len() as size_t,
         _ => 0,
     }
 }
@@ -232,7 +283,10 @@ pub unsafe extern "C" fn cass_error_result_arg_type(
 ) -> CassError {
     let error_result: &CassErrorResult = ptr_to_ref(error_result);
     match error_result {
-        QueryError::DbError(DbError::FunctionFailure { arg_types, .. }, _) => {
+        CassErrorResult::Query(QueryError::DbError(
+            DbError::FunctionFailure { arg_types, .. },
+            _,
+        )) => {
             if index >= arg_types.len() as size_t {
                 return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
             }

--- a/scylla-rust-wrapper/src/query_error.rs
+++ b/scylla-rust-wrapper/src/query_error.rs
@@ -3,6 +3,8 @@ use crate::cass_error::*;
 use crate::cass_error_types::CassWriteType;
 use crate::cass_types::CassConsistency;
 use crate::types::*;
+use scylla::deserialize::DeserializationError;
+use scylla::frame::frame_errors::ResultMetadataAndRowsCountParseError;
 use scylla::statement::Consistency;
 use scylla::transport::errors::*;
 use thiserror::Error;
@@ -11,6 +13,10 @@ use thiserror::Error;
 pub enum CassErrorResult {
     #[error(transparent)]
     Query(#[from] QueryError),
+    #[error(transparent)]
+    ResultMetadataLazyDeserialization(#[from] ResultMetadataAndRowsCountParseError),
+    #[error("Failed to deserialize rows: {0}")]
+    Deserialization(#[from] DeserializationError),
 }
 
 impl From<Consistency> for CassConsistency {

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -224,7 +224,7 @@ pub unsafe extern "C" fn cass_session_execute_batch(
                 tracing_id: None,
                 paging_state_response: PagingStateResponse::NoMorePages,
             }))),
-            Err(err) => Ok(CassResultValue::QueryError(Arc::new(err))),
+            Err(err) => Ok(CassResultValue::QueryError(Arc::new(err.into()))),
         }
     };
 
@@ -243,7 +243,7 @@ async fn request_with_timeout(
     match tokio::time::timeout(Duration::from_millis(request_timeout_ms), future).await {
         Ok(result) => result,
         Err(_timeout_err) => Ok(CassResultValue::QueryError(Arc::new(
-            QueryError::TimeoutError,
+            QueryError::TimeoutError.into(),
         ))),
     }
 }
@@ -372,7 +372,7 @@ pub unsafe extern "C" fn cass_session_execute(
 
                 Ok(CassResultValue::QueryResult(cass_result))
             }
-            Err(err) => Ok(CassResultValue::QueryError(Arc::new(err))),
+            Err(err) => Ok(CassResultValue::QueryError(Arc::new(err.into()))),
         }
     };
 

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -128,7 +128,7 @@ impl CassSessionInner {
         let session = session_builder
             .build()
             .await
-            .map_err(|err| (CassError::from(&err), err.msg()))?;
+            .map_err(|err| (err.to_cass_error(), err.msg()))?;
 
         *session_guard = Some(CassSessionInner {
             session,
@@ -538,7 +538,7 @@ pub unsafe extern "C" fn cass_session_prepare_from_existing(
         let prepared = session
             .prepare(query.query.clone())
             .await
-            .map_err(|err| (CassError::from(&err), err.msg()))?;
+            .map_err(|err| (err.to_cass_error(), err.msg()))?;
 
         Ok(CassResultValue::Prepared(Arc::new(
             CassPrepared::new_from_prepared_statement(prepared),
@@ -582,7 +582,7 @@ pub unsafe extern "C" fn cass_session_prepare_n(
         let mut prepared = session
             .prepare(query)
             .await
-            .map_err(|err| (CassError::from(&err), err.msg()))?;
+            .map_err(|err| (err.to_cass_error(), err.msg()))?;
 
         // Set Cpp Driver default configuration for queries:
         prepared.set_consistency(Consistency::One);


### PR DESCRIPTION
First 4 commits are a bunch of preparations, to reduce the noise during the commit that actually bumps the version.

One of them fixes most of the occurrences of https://github.com/scylladb/cpp-rust-driver/issues/177. There are still a few places to be addressed, that are non error related.

# Bump to 0.15 commit

## CassResult was refactored yet again.
Now, we clearly distinguish betwen Rows and non-Rows result. `CassResultKind` and `CassRowsResult` are introduced. `CassRowsResult` holds information about the (for now, eagerly deserialized) rows and metadata. The usages of `CassResult` are adjusted throughout the codebase.

## CassErrorResult was transformed to an enum:
- query error - an error that occurred during query execution (before rows deserialization)
- metadata deserialization error - happens during conversion from QueryResult
  to QueryRowsResult
- deserialization error - happens during eager rows deserialization.

## CassResult construction logic was adjusted to new QueryResult.
As mentioned above, some errors can occur during conversion, thus `CassResult::from_result_payload` returns a StdResult now. For now, we eagerly deserialize the rows. This is equivalent to the version before this PR.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~