### PR TITLE
type safety: ffi pointer manipulation API

### DIFF
--- a/scylla-rust-wrapper/clippy.toml
+++ b/scylla-rust-wrapper/clippy.toml
@@ -1,0 +1,21 @@
+disallowed-methods = [
+    "std::boxed::Box::from_raw",
+    "std::boxed::Box::from_raw_in",
+    "std::boxed::Box::into_raw",
+    "std::boxed::Box::into_raw_with_allocator",
+
+    "std::sync::Arc::as_ptr",
+    "std::sync::Arc::decrement_strong_count",
+    "std::sync::Arc::from_raw",
+    "std::sync::Arc::increment_strong_count",
+    "std::sync::Arc::into_raw",
+
+    "std::rc::Rc::as_ptr",
+    "std::rc::Rc::decrement_strong_count",
+    "std::rc::Rc::from_raw",
+    "std::rc::Rc::increment_strong_count",
+    "std::rc::Rc::into_raw",
+
+    "const_ptr::as_ref",
+    "mut_ptr::as_mut"
+]

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -97,3 +97,77 @@ macro_rules! make_c_str {
 
 #[cfg(test)]
 pub(crate) use make_c_str;
+
+/// Defines a pointer manipulation API for non-shared heap-allocated data.
+///
+/// Implement this trait for types that are allocated by the driver via [`Box::new`],
+/// and then returned to the user as a pointer. The user is responsible for freeing
+/// the memory associated with the pointer using corresponding driver's API function.
+pub trait BoxFFI {
+    fn into_ptr(self: Box<Self>) -> *mut Self {
+        Box::into_raw(self)
+    }
+    unsafe fn from_ptr(ptr: *mut Self) -> Box<Self> {
+        Box::from_raw(ptr)
+    }
+    unsafe fn as_maybe_ref<'a>(ptr: *const Self) -> Option<&'a Self> {
+        ptr.as_ref()
+    }
+    unsafe fn as_ref<'a>(ptr: *const Self) -> &'a Self {
+        ptr.as_ref().unwrap()
+    }
+    unsafe fn as_mut_ref<'a>(ptr: *mut Self) -> &'a mut Self {
+        ptr.as_mut().unwrap()
+    }
+    unsafe fn free(ptr: *mut Self) {
+        std::mem::drop(BoxFFI::from_ptr(ptr));
+    }
+}
+
+/// Defines a pointer manipulation API for shared heap-allocated data.
+///
+/// Implement this trait for types that require a shared ownership of data.
+/// The data should be allocated via [`Arc::new`], and then returned to the user as a pointer.
+/// The user is responsible for freeing the memory associated
+/// with the pointer using corresponding driver's API function.
+pub trait ArcFFI {
+    fn as_ptr(self: &Arc<Self>) -> *const Self {
+        Arc::as_ptr(self)
+    }
+    fn into_ptr(self: Arc<Self>) -> *const Self {
+        Arc::into_raw(self)
+    }
+    unsafe fn from_ptr(ptr: *const Self) -> Arc<Self> {
+        Arc::from_raw(ptr)
+    }
+    unsafe fn cloned_from_ptr(ptr: *const Self) -> Arc<Self> {
+        Arc::increment_strong_count(ptr);
+        Arc::from_raw(ptr)
+    }
+    unsafe fn as_maybe_ref<'a>(ptr: *const Self) -> Option<&'a Self> {
+        ptr.as_ref()
+    }
+    unsafe fn as_ref<'a>(ptr: *const Self) -> &'a Self {
+        ptr.as_ref().unwrap()
+    }
+    unsafe fn free(ptr: *const Self) {
+        std::mem::drop(ArcFFI::from_ptr(ptr));
+    }
+}
+
+/// Defines a pointer manipulation API for data owned by some other object.
+///
+/// Implement this trait for the types that do not need to be freed (directly) by the user.
+/// The lifetime of the data is bound to some other object owning it.
+///
+/// For example: lifetime of CassRow is bound by the lifetime of CassResult.
+/// There is no API function that frees the CassRow. It should be automatically
+/// freed when user calls cass_result_free.
+pub trait RefFFI {
+    fn as_ptr(&self) -> *const Self {
+        self as *const Self
+    }
+    unsafe fn as_ref<'a>(ptr: *const Self) -> &'a Self {
+        ptr.as_ref().unwrap()
+    }
+}

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -4,33 +4,6 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::sync::Arc;
 
-pub unsafe fn ptr_to_ref<T>(ptr: *const T) -> &'static T {
-    ptr.as_ref().unwrap()
-}
-
-pub unsafe fn ptr_to_ref_mut<T>(ptr: *mut T) -> &'static mut T {
-    ptr.as_mut().unwrap()
-}
-
-pub unsafe fn free_boxed<T>(ptr: *mut T) {
-    if !ptr.is_null() {
-        // This takes the ownership of the boxed value and drops it
-        let _ = Box::from_raw(ptr);
-    }
-}
-
-pub unsafe fn clone_arced<T>(ptr: *const T) -> Arc<T> {
-    Arc::increment_strong_count(ptr);
-    Arc::from_raw(ptr)
-}
-
-pub unsafe fn free_arced<T>(ptr: *const T) {
-    if !ptr.is_null() {
-        // This decrements the arc's internal counter and potentially drops it
-        Arc::from_raw(ptr);
-    }
-}
-
 pub unsafe fn ptr_to_cstr(ptr: *const c_char) -> Option<&'static str> {
     CStr::from_ptr(ptr).to_str().ok()
 }

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -78,18 +78,23 @@ pub(crate) use make_c_str;
 /// the memory associated with the pointer using corresponding driver's API function.
 pub trait BoxFFI {
     fn into_ptr(self: Box<Self>) -> *mut Self {
+        #[allow(clippy::disallowed_methods)]
         Box::into_raw(self)
     }
     unsafe fn from_ptr(ptr: *mut Self) -> Box<Self> {
+        #[allow(clippy::disallowed_methods)]
         Box::from_raw(ptr)
     }
     unsafe fn as_maybe_ref<'a>(ptr: *const Self) -> Option<&'a Self> {
+        #[allow(clippy::disallowed_methods)]
         ptr.as_ref()
     }
     unsafe fn as_ref<'a>(ptr: *const Self) -> &'a Self {
+        #[allow(clippy::disallowed_methods)]
         ptr.as_ref().unwrap()
     }
     unsafe fn as_mut_ref<'a>(ptr: *mut Self) -> &'a mut Self {
+        #[allow(clippy::disallowed_methods)]
         ptr.as_mut().unwrap()
     }
     unsafe fn free(ptr: *mut Self) {
@@ -105,22 +110,29 @@ pub trait BoxFFI {
 /// with the pointer using corresponding driver's API function.
 pub trait ArcFFI {
     fn as_ptr(self: &Arc<Self>) -> *const Self {
+        #[allow(clippy::disallowed_methods)]
         Arc::as_ptr(self)
     }
     fn into_ptr(self: Arc<Self>) -> *const Self {
+        #[allow(clippy::disallowed_methods)]
         Arc::into_raw(self)
     }
     unsafe fn from_ptr(ptr: *const Self) -> Arc<Self> {
+        #[allow(clippy::disallowed_methods)]
         Arc::from_raw(ptr)
     }
     unsafe fn cloned_from_ptr(ptr: *const Self) -> Arc<Self> {
+        #[allow(clippy::disallowed_methods)]
         Arc::increment_strong_count(ptr);
+        #[allow(clippy::disallowed_methods)]
         Arc::from_raw(ptr)
     }
     unsafe fn as_maybe_ref<'a>(ptr: *const Self) -> Option<&'a Self> {
+        #[allow(clippy::disallowed_methods)]
         ptr.as_ref()
     }
     unsafe fn as_ref<'a>(ptr: *const Self) -> &'a Self {
+        #[allow(clippy::disallowed_methods)]
         ptr.as_ref().unwrap()
     }
     unsafe fn free(ptr: *const Self) {
@@ -141,6 +153,7 @@ pub trait RefFFI {
         self as *const Self
     }
     unsafe fn as_ref<'a>(ptr: *const Self) -> &'a Self {
+        #[allow(clippy::disallowed_methods)]
         ptr.as_ref().unwrap()
     }
 }

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -61,7 +61,7 @@ macro_rules! make_index_binder {
             #[allow(unused_imports)]
             use crate::value::CassCqlValue::*;
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(ptr_to_ref_mut(this), index as usize, v),
+                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this), index as usize, v),
                 Err(e) => e,
             }
         }
@@ -82,7 +82,7 @@ macro_rules! make_name_binder {
             use crate::value::CassCqlValue::*;
             let name = ptr_to_cstr(name).unwrap();
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(ptr_to_ref_mut(this), name, v),
+                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this), name, v),
                 Err(e) => e,
             }
         }
@@ -104,7 +104,7 @@ macro_rules! make_name_n_binder {
             use crate::value::CassCqlValue::*;
             let name = ptr_to_cstr_n(name, name_length).unwrap();
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(ptr_to_ref_mut(this), name, v),
+                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this), name, v),
                 Err(e) => e,
             }
         }
@@ -123,7 +123,7 @@ macro_rules! make_appender {
             #[allow(unused_imports)]
             use crate::value::CassCqlValue::*;
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(ptr_to_ref_mut(this), v),
+                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this), v),
                 Err(e) => e,
             }
         }
@@ -303,7 +303,7 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $consume_v,
             $fn,
             |p: *const crate::collection::CassCollection| {
-                match std::convert::TryInto::try_into(ptr_to_ref(p)) {
+                match std::convert::TryInto::try_into(BoxFFI::as_ref(p)) {
                     Ok(v) => Ok(Some(v)),
                     Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
                 }
@@ -317,7 +317,7 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $consume_v,
             $fn,
             |p: *const crate::tuple::CassTuple| {
-                Ok(Some(ptr_to_ref(p).into()))
+                Ok(Some(BoxFFI::as_ref(p).into()))
             },
             [p @ *const crate::tuple::CassTuple]
         );
@@ -327,7 +327,7 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |p: *const crate::user_type::CassUserType| Ok(Some(ptr_to_ref(p).into())),
+            |p: *const crate::user_type::CassUserType| Ok(Some(BoxFFI::as_ref(p).into())),
             [p @ *const crate::user_type::CassUserType]
         );
     };

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -16,7 +16,8 @@ pub(crate) use crate::cass_batch_types::CassBatchType;
 pub(crate) use crate::cass_consistency_types::CassConsistency;
 pub(crate) use crate::cass_data_types::CassValueType;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct UDTDataType {
     // Vec to preserve the order of types
     pub field_types: Vec<(String, Arc<CassDataType>)>,
@@ -137,7 +138,8 @@ impl Default for UDTDataType {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum MapDataType {
     Untyped,
     Key(Arc<CassDataType>),
@@ -150,7 +152,8 @@ pub struct CassColumnSpec {
     pub data_type: Arc<CassDataType>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum CassDataTypeInner {
     Value(CassValueType),
     UDT(UDTDataType),
@@ -260,11 +263,13 @@ impl CassDataTypeInner {
 pub struct CassDataType(UnsafeCell<CassDataTypeInner>);
 
 /// PartialEq and Eq for test purposes.
+#[cfg(test)]
 impl PartialEq for CassDataType {
     fn eq(&self, other: &Self) -> bool {
         unsafe { self.get_unchecked() == other.get_unchecked() }
     }
 }
+#[cfg(test)]
 impl Eq for CassDataType {}
 
 unsafe impl Sync for CassDataType {}

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -489,6 +489,7 @@ mod tests {
     //   the future, and execute its callback
     #[test]
     #[ntest::timeout(600)]
+    #[allow(clippy::disallowed_methods)]
     fn test_cass_future_callback() {
         unsafe {
             const ERROR_MSG: &str = "NOBODY EXPECTED SPANISH INQUISITION";

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -1,7 +1,7 @@
 use std::ffi::{c_char, CString};
 
 use crate::{
-    argconv::ptr_to_ref,
+    argconv::BoxFFI,
     cluster::CassCluster,
     types::{cass_int32_t, cass_uint16_t, size_t},
 };
@@ -10,14 +10,14 @@ use crate::{
 pub unsafe extern "C" fn testing_cluster_get_connect_timeout(
     cluster_raw: *const CassCluster,
 ) -> cass_uint16_t {
-    let cluster = ptr_to_ref(cluster_raw);
+    let cluster = BoxFFI::as_ref(cluster_raw);
 
     cluster.get_session_config().connect_timeout.as_millis() as cass_uint16_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn testing_cluster_get_port(cluster_raw: *const CassCluster) -> cass_int32_t {
-    let cluster = ptr_to_ref(cluster_raw);
+    let cluster = BoxFFI::as_ref(cluster_raw);
 
     cluster.get_port() as cass_int32_t
 }
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn testing_cluster_get_contact_points(
     contact_points: *mut *mut c_char,
     contact_points_length: *mut size_t,
 ) {
-    let cluster = ptr_to_ref(cluster_raw);
+    let cluster = BoxFFI::as_ref(cluster_raw);
 
     let contact_points_string = cluster.get_contact_points().join(",");
     let length = contact_points_string.len();

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -122,7 +122,7 @@ lazy_static! {
 
 // #[no_mangle]
 // pub extern "C" fn create_foo() -> *mut Foo {
-//     Box::into_raw(Box::new(Foo))
+//     BoxFFI::into_raw(Box::new(Foo))
 // }
 
 // To borrow (and not free) from C:

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -1,4 +1,4 @@
-use crate::argconv::{arr_to_cstr, ptr_to_cstr, ptr_to_ref, str_to_arr};
+use crate::argconv::{arr_to_cstr, ptr_to_cstr, str_to_arr, RefFFI};
 use crate::cass_log_types::{CassLogLevel, CassLogMessage};
 use crate::types::size_t;
 use crate::LOGGER;
@@ -13,6 +13,8 @@ use tracing::Level;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::Layer;
+
+impl RefFFI for CassLogMessage {}
 
 pub type CassLogCallback =
     Option<unsafe extern "C" fn(message: *const CassLogMessage, data: *mut c_void)>;
@@ -63,7 +65,7 @@ impl TryFrom<CassLogLevel> for Level {
 pub const CASS_LOG_MAX_MESSAGE_SIZE: usize = 1024;
 
 pub unsafe extern "C" fn stderr_log_callback(message: *const CassLogMessage, _data: *mut c_void) {
-    let message = ptr_to_ref(message);
+    let message = RefFFI::as_ref(message);
 
     eprintln!(
         "{} [{}] ({}:{}) {}",

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -13,6 +13,8 @@ pub struct CassSchemaMeta {
     pub keyspaces: HashMap<String, CassKeyspaceMeta>,
 }
 
+impl BoxFFI for CassSchemaMeta {}
+
 pub struct CassKeyspaceMeta {
     pub name: String,
 
@@ -22,6 +24,9 @@ pub struct CassKeyspaceMeta {
     pub views: HashMap<String, Arc<CassMaterializedViewMeta>>,
 }
 
+// Owned by CassSchemaMeta
+impl RefFFI for CassKeyspaceMeta {}
+
 pub struct CassTableMeta {
     pub name: String,
     pub columns_metadata: HashMap<String, CassColumnMeta>,
@@ -30,17 +35,28 @@ pub struct CassTableMeta {
     pub views: HashMap<String, Arc<CassMaterializedViewMeta>>,
 }
 
+// Either:
+// - owned by CassMaterializedViewMeta - won't be given to user
+// - Owned by CassKeyspaceMeta (in Arc), referenced (Weak) by CassMaterializedViewMeta
+impl RefFFI for CassTableMeta {}
+
 pub struct CassMaterializedViewMeta {
     pub name: String,
     pub view_metadata: CassTableMeta,
     pub base_table: Weak<CassTableMeta>,
 }
 
+// Shared ownership by CassKeyspaceMeta and CassTableMeta
+impl RefFFI for CassMaterializedViewMeta {}
+
 pub struct CassColumnMeta {
     pub name: String,
     pub column_type: CassDataType,
     pub column_kind: CassColumnType,
 }
+
+// Owned by CassTableMeta
+impl RefFFI for CassColumnMeta {}
 
 pub unsafe fn create_table_metadata(
     keyspace_name: &str,
@@ -82,7 +98,7 @@ pub unsafe fn create_table_metadata(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_schema_meta_free(schema_meta: *mut CassSchemaMeta) {
-    free_boxed(schema_meta)
+    BoxFFI::free(schema_meta);
 }
 
 #[no_mangle]
@@ -103,7 +119,7 @@ pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name_n(
         return std::ptr::null();
     }
 
-    let metadata = ptr_to_ref(schema_meta);
+    let metadata = BoxFFI::as_ref(schema_meta);
     let keyspace = ptr_to_cstr_n(keyspace_name, keyspace_name_length).unwrap();
 
     let keyspace_meta = metadata.keyspaces.get(keyspace);
@@ -120,7 +136,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_name(
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) {
-    let keyspace_meta = ptr_to_ref(keyspace_meta);
+    let keyspace_meta = RefFFI::as_ref(keyspace_meta);
     write_str_to_c(keyspace_meta.name.as_str(), name, name_length)
 }
 
@@ -142,14 +158,14 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
         return std::ptr::null();
     }
 
-    let keyspace_meta = ptr_to_ref(keyspace_meta);
+    let keyspace_meta = RefFFI::as_ref(keyspace_meta);
     let user_type_name = ptr_to_cstr_n(type_, type_length).unwrap();
 
     match keyspace_meta
         .user_defined_type_data_type
         .get(user_type_name)
     {
-        Some(udt) => Arc::as_ptr(udt),
+        Some(udt) => ArcFFI::as_ptr(udt),
         None => std::ptr::null(),
     }
 }
@@ -172,13 +188,13 @@ pub unsafe extern "C" fn cass_keyspace_meta_table_by_name_n(
         return std::ptr::null();
     }
 
-    let keyspace_meta = ptr_to_ref(keyspace_meta);
+    let keyspace_meta = RefFFI::as_ref(keyspace_meta);
     let table_name = ptr_to_cstr_n(table, table_length).unwrap();
 
     let table_meta = keyspace_meta.tables.get(table_name);
 
     match table_meta {
-        Some(meta) => Arc::as_ptr(meta),
+        Some(meta) => RefFFI::as_ptr(meta),
         None => std::ptr::null(),
     }
 }
@@ -189,13 +205,13 @@ pub unsafe extern "C" fn cass_table_meta_name(
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) {
-    let table_meta = ptr_to_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta);
     write_str_to_c(table_meta.name.as_str(), name, name_length)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_column_count(table_meta: *const CassTableMeta) -> size_t {
-    let table_meta = ptr_to_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta);
     table_meta.columns_metadata.len() as size_t
 }
 
@@ -204,7 +220,7 @@ pub unsafe extern "C" fn cass_table_meta_partition_key(
     table_meta: *const CassTableMeta,
     index: size_t,
 ) -> *const CassColumnMeta {
-    let table_meta = ptr_to_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta);
 
     match table_meta.partition_keys.get(index as usize) {
         Some(column_name) => match table_meta.columns_metadata.get(column_name) {
@@ -219,7 +235,7 @@ pub unsafe extern "C" fn cass_table_meta_partition_key(
 pub unsafe extern "C" fn cass_table_meta_partition_key_count(
     table_meta: *const CassTableMeta,
 ) -> size_t {
-    let table_meta = ptr_to_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta);
     table_meta.partition_keys.len() as size_t
 }
 
@@ -228,7 +244,7 @@ pub unsafe extern "C" fn cass_table_meta_clustering_key(
     table_meta: *const CassTableMeta,
     index: size_t,
 ) -> *const CassColumnMeta {
-    let table_meta = ptr_to_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta);
 
     match table_meta.clustering_keys.get(index as usize) {
         Some(column_name) => match table_meta.columns_metadata.get(column_name) {
@@ -243,7 +259,7 @@ pub unsafe extern "C" fn cass_table_meta_clustering_key(
 pub unsafe extern "C" fn cass_table_meta_clustering_key_count(
     table_meta: *const CassTableMeta,
 ) -> size_t {
-    let table_meta = ptr_to_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta);
     table_meta.clustering_keys.len() as size_t
 }
 
@@ -265,7 +281,7 @@ pub unsafe extern "C" fn cass_table_meta_column_by_name_n(
         return std::ptr::null();
     }
 
-    let table_meta = ptr_to_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta);
     let column_name = ptr_to_cstr_n(column, column_length).unwrap();
 
     match table_meta.columns_metadata.get(column_name) {
@@ -280,7 +296,7 @@ pub unsafe extern "C" fn cass_column_meta_name(
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) {
-    let column_meta = ptr_to_ref(column_meta);
+    let column_meta = RefFFI::as_ref(column_meta);
     write_str_to_c(column_meta.name.as_str(), name, name_length)
 }
 
@@ -288,7 +304,7 @@ pub unsafe extern "C" fn cass_column_meta_name(
 pub unsafe extern "C" fn cass_column_meta_data_type(
     column_meta: *const CassColumnMeta,
 ) -> *const CassDataType {
-    let column_meta = ptr_to_ref(column_meta);
+    let column_meta = RefFFI::as_ref(column_meta);
     &column_meta.column_type as *const CassDataType
 }
 
@@ -296,7 +312,7 @@ pub unsafe extern "C" fn cass_column_meta_data_type(
 pub unsafe extern "C" fn cass_column_meta_type(
     column_meta: *const CassColumnMeta,
 ) -> CassColumnType {
-    let column_meta = ptr_to_ref(column_meta);
+    let column_meta = RefFFI::as_ref(column_meta);
     column_meta.column_kind
 }
 
@@ -318,11 +334,11 @@ pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name_n(
         return std::ptr::null();
     }
 
-    let keyspace_meta = ptr_to_ref(keyspace_meta);
+    let keyspace_meta = RefFFI::as_ref(keyspace_meta);
     let view_name = ptr_to_cstr_n(view, view_length).unwrap();
 
     match keyspace_meta.views.get(view_name) {
-        Some(view_meta) => Arc::as_ptr(view_meta),
+        Some(view_meta) => RefFFI::as_ptr(view_meta.as_ref()),
         None => std::ptr::null(),
     }
 }
@@ -345,11 +361,11 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name_n(
         return std::ptr::null();
     }
 
-    let table_meta = ptr_to_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta);
     let view_name = ptr_to_cstr_n(view, view_length).unwrap();
 
     match table_meta.views.get(view_name) {
-        Some(view_meta) => Arc::as_ptr(view_meta),
+        Some(view_meta) => RefFFI::as_ptr(view_meta.as_ref()),
         None => std::ptr::null(),
     }
 }
@@ -358,7 +374,7 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name_n(
 pub unsafe extern "C" fn cass_table_meta_materialized_view_count(
     table_meta: *const CassTableMeta,
 ) -> size_t {
-    let table_meta = ptr_to_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta);
     table_meta.views.len() as size_t
 }
 
@@ -367,10 +383,10 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view(
     table_meta: *const CassTableMeta,
     index: size_t,
 ) -> *const CassMaterializedViewMeta {
-    let table_meta = ptr_to_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta);
 
     match table_meta.views.iter().nth(index as usize) {
-        Some(view_meta) => Arc::as_ptr(view_meta.1),
+        Some(view_meta) => RefFFI::as_ptr(view_meta.1.as_ref()),
         None => std::ptr::null(),
     }
 }
@@ -393,7 +409,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name_n(
         return std::ptr::null();
     }
 
-    let view_meta = ptr_to_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta);
     let column_name = ptr_to_cstr_n(column, column_length).unwrap();
 
     match view_meta.view_metadata.columns_metadata.get(column_name) {
@@ -408,7 +424,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_name(
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) {
-    let view_meta = ptr_to_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta);
     write_str_to_c(view_meta.name.as_str(), name, name_length)
 }
 
@@ -416,7 +432,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_name(
 pub unsafe extern "C" fn cass_materialized_view_meta_base_table(
     view_meta: *const CassMaterializedViewMeta,
 ) -> *const CassTableMeta {
-    let view_meta = ptr_to_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta);
     view_meta.base_table.as_ptr()
 }
 
@@ -424,7 +440,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_base_table(
 pub unsafe extern "C" fn cass_materialized_view_meta_column_count(
     view_meta: *const CassMaterializedViewMeta,
 ) -> size_t {
-    let view_meta = ptr_to_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta);
     view_meta.view_metadata.columns_metadata.len() as size_t
 }
 
@@ -433,7 +449,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column(
     view_meta: *const CassMaterializedViewMeta,
     index: size_t,
 ) -> *const CassColumnMeta {
-    let view_meta = ptr_to_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta);
 
     match view_meta
         .view_metadata
@@ -450,7 +466,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column(
 pub unsafe extern "C" fn cass_materialized_view_meta_partition_key_count(
     view_meta: *const CassMaterializedViewMeta,
 ) -> size_t {
-    let view_meta = ptr_to_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta);
     view_meta.view_metadata.partition_keys.len() as size_t
 }
 
@@ -458,7 +474,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_partition_key(
     view_meta: *const CassMaterializedViewMeta,
     index: size_t,
 ) -> *const CassColumnMeta {
-    let view_meta = ptr_to_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta);
 
     match view_meta.view_metadata.partition_keys.get(index as usize) {
         Some(column_name) => match view_meta.view_metadata.columns_metadata.get(column_name) {
@@ -473,7 +489,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_partition_key(
 pub unsafe extern "C" fn cass_materialized_view_meta_clustering_key_count(
     view_meta: *const CassMaterializedViewMeta,
 ) -> size_t {
-    let view_meta = ptr_to_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta);
     view_meta.view_metadata.clustering_keys.len() as size_t
 }
 
@@ -481,7 +497,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_clustering_key(
     view_meta: *const CassMaterializedViewMeta,
     index: size_t,
 ) -> *const CassColumnMeta {
-    let view_meta = ptr_to_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta);
 
     match view_meta.view_metadata.clustering_keys.get(index as usize) {
         Some(column_name) => match view_meta.view_metadata.columns_metadata.get(column_name) {

--- a/scylla-rust-wrapper/src/query_error.rs
+++ b/scylla-rust-wrapper/src/query_error.rs
@@ -19,6 +19,8 @@ pub enum CassErrorResult {
     Deserialization(#[from] DeserializationError),
 }
 
+impl ArcFFI for CassErrorResult {}
+
 impl From<Consistency> for CassConsistency {
     fn from(c: Consistency) -> CassConsistency {
         match c {
@@ -55,12 +57,12 @@ impl From<&WriteType> for CassWriteType {
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_free(error_result: *const CassErrorResult) {
-    free_arced(error_result);
+    ArcFFI::free(error_result);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_code(error_result: *const CassErrorResult) -> CassError {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     error_result.to_cass_error()
 }
 
@@ -68,7 +70,7 @@ pub unsafe extern "C" fn cass_error_result_code(error_result: *const CassErrorRe
 pub unsafe extern "C" fn cass_error_result_consistency(
     error_result: *const CassErrorResult,
 ) -> CassConsistency {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(
             DbError::Unavailable { consistency, .. },
@@ -98,7 +100,7 @@ pub unsafe extern "C" fn cass_error_result_consistency(
 pub unsafe extern "C" fn cass_error_result_responses_received(
     error_result: *const CassErrorResult,
 ) -> cass_int32_t {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(DbError::Unavailable { alive, .. }, _)) => {
             *alive
@@ -123,7 +125,7 @@ pub unsafe extern "C" fn cass_error_result_responses_received(
 pub unsafe extern "C" fn cass_error_result_responses_required(
     error_result: *const CassErrorResult,
 ) -> cass_int32_t {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(DbError::Unavailable { required, .. }, _)) => {
             *required
@@ -148,7 +150,7 @@ pub unsafe extern "C" fn cass_error_result_responses_required(
 pub unsafe extern "C" fn cass_error_result_num_failures(
     error_result: *const CassErrorResult,
 ) -> cass_int32_t {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(
             DbError::ReadFailure { numfailures, .. },
@@ -166,7 +168,7 @@ pub unsafe extern "C" fn cass_error_result_num_failures(
 pub unsafe extern "C" fn cass_error_result_data_present(
     error_result: *const CassErrorResult,
 ) -> cass_bool_t {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(
             DbError::ReadTimeout { data_present, .. },
@@ -196,7 +198,7 @@ pub unsafe extern "C" fn cass_error_result_data_present(
 pub unsafe extern "C" fn cass_error_result_write_type(
     error_result: *const CassErrorResult,
 ) -> CassWriteType {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(
             DbError::WriteTimeout { write_type, .. },
@@ -216,7 +218,7 @@ pub unsafe extern "C" fn cass_error_result_keyspace(
     c_keyspace: *mut *const ::std::os::raw::c_char,
     c_keyspace_len: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(DbError::AlreadyExists { keyspace, .. }, _)) => {
             write_str_to_c(keyspace.as_str(), c_keyspace, c_keyspace_len);
@@ -239,7 +241,7 @@ pub unsafe extern "C" fn cass_error_result_table(
     c_table: *mut *const ::std::os::raw::c_char,
     c_table_len: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(DbError::AlreadyExists { table, .. }, _)) => {
             write_str_to_c(table.as_str(), c_table, c_table_len);
@@ -255,7 +257,7 @@ pub unsafe extern "C" fn cass_error_result_function(
     c_function: *mut *const ::std::os::raw::c_char,
     c_function_len: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(
             DbError::FunctionFailure { function, .. },
@@ -270,7 +272,7 @@ pub unsafe extern "C" fn cass_error_result_function(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_num_arg_types(error_result: *const CassErrorResult) -> size_t {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(
             DbError::FunctionFailure { arg_types, .. },
@@ -287,7 +289,7 @@ pub unsafe extern "C" fn cass_error_result_arg_type(
     arg_type: *mut *const ::std::os::raw::c_char,
     arg_type_length: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ptr_to_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
     match error_result {
         CassErrorResult::Query(QueryError::DbError(
             DbError::FunctionFailure { arg_types, .. },

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -95,6 +95,8 @@ impl CassResult {
     }
 }
 
+impl ArcFFI for CassResult {}
+
 #[derive(Debug)]
 pub struct CassResultMetadata {
     pub col_specs: Vec<CassColumnSpec>,
@@ -147,6 +149,8 @@ pub struct CassRow {
     pub result_metadata: Arc<CassResultMetadata>,
 }
 
+impl RefFFI for CassRow {}
+
 pub fn create_cass_rows_from_rows(
     rows: Vec<Row>,
     metadata: &Arc<CassResultMetadata>,
@@ -180,6 +184,8 @@ pub struct CassValue {
     pub value: Option<Value>,
     pub value_type: Arc<CassDataType>,
 }
+
+impl RefFFI for CassValue {}
 
 fn create_cass_row_columns(row: Row, metadata: &Arc<CassResultMetadata>) -> Vec<CassValue> {
     row.columns
@@ -361,15 +367,17 @@ pub enum CassIterator {
     CassViewMetaIterator(CassViewMetaIterator),
 }
 
+impl BoxFFI for CassIterator {}
+
 #[no_mangle]
 pub unsafe extern "C" fn cass_iterator_free(iterator: *mut CassIterator) {
-    free_boxed(iterator);
+    BoxFFI::free(iterator);
 }
 
 // After creating an iterator we have to call next() before accessing the value
 #[no_mangle]
 pub unsafe extern "C" fn cass_iterator_next(iterator: *mut CassIterator) -> cass_bool_t {
-    let mut iter = ptr_to_ref_mut(iterator);
+    let mut iter = BoxFFI::as_mut_ref(iterator);
 
     match &mut iter {
         CassIterator::CassResultIterator(result_iterator) => {
@@ -469,7 +477,7 @@ pub unsafe extern "C" fn cass_iterator_next(iterator: *mut CassIterator) -> cass
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_iterator_get_row(iterator: *const CassIterator) -> *const CassRow {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     // Defined only for result iterator, for other types should return null
     if let CassIterator::CassResultIterator(result_iterator) = iter {
@@ -497,7 +505,7 @@ pub unsafe extern "C" fn cass_iterator_get_row(iterator: *const CassIterator) ->
 pub unsafe extern "C" fn cass_iterator_get_column(
     iterator: *const CassIterator,
 ) -> *const CassValue {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     // Defined only for row iterator, for other types should return null
     if let CassIterator::CassRowIterator(row_iterator) = iter {
@@ -521,7 +529,7 @@ pub unsafe extern "C" fn cass_iterator_get_column(
 pub unsafe extern "C" fn cass_iterator_get_value(
     iterator: *const CassIterator,
 ) -> *const CassValue {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     // Defined only for collections(list, set and map) or tuple iterator, for other types should return null
     if let CassIterator::CassCollectionIterator(collection_iterator) = iter {
@@ -558,7 +566,7 @@ pub unsafe extern "C" fn cass_iterator_get_value(
 pub unsafe extern "C" fn cass_iterator_get_map_key(
     iterator: *const CassIterator,
 ) -> *const CassValue {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     if let CassIterator::CassMapIterator(map_iterator) = iter {
         let iter_position = match map_iterator.position {
@@ -585,7 +593,7 @@ pub unsafe extern "C" fn cass_iterator_get_map_key(
 pub unsafe extern "C" fn cass_iterator_get_map_value(
     iterator: *const CassIterator,
 ) -> *const CassValue {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     if let CassIterator::CassMapIterator(map_iterator) = iter {
         let iter_position = match map_iterator.position {
@@ -614,7 +622,7 @@ pub unsafe extern "C" fn cass_iterator_get_user_type_field_name(
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) -> CassError {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     if let CassIterator::CassUdtIterator(udt_iterator) = iter {
         let iter_position = match udt_iterator.position {
@@ -647,7 +655,7 @@ pub unsafe extern "C" fn cass_iterator_get_user_type_field_name(
 pub unsafe extern "C" fn cass_iterator_get_user_type_field_value(
     iterator: *const CassIterator,
 ) -> *const CassValue {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     if let CassIterator::CassUdtIterator(udt_iterator) = iter {
         let iter_position = match udt_iterator.position {
@@ -678,7 +686,7 @@ pub unsafe extern "C" fn cass_iterator_get_user_type_field_value(
 pub unsafe extern "C" fn cass_iterator_get_keyspace_meta(
     iterator: *const CassIterator,
 ) -> *const CassKeyspaceMeta {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     if let CassIterator::CassSchemaMetaIterator(schema_meta_iterator) = iter {
         let iter_position = match schema_meta_iterator.position {
@@ -705,7 +713,7 @@ pub unsafe extern "C" fn cass_iterator_get_keyspace_meta(
 pub unsafe extern "C" fn cass_iterator_get_table_meta(
     iterator: *const CassIterator,
 ) -> *const CassTableMeta {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     if let CassIterator::CassKeyspaceMetaTableIterator(keyspace_meta_iterator) = iter {
         let iter_position = match keyspace_meta_iterator.position {
@@ -720,7 +728,7 @@ pub unsafe extern "C" fn cass_iterator_get_table_meta(
             .nth(iter_position);
 
         return match table_meta_entry_opt {
-            Some(table_meta_entry) => Arc::as_ptr(table_meta_entry.1),
+            Some(table_meta_entry) => RefFFI::as_ptr(table_meta_entry.1.as_ref()),
             None => std::ptr::null(),
         };
     }
@@ -732,7 +740,7 @@ pub unsafe extern "C" fn cass_iterator_get_table_meta(
 pub unsafe extern "C" fn cass_iterator_get_user_type(
     iterator: *const CassIterator,
 ) -> *const CassDataType {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     if let CassIterator::CassKeyspaceMetaUserTypeIterator(keyspace_meta_iterator) = iter {
         let iter_position = match keyspace_meta_iterator.position {
@@ -747,7 +755,7 @@ pub unsafe extern "C" fn cass_iterator_get_user_type(
             .nth(iter_position);
 
         return match udt_to_type_entry_opt {
-            Some(udt_to_type_entry) => Arc::as_ptr(udt_to_type_entry.1),
+            Some(udt_to_type_entry) => ArcFFI::as_ptr(udt_to_type_entry.1),
             None => std::ptr::null(),
         };
     }
@@ -759,7 +767,7 @@ pub unsafe extern "C" fn cass_iterator_get_user_type(
 pub unsafe extern "C" fn cass_iterator_get_column_meta(
     iterator: *const CassIterator,
 ) -> *const CassColumnMeta {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     match iter {
         CassIterator::CassTableMetaIterator(table_meta_iterator) => {
@@ -805,7 +813,7 @@ pub unsafe extern "C" fn cass_iterator_get_column_meta(
 pub unsafe extern "C" fn cass_iterator_get_materialized_view_meta(
     iterator: *const CassIterator,
 ) -> *const CassMaterializedViewMeta {
-    let iter = ptr_to_ref(iterator);
+    let iter = BoxFFI::as_ref(iterator);
 
     match iter {
         CassIterator::CassKeyspaceMetaViewIterator(keyspace_meta_iterator) => {
@@ -817,7 +825,7 @@ pub unsafe extern "C" fn cass_iterator_get_materialized_view_meta(
             let view_meta_entry_opt = keyspace_meta_iterator.value.views.iter().nth(iter_position);
 
             match view_meta_entry_opt {
-                Some(view_meta_entry) => Arc::as_ptr(view_meta_entry.1),
+                Some(view_meta_entry) => RefFFI::as_ptr(view_meta_entry.1.as_ref()),
                 None => std::ptr::null(),
             }
         }
@@ -830,7 +838,7 @@ pub unsafe extern "C" fn cass_iterator_get_materialized_view_meta(
             let view_meta_entry_opt = table_meta_iterator.value.views.iter().nth(iter_position);
 
             match view_meta_entry_opt {
-                Some(view_meta_entry) => Arc::as_ptr(view_meta_entry.1),
+                Some(view_meta_entry) => RefFFI::as_ptr(view_meta_entry.1.as_ref()),
                 None => std::ptr::null(),
             }
         }
@@ -840,26 +848,26 @@ pub unsafe extern "C" fn cass_iterator_get_materialized_view_meta(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_iterator_from_result(result: *const CassResult) -> *mut CassIterator {
-    let result_from_raw = clone_arced(result);
+    let result_from_raw = ArcFFI::cloned_from_ptr(result);
 
     let iterator = CassResultIterator {
         result: result_from_raw,
         position: None,
     };
 
-    Box::into_raw(Box::new(CassIterator::CassResultIterator(iterator)))
+    BoxFFI::into_ptr(Box::new(CassIterator::CassResultIterator(iterator)))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_iterator_from_row(row: *const CassRow) -> *mut CassIterator {
-    let row_from_raw = ptr_to_ref(row);
+    let row_from_raw = RefFFI::as_ref(row);
 
     let iterator = CassRowIterator {
         row: row_from_raw,
         position: None,
     };
 
-    Box::into_raw(Box::new(CassIterator::CassRowIterator(iterator)))
+    BoxFFI::into_ptr(Box::new(CassIterator::CassRowIterator(iterator)))
 }
 
 #[no_mangle]
@@ -872,7 +880,7 @@ pub unsafe extern "C" fn cass_iterator_from_collection(
         return std::ptr::null_mut();
     }
 
-    let val = ptr_to_ref(value);
+    let val = RefFFI::as_ref(value);
     let item_count = cass_value_item_count(value);
     let item_count = match cass_value_type(value) {
         CassValueType::CASS_VALUE_TYPE_MAP => item_count * 2,
@@ -885,12 +893,12 @@ pub unsafe extern "C" fn cass_iterator_from_collection(
         position: None,
     };
 
-    Box::into_raw(Box::new(CassIterator::CassCollectionIterator(iterator)))
+    BoxFFI::into_ptr(Box::new(CassIterator::CassCollectionIterator(iterator)))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_iterator_from_tuple(value: *const CassValue) -> *mut CassIterator {
-    let tuple = ptr_to_ref(value);
+    let tuple = RefFFI::as_ref(value);
 
     if let Some(Value::CollectionValue(Collection::Tuple(val))) = &tuple.value {
         let item_count = val.len();
@@ -900,7 +908,7 @@ pub unsafe extern "C" fn cass_iterator_from_tuple(value: *const CassValue) -> *m
             position: None,
         };
 
-        return Box::into_raw(Box::new(CassIterator::CassCollectionIterator(iterator)));
+        return BoxFFI::into_ptr(Box::new(CassIterator::CassCollectionIterator(iterator)));
     }
 
     std::ptr::null_mut()
@@ -908,7 +916,7 @@ pub unsafe extern "C" fn cass_iterator_from_tuple(value: *const CassValue) -> *m
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_iterator_from_map(value: *const CassValue) -> *mut CassIterator {
-    let map = ptr_to_ref(value);
+    let map = RefFFI::as_ref(value);
 
     if let Some(Value::CollectionValue(Collection::Map(val))) = &map.value {
         let item_count = val.len();
@@ -918,7 +926,7 @@ pub unsafe extern "C" fn cass_iterator_from_map(value: *const CassValue) -> *mut
             position: None,
         };
 
-        return Box::into_raw(Box::new(CassIterator::CassMapIterator(iterator)));
+        return BoxFFI::into_ptr(Box::new(CassIterator::CassMapIterator(iterator)));
     }
 
     std::ptr::null_mut()
@@ -928,7 +936,7 @@ pub unsafe extern "C" fn cass_iterator_from_map(value: *const CassValue) -> *mut
 pub unsafe extern "C" fn cass_iterator_fields_from_user_type(
     value: *const CassValue,
 ) -> *mut CassIterator {
-    let udt = ptr_to_ref(value);
+    let udt = RefFFI::as_ref(value);
 
     if let Some(Value::CollectionValue(Collection::UserDefinedType { fields, .. })) = &udt.value {
         let item_count = fields.len();
@@ -938,7 +946,7 @@ pub unsafe extern "C" fn cass_iterator_fields_from_user_type(
             position: None,
         };
 
-        return Box::into_raw(Box::new(CassIterator::CassUdtIterator(iterator)));
+        return BoxFFI::into_ptr(Box::new(CassIterator::CassUdtIterator(iterator)));
     }
 
     std::ptr::null_mut()
@@ -948,7 +956,7 @@ pub unsafe extern "C" fn cass_iterator_fields_from_user_type(
 pub unsafe extern "C" fn cass_iterator_keyspaces_from_schema_meta(
     schema_meta: *const CassSchemaMeta,
 ) -> *mut CassIterator {
-    let metadata = ptr_to_ref(schema_meta);
+    let metadata = BoxFFI::as_ref(schema_meta);
 
     let iterator = CassSchemaMetaIterator {
         value: metadata,
@@ -956,14 +964,14 @@ pub unsafe extern "C" fn cass_iterator_keyspaces_from_schema_meta(
         position: None,
     };
 
-    Box::into_raw(Box::new(CassIterator::CassSchemaMetaIterator(iterator)))
+    BoxFFI::into_ptr(Box::new(CassIterator::CassSchemaMetaIterator(iterator)))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_iterator_tables_from_keyspace_meta(
     keyspace_meta: *const CassKeyspaceMeta,
 ) -> *mut CassIterator {
-    let metadata = ptr_to_ref(keyspace_meta);
+    let metadata = RefFFI::as_ref(keyspace_meta);
 
     let iterator = CassKeyspaceMetaIterator {
         value: metadata,
@@ -971,7 +979,7 @@ pub unsafe extern "C" fn cass_iterator_tables_from_keyspace_meta(
         position: None,
     };
 
-    Box::into_raw(Box::new(CassIterator::CassKeyspaceMetaTableIterator(
+    BoxFFI::into_ptr(Box::new(CassIterator::CassKeyspaceMetaTableIterator(
         iterator,
     )))
 }
@@ -980,7 +988,7 @@ pub unsafe extern "C" fn cass_iterator_tables_from_keyspace_meta(
 pub unsafe extern "C" fn cass_iterator_materialized_views_from_keyspace_meta(
     keyspace_meta: *const CassKeyspaceMeta,
 ) -> *mut CassIterator {
-    let metadata = ptr_to_ref(keyspace_meta);
+    let metadata = RefFFI::as_ref(keyspace_meta);
 
     let iterator = CassKeyspaceMetaIterator {
         value: metadata,
@@ -988,7 +996,7 @@ pub unsafe extern "C" fn cass_iterator_materialized_views_from_keyspace_meta(
         position: None,
     };
 
-    Box::into_raw(Box::new(CassIterator::CassKeyspaceMetaViewIterator(
+    BoxFFI::into_ptr(Box::new(CassIterator::CassKeyspaceMetaViewIterator(
         iterator,
     )))
 }
@@ -997,7 +1005,7 @@ pub unsafe extern "C" fn cass_iterator_materialized_views_from_keyspace_meta(
 pub unsafe extern "C" fn cass_iterator_user_types_from_keyspace_meta(
     keyspace_meta: *const CassKeyspaceMeta,
 ) -> *mut CassIterator {
-    let metadata = ptr_to_ref(keyspace_meta);
+    let metadata = RefFFI::as_ref(keyspace_meta);
 
     let iterator = CassKeyspaceMetaIterator {
         value: metadata,
@@ -1005,7 +1013,7 @@ pub unsafe extern "C" fn cass_iterator_user_types_from_keyspace_meta(
         position: None,
     };
 
-    Box::into_raw(Box::new(CassIterator::CassKeyspaceMetaUserTypeIterator(
+    BoxFFI::into_ptr(Box::new(CassIterator::CassKeyspaceMetaUserTypeIterator(
         iterator,
     )))
 }
@@ -1014,7 +1022,7 @@ pub unsafe extern "C" fn cass_iterator_user_types_from_keyspace_meta(
 pub unsafe extern "C" fn cass_iterator_columns_from_table_meta(
     table_meta: *const CassTableMeta,
 ) -> *mut CassIterator {
-    let metadata = ptr_to_ref(table_meta);
+    let metadata = RefFFI::as_ref(table_meta);
 
     let iterator = CassTableMetaIterator {
         value: metadata,
@@ -1022,13 +1030,13 @@ pub unsafe extern "C" fn cass_iterator_columns_from_table_meta(
         position: None,
     };
 
-    Box::into_raw(Box::new(CassIterator::CassTableMetaIterator(iterator)))
+    BoxFFI::into_ptr(Box::new(CassIterator::CassTableMetaIterator(iterator)))
 }
 
 pub unsafe extern "C" fn cass_iterator_materialized_views_from_table_meta(
     table_meta: *const CassTableMeta,
 ) -> *mut CassIterator {
-    let metadata = ptr_to_ref(table_meta);
+    let metadata = RefFFI::as_ref(table_meta);
 
     let iterator = CassTableMetaIterator {
         value: metadata,
@@ -1036,13 +1044,13 @@ pub unsafe extern "C" fn cass_iterator_materialized_views_from_table_meta(
         position: None,
     };
 
-    Box::into_raw(Box::new(CassIterator::CassTableMetaIterator(iterator)))
+    BoxFFI::into_ptr(Box::new(CassIterator::CassTableMetaIterator(iterator)))
 }
 
 pub unsafe extern "C" fn cass_iterator_columns_from_materialized_view_meta(
     view_meta: *const CassMaterializedViewMeta,
 ) -> *mut CassIterator {
-    let metadata = ptr_to_ref(view_meta);
+    let metadata = RefFFI::as_ref(view_meta);
 
     let iterator = CassViewMetaIterator {
         value: metadata,
@@ -1050,17 +1058,17 @@ pub unsafe extern "C" fn cass_iterator_columns_from_materialized_view_meta(
         position: None,
     };
 
-    Box::into_raw(Box::new(CassIterator::CassViewMetaIterator(iterator)))
+    BoxFFI::into_ptr(Box::new(CassIterator::CassViewMetaIterator(iterator)))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_result_free(result_raw: *const CassResult) {
-    free_arced(result_raw);
+    ArcFFI::free(result_raw);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_result_has_more_pages(result: *const CassResult) -> cass_bool_t {
-    let result = ptr_to_ref(result);
+    let result = ArcFFI::as_ref(result);
     (!result.paging_state_response.finished()) as cass_bool_t
 }
 
@@ -1069,7 +1077,7 @@ pub unsafe extern "C" fn cass_row_get_column(
     row_raw: *const CassRow,
     index: size_t,
 ) -> *const CassValue {
-    let row: &CassRow = ptr_to_ref(row_raw);
+    let row: &CassRow = RefFFI::as_ref(row_raw);
 
     let index_usize: usize = index.try_into().unwrap();
     let column_value = match row.columns.get(index_usize) {
@@ -1097,7 +1105,7 @@ pub unsafe extern "C" fn cass_row_get_column_by_name_n(
     name: *const c_char,
     name_length: size_t,
 ) -> *const CassValue {
-    let row_from_raw = ptr_to_ref(row);
+    let row_from_raw = RefFFI::as_ref(row);
     let mut name_str = ptr_to_cstr_n(name, name_length).unwrap();
     let mut is_case_sensitive = false;
 
@@ -1130,7 +1138,7 @@ pub unsafe extern "C" fn cass_result_column_name(
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) -> CassError {
-    let result_from_raw = ptr_to_ref(result);
+    let result_from_raw = ArcFFI::as_ref(result);
     let index_usize: usize = index.try_into().unwrap();
 
     let CassResultKind::Rows(CassRowsResult { metadata, .. }) = &result_from_raw.kind else {
@@ -1165,7 +1173,7 @@ pub unsafe extern "C" fn cass_result_column_data_type(
     result: *const CassResult,
     index: size_t,
 ) -> *const CassDataType {
-    let result_from_raw: &CassResult = ptr_to_ref(result);
+    let result_from_raw: &CassResult = ArcFFI::as_ref(result);
     let index_usize: usize = index
         .try_into()
         .expect("Provided index is out of bounds. Max possible value is usize::MAX");
@@ -1177,22 +1185,22 @@ pub unsafe extern "C" fn cass_result_column_data_type(
     metadata
         .col_specs
         .get(index_usize)
-        .map(|col_spec| Arc::as_ptr(&col_spec.data_type))
+        .map(|col_spec| ArcFFI::as_ptr(&col_spec.data_type))
         .unwrap_or(std::ptr::null())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_value_type(value: *const CassValue) -> CassValueType {
-    let value_from_raw = ptr_to_ref(value);
+    let value_from_raw = RefFFI::as_ref(value);
 
-    cass_data_type_type(Arc::as_ptr(&value_from_raw.value_type))
+    cass_data_type_type(ArcFFI::as_ptr(&value_from_raw.value_type))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_value_data_type(value: *const CassValue) -> *const CassDataType {
-    let value_from_raw = ptr_to_ref(value);
+    let value_from_raw = RefFFI::as_ref(value);
 
-    Arc::as_ptr(&value_from_raw.value_type)
+    ArcFFI::as_ptr(&value_from_raw.value_type)
 }
 
 macro_rules! val_ptr_to_ref_ensure_non_null {
@@ -1200,7 +1208,7 @@ macro_rules! val_ptr_to_ref_ensure_non_null {
         if $ptr.is_null() {
             return CassError::CASS_ERROR_LIB_NULL_VALUE;
         }
-        ptr_to_ref($ptr)
+        RefFFI::as_ref($ptr)
     }};
 }
 
@@ -1373,7 +1381,7 @@ pub unsafe extern "C" fn cass_value_get_decimal(
     varint_size: *mut size_t,
     scale: *mut cass_int32_t,
 ) -> CassError {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = RefFFI::as_ref(value);
     let decimal = match &val.value {
         Some(Value::RegularValue(CqlValue::Decimal(decimal))) => decimal,
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -1464,13 +1472,13 @@ pub unsafe extern "C" fn cass_value_get_bytes(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_value_is_null(value: *const CassValue) -> cass_bool_t {
-    let val: &CassValue = ptr_to_ref(value);
+    let val: &CassValue = RefFFI::as_ref(value);
     val.value.is_none() as cass_bool_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_value_is_collection(value: *const CassValue) -> cass_bool_t {
-    let val = ptr_to_ref(value);
+    let val = RefFFI::as_ref(value);
 
     matches!(
         val.value_type.get_unchecked().get_value_type(),
@@ -1482,7 +1490,7 @@ pub unsafe extern "C" fn cass_value_is_collection(value: *const CassValue) -> ca
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_value_is_duration(value: *const CassValue) -> cass_bool_t {
-    let val = ptr_to_ref(value);
+    let val = RefFFI::as_ref(value);
 
     (val.value_type.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_DURATION)
         as cass_bool_t
@@ -1490,7 +1498,7 @@ pub unsafe extern "C" fn cass_value_is_duration(value: *const CassValue) -> cass
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_value_item_count(collection: *const CassValue) -> size_t {
-    let val = ptr_to_ref(collection);
+    let val = RefFFI::as_ref(collection);
 
     match &val.value {
         Some(Value::CollectionValue(Collection::List(list))) => list.len() as size_t,
@@ -1508,7 +1516,7 @@ pub unsafe extern "C" fn cass_value_item_count(collection: *const CassValue) -> 
 pub unsafe extern "C" fn cass_value_primary_sub_type(
     collection: *const CassValue,
 ) -> CassValueType {
-    let val = ptr_to_ref(collection);
+    let val = RefFFI::as_ref(collection);
 
     match val.value_type.get_unchecked() {
         CassDataTypeInner::List {
@@ -1527,7 +1535,7 @@ pub unsafe extern "C" fn cass_value_primary_sub_type(
 pub unsafe extern "C" fn cass_value_secondary_sub_type(
     collection: *const CassValue,
 ) -> CassValueType {
-    let val = ptr_to_ref(collection);
+    let val = RefFFI::as_ref(collection);
 
     match val.value_type.get_unchecked() {
         CassDataTypeInner::Map {
@@ -1540,7 +1548,7 @@ pub unsafe extern "C" fn cass_value_secondary_sub_type(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_result_row_count(result_raw: *const CassResult) -> size_t {
-    let result = ptr_to_ref(result_raw);
+    let result = ArcFFI::as_ref(result_raw);
 
     let CassResultKind::Rows(CassRowsResult { rows, .. }) = &result.kind else {
         return 0;
@@ -1551,7 +1559,7 @@ pub unsafe extern "C" fn cass_result_row_count(result_raw: *const CassResult) ->
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_result_column_count(result_raw: *const CassResult) -> size_t {
-    let result = ptr_to_ref(result_raw);
+    let result = ArcFFI::as_ref(result_raw);
 
     let CassResultKind::Rows(CassRowsResult { metadata, .. }) = &result.kind else {
         return 0;
@@ -1562,7 +1570,7 @@ pub unsafe extern "C" fn cass_result_column_count(result_raw: *const CassResult)
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_result_first_row(result_raw: *const CassResult) -> *const CassRow {
-    let result = ptr_to_ref(result_raw);
+    let result = ArcFFI::as_ref(result_raw);
 
     let CassResultKind::Rows(CassRowsResult { rows, .. }) = &result.kind else {
         return std::ptr::null();
@@ -1583,7 +1591,7 @@ pub unsafe extern "C" fn cass_result_paging_state_token(
         return CassError::CASS_ERROR_LIB_NO_PAGING_STATE;
     }
 
-    let result_from_raw = ptr_to_ref(result);
+    let result_from_raw = ArcFFI::as_ref(result);
 
     match &result_from_raw.paging_state_response {
         PagingStateResponse::HasMorePages { state } => match state.as_bytes_slice() {
@@ -1615,11 +1623,12 @@ mod tests {
     };
 
     use crate::{
+        argconv::ArcFFI,
         cass_error::CassError,
         cass_types::{CassDataType, CassDataTypeInner, CassValueType},
         query_result::{
             cass_result_column_data_type, cass_result_column_name, cass_result_first_row,
-            ptr_to_cstr_n, ptr_to_ref, size_t,
+            ptr_to_cstr_n, size_t,
         },
     };
 
@@ -1723,21 +1732,24 @@ mod tests {
 
             // cass_result_column_data_type test
             {
-                let first_col_data_type = ptr_to_ref(cass_result_column_data_type(result_ptr, 0));
+                let first_col_data_type =
+                    ArcFFI::as_ref(cass_result_column_data_type(result_ptr, 0));
                 assert_eq!(
                     &CassDataType::new(CassDataTypeInner::Value(
                         CassValueType::CASS_VALUE_TYPE_BIGINT
                     )),
                     first_col_data_type
                 );
-                let second_col_data_type = ptr_to_ref(cass_result_column_data_type(result_ptr, 1));
+                let second_col_data_type =
+                    ArcFFI::as_ref(cass_result_column_data_type(result_ptr, 1));
                 assert_eq!(
                     &CassDataType::new(CassDataTypeInner::Value(
                         CassValueType::CASS_VALUE_TYPE_VARINT
                     )),
                     second_col_data_type
                 );
-                let third_col_data_type = ptr_to_ref(cass_result_column_data_type(result_ptr, 2));
+                let third_col_data_type =
+                    ArcFFI::as_ref(cass_result_column_data_type(result_ptr, 2));
                 assert_eq!(
                     &CassDataType::new(CassDataTypeInner::List {
                         typ: Some(CassDataType::new_arced(CassDataTypeInner::Value(

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -1,7 +1,8 @@
-use crate::argconv::free_boxed;
 use scylla::retry_policy::{DefaultRetryPolicy, FallthroughRetryPolicy};
 use scylla::transport::downgrading_consistency_retry_policy::DowngradingConsistencyRetryPolicy;
 use std::sync::Arc;
+
+use crate::argconv::ArcFFI;
 
 pub enum RetryPolicy {
     DefaultRetryPolicy(Arc<DefaultRetryPolicy>),
@@ -11,28 +12,30 @@ pub enum RetryPolicy {
 
 pub type CassRetryPolicy = RetryPolicy;
 
+impl ArcFFI for CassRetryPolicy {}
+
 #[no_mangle]
 pub extern "C" fn cass_retry_policy_default_new() -> *const CassRetryPolicy {
-    Box::into_raw(Box::new(RetryPolicy::DefaultRetryPolicy(Arc::new(
+    ArcFFI::into_ptr(Arc::new(RetryPolicy::DefaultRetryPolicy(Arc::new(
         DefaultRetryPolicy,
     ))))
 }
 
 #[no_mangle]
 pub extern "C" fn cass_retry_policy_downgrading_consistency_new() -> *const CassRetryPolicy {
-    Box::into_raw(Box::new(RetryPolicy::DowngradingConsistencyRetryPolicy(
+    ArcFFI::into_ptr(Arc::new(RetryPolicy::DowngradingConsistencyRetryPolicy(
         Arc::new(DowngradingConsistencyRetryPolicy),
     )))
 }
 
 #[no_mangle]
 pub extern "C" fn cass_retry_policy_fallthrough_new() -> *const CassRetryPolicy {
-    Box::into_raw(Box::new(RetryPolicy::FallthroughRetryPolicy(Arc::new(
+    ArcFFI::into_ptr(Arc::new(RetryPolicy::FallthroughRetryPolicy(Arc::new(
         FallthroughRetryPolicy,
     ))))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_retry_policy_free(retry_policy: *mut CassRetryPolicy) {
-    free_boxed(retry_policy);
+pub unsafe extern "C" fn cass_retry_policy_free(retry_policy: *const CassRetryPolicy) {
+    ArcFFI::free(retry_policy);
 }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -139,10 +139,12 @@ impl CassSessionInner {
 
 pub type CassSession = RwLock<Option<CassSessionInner>>;
 
+impl ArcFFI for CassSession {}
+
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_new() -> *mut CassSession {
     let session = Arc::new(RwLock::new(None::<CassSessionInner>));
-    Arc::into_raw(session) as *mut CassSession
+    ArcFFI::into_ptr(session) as *mut CassSession
 }
 
 #[no_mangle]
@@ -150,8 +152,8 @@ pub unsafe extern "C" fn cass_session_connect(
     session_raw: *mut CassSession,
     cluster_raw: *const CassCluster,
 ) -> *const CassFuture {
-    let session_opt = ptr_to_ref(session_raw);
-    let cluster: &CassCluster = ptr_to_ref(cluster_raw);
+    let session_opt = ArcFFI::as_ref(session_raw);
+    let cluster: &CassCluster = BoxFFI::as_ref(cluster_raw);
 
     CassSessionInner::connect(session_opt, cluster, None)
 }
@@ -172,8 +174,8 @@ pub unsafe extern "C" fn cass_session_connect_keyspace_n(
     keyspace: *const c_char,
     keyspace_length: size_t,
 ) -> *const CassFuture {
-    let session_opt = ptr_to_ref(session_raw);
-    let cluster: &CassCluster = ptr_to_ref(cluster_raw);
+    let session_opt = ArcFFI::as_ref(session_raw);
+    let cluster: &CassCluster = BoxFFI::as_ref(cluster_raw);
     let keyspace = ptr_to_cstr_n(keyspace, keyspace_length).map(ToOwned::to_owned);
 
     CassSessionInner::connect(session_opt, cluster, keyspace)
@@ -184,8 +186,8 @@ pub unsafe extern "C" fn cass_session_execute_batch(
     session_raw: *mut CassSession,
     batch_raw: *const CassBatch,
 ) -> *const CassFuture {
-    let session_opt = ptr_to_ref(session_raw);
-    let batch_from_raw = ptr_to_ref(batch_raw);
+    let session_opt = ArcFFI::as_ref(session_raw);
+    let batch_from_raw = BoxFFI::as_ref(batch_raw);
     let mut state = batch_from_raw.state.clone();
     let request_timeout_ms = batch_from_raw.batch_request_timeout_ms;
 
@@ -250,10 +252,10 @@ pub unsafe extern "C" fn cass_session_execute(
     session_raw: *mut CassSession,
     statement_raw: *const CassStatement,
 ) -> *const CassFuture {
-    let session_opt = ptr_to_ref(session_raw);
+    let session_opt = ArcFFI::as_ref(session_raw);
 
     // DO NOT refer to `statement_opt` inside the async block, as I've done just to face a segfault.
-    let statement_opt = ptr_to_ref(statement_raw);
+    let statement_opt = BoxFFI::as_ref(statement_raw);
     let paging_state = statement_opt.paging_state.clone();
     let paging_enabled = statement_opt.paging_enabled;
     let bound_values = statement_opt.bound_values.clone();
@@ -377,8 +379,8 @@ pub unsafe extern "C" fn cass_session_prepare_from_existing(
     cass_session: *mut CassSession,
     statement: *const CassStatement,
 ) -> *const CassFuture {
-    let session = ptr_to_ref(cass_session);
-    let cass_statement = ptr_to_ref(statement);
+    let session = ArcFFI::as_ref(cass_session);
+    let cass_statement = BoxFFI::as_ref(statement);
     let statement = cass_statement.statement.clone();
 
     CassFuture::make_raw(async move {
@@ -429,7 +431,7 @@ pub unsafe extern "C" fn cass_session_prepare_n(
         // There is a test for this: `NullStringApiArgsTest.Integration_Cassandra_PrepareNullQuery`.
         .unwrap_or_default();
     let query = Query::new(query_str.to_string());
-    let cass_session: &CassSession = ptr_to_ref(cass_session_raw);
+    let cass_session = ArcFFI::as_ref(cass_session_raw);
 
     CassFuture::make_raw(async move {
         let session_guard = cass_session.read().await;
@@ -457,12 +459,12 @@ pub unsafe extern "C" fn cass_session_prepare_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_free(session_raw: *mut CassSession) {
-    free_arced(session_raw);
+    ArcFFI::free(session_raw);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_close(session: *mut CassSession) -> *const CassFuture {
-    let session_opt = ptr_to_ref(session);
+    let session_opt = ArcFFI::as_ref(session);
 
     CassFuture::make_raw(async move {
         let mut session_guard = session_opt.write().await;
@@ -481,7 +483,7 @@ pub unsafe extern "C" fn cass_session_close(session: *mut CassSession) -> *const
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_get_client_id(session: *const CassSession) -> CassUuid {
-    let cass_session = ptr_to_ref(session);
+    let cass_session = ArcFFI::as_ref(session);
 
     let client_id: uuid::Uuid = cass_session.blocking_read().as_ref().unwrap().client_id;
     client_id.into()
@@ -491,7 +493,7 @@ pub unsafe extern "C" fn cass_session_get_client_id(session: *const CassSession)
 pub unsafe extern "C" fn cass_session_get_schema_meta(
     session: *const CassSession,
 ) -> *const CassSchemaMeta {
-    let cass_session = ptr_to_ref(session);
+    let cass_session = ArcFFI::as_ref(session);
     let mut keyspaces: HashMap<String, CassKeyspaceMeta> = HashMap::new();
 
     for (keyspace_name, keyspace) in cass_session
@@ -565,7 +567,7 @@ pub unsafe extern "C" fn cass_session_get_schema_meta(
         );
     }
 
-    Box::into_raw(Box::new(CassSchemaMeta { keyspaces }))
+    BoxFFI::into_ptr(Box::new(CassSchemaMeta { keyspaces }))
 }
 
 #[cfg(test)]
@@ -580,7 +582,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        argconv::{make_c_str, ptr_to_ref},
+        argconv::make_c_str,
         batch::{
             cass_batch_add_statement, cass_batch_free, cass_batch_new, cass_batch_set_retry_policy,
         },
@@ -721,7 +723,7 @@ mod tests {
                 cass_future_wait_check_and_free(cass_session_connect(session_raw, cluster_raw));
                 // Initially, the profile map is empty.
 
-                assert!(ptr_to_ref(session_raw)
+                assert!(ArcFFI::as_ref(session_raw)
                     .blocking_read()
                     .as_ref()
                     .unwrap()
@@ -730,7 +732,7 @@ mod tests {
 
                 cass_cluster_set_execution_profile(cluster_raw, make_c_str!("prof"), profile_raw);
                 // Mutations in cluster do not affect the session that was connected before.
-                assert!(ptr_to_ref(session_raw)
+                assert!(ArcFFI::as_ref(session_raw)
                     .blocking_read()
                     .as_ref()
                     .unwrap()
@@ -741,7 +743,7 @@ mod tests {
 
                 // Mutations in cluster are now propagated to the session.
                 cass_future_wait_check_and_free(cass_session_connect(session_raw, cluster_raw));
-                let profile_map_keys = ptr_to_ref(session_raw)
+                let profile_map_keys = ArcFFI::as_ref(session_raw)
                     .blocking_read()
                     .as_ref()
                     .unwrap()
@@ -827,8 +829,8 @@ mod tests {
             cass_future_wait_check_and_free(cass_session_connect(session_raw, cluster_raw));
             {
                 /* Test valid configurations */
-                let statement = ptr_to_ref(statement_raw);
-                let batch = ptr_to_ref(batch_raw);
+                let statement = BoxFFI::as_ref(statement_raw);
+                let batch = BoxFFI::as_ref(batch_raw);
                 {
                     assert!(statement.exec_profile.is_none());
                     assert!(batch.exec_profile.is_none());

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -1,7 +1,7 @@
 use crate::argconv::*;
 use crate::batch::CassBatch;
 use crate::cass_error::*;
-use crate::cass_types::{CassDataType, UDTDataType};
+use crate::cass_types::{CassDataType, CassDataTypeInner, UDTDataType};
 use crate::cluster::build_session_builder;
 use crate::cluster::CassCluster;
 use crate::exec_profile::{CassExecProfile, ExecProfileName, PerStatementExecProfile};
@@ -509,7 +509,7 @@ pub unsafe extern "C" fn cass_session_get_schema_meta(
         for udt_name in keyspace.user_defined_types.keys() {
             user_defined_type_data_type.insert(
                 udt_name.clone(),
-                Arc::new(CassDataType::UDT(UDTDataType::create_with_params(
+                CassDataType::new_arced(CassDataTypeInner::UDT(UDTDataType::create_with_params(
                     &keyspace.user_defined_types,
                     keyspace_name,
                     udt_name,

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -15,6 +15,8 @@ pub struct CassTuple {
     pub items: Vec<Option<CassCqlValue>>,
 }
 
+impl BoxFFI for CassTuple {}
+
 impl CassTuple {
     fn get_types(&self) -> Option<&Vec<Arc<CassDataType>>> {
         match &self.data_type {
@@ -60,7 +62,7 @@ impl From<&CassTuple> for CassCqlValue {
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_tuple_new(item_count: size_t) -> *mut CassTuple {
-    Box::into_raw(Box::new(CassTuple {
+    BoxFFI::into_ptr(Box::new(CassTuple {
         data_type: None,
         items: vec![None; item_count as usize],
     }))
@@ -70,12 +72,12 @@ pub unsafe extern "C" fn cass_tuple_new(item_count: size_t) -> *mut CassTuple {
 unsafe extern "C" fn cass_tuple_new_from_data_type(
     data_type: *const CassDataType,
 ) -> *mut CassTuple {
-    let data_type = clone_arced(data_type);
+    let data_type = ArcFFI::cloned_from_ptr(data_type);
     let item_count = match data_type.get_unchecked() {
         CassDataTypeInner::Tuple(v) => v.len(),
         _ => return std::ptr::null_mut(),
     };
-    Box::into_raw(Box::new(CassTuple {
+    BoxFFI::into_ptr(Box::new(CassTuple {
         data_type: Some(data_type),
         items: vec![None; item_count],
     }))
@@ -83,13 +85,13 @@ unsafe extern "C" fn cass_tuple_new_from_data_type(
 
 #[no_mangle]
 unsafe extern "C" fn cass_tuple_free(tuple: *mut CassTuple) {
-    free_boxed(tuple)
+    BoxFFI::free(tuple);
 }
 
 #[no_mangle]
 unsafe extern "C" fn cass_tuple_data_type(tuple: *const CassTuple) -> *const CassDataType {
-    match &ptr_to_ref(tuple).data_type {
-        Some(t) => Arc::as_ptr(t),
+    match &BoxFFI::as_ref(tuple).data_type {
+        Some(t) => ArcFFI::as_ptr(t),
         None => &UNTYPED_TUPLE_TYPE,
     }
 }

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -1,12 +1,13 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::cass_types::CassDataType;
+use crate::cass_types::CassDataTypeInner;
 use crate::types::*;
 use crate::value;
 use crate::value::CassCqlValue;
 use std::sync::Arc;
 
-static UNTYPED_TUPLE_TYPE: CassDataType = CassDataType::Tuple(Vec::new());
+static UNTYPED_TUPLE_TYPE: CassDataType = CassDataType::new(CassDataTypeInner::Tuple(Vec::new()));
 
 #[derive(Clone)]
 pub struct CassTuple {
@@ -17,8 +18,8 @@ pub struct CassTuple {
 impl CassTuple {
     fn get_types(&self) -> Option<&Vec<Arc<CassDataType>>> {
         match &self.data_type {
-            Some(t) => match &**t {
-                CassDataType::Tuple(v) => Some(v),
+            Some(t) => match unsafe { t.as_ref().get_unchecked() } {
+                CassDataTypeInner::Tuple(v) => Some(v),
                 _ => unreachable!(),
             },
             None => None,
@@ -70,8 +71,8 @@ unsafe extern "C" fn cass_tuple_new_from_data_type(
     data_type: *const CassDataType,
 ) -> *mut CassTuple {
     let data_type = clone_arced(data_type);
-    let item_count = match &*data_type {
-        CassDataType::Tuple(v) => v.len(),
+    let item_count = match data_type.get_unchecked() {
+        CassDataTypeInner::Tuple(v) => v.len(),
         _ => return std::ptr::null_mut(),
     };
     Box::into_raw(Box::new(CassTuple {

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -1,5 +1,5 @@
 use crate::cass_error::CassError;
-use crate::cass_types::CassDataType;
+use crate::cass_types::{CassDataType, CassDataTypeInner};
 use crate::types::*;
 use crate::value::CassCqlValue;
 use crate::{argconv::*, value};
@@ -19,7 +19,9 @@ impl CassUserType {
         if index >= self.field_values.len() {
             return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
         }
-        if !value::is_type_compatible(&value, &self.data_type.get_udt_type().field_types[index].1) {
+        if !value::is_type_compatible(&value, unsafe {
+            &self.data_type.get_unchecked().get_udt_type().field_types[index].1
+        }) {
             return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE;
         }
         self.field_values[index] = value;
@@ -28,9 +30,14 @@ impl CassUserType {
 
     fn set_field_by_name(&mut self, name: &str, value: Option<CassCqlValue>) -> CassError {
         let mut found_field: bool = false;
-        for (index, (field_name, field_type)) in
-            self.data_type.get_udt_type().field_types.iter().enumerate()
-        {
+        for (index, (field_name, field_type)) in unsafe {
+            self.data_type
+                .get_unchecked()
+                .get_udt_type()
+                .field_types
+                .iter()
+                .enumerate()
+        } {
             if *field_name == name {
                 found_field = true;
                 if index >= self.field_values.len() {
@@ -58,7 +65,14 @@ impl From<&CassUserType> for CassCqlValue {
             fields: user_type
                 .field_values
                 .iter()
-                .zip(user_type.data_type.get_udt_type().field_types.iter())
+                .zip(unsafe {
+                    user_type
+                        .data_type
+                        .get_unchecked()
+                        .get_udt_type()
+                        .field_types
+                        .iter()
+                })
                 .map(|(v, (name, _))| (name.clone(), v.clone()))
                 .collect(),
         }
@@ -71,8 +85,8 @@ pub unsafe extern "C" fn cass_user_type_new_from_data_type(
 ) -> *mut CassUserType {
     let data_type = clone_arced(data_type_raw);
 
-    match &*data_type {
-        CassDataType::UDT(udt_data_type) => {
+    match data_type.get_unchecked() {
+        CassDataTypeInner::UDT(udt_data_type) => {
             let field_values = vec![None; udt_data_type.field_types.len()];
             Box::into_raw(Box::new(CassUserType {
                 data_type,

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -31,7 +31,8 @@ use crate::cass_types::{CassDataType, CassValueType};
 ///
 /// There is no such method as `cass_statement_bind_counter`, and so
 /// we need to serialize the counter value using `CassCqlValue::BigInt`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum CassCqlValue {
     TinyInt(i8),
     SmallInt(i16),

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -83,87 +83,103 @@ pub fn is_type_compatible(value: &Option<CassCqlValue>, typ: &CassDataType) -> b
 impl CassCqlValue {
     pub fn is_type_compatible(&self, typ: &CassDataType) -> bool {
         match self {
-            CassCqlValue::TinyInt(_) => {
-                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_TINY_INT
-            }
-            CassCqlValue::SmallInt(_) => {
-                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_SMALL_INT
-            }
-            CassCqlValue::Int(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_INT,
-            CassCqlValue::BigInt(_) => {
+            CassCqlValue::TinyInt(_) => unsafe {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_TINY_INT
+            },
+            CassCqlValue::SmallInt(_) => unsafe {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_SMALL_INT
+            },
+            CassCqlValue::Int(_) => unsafe {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_INT
+            },
+            CassCqlValue::BigInt(_) => unsafe {
                 matches!(
-                    typ.get_value_type(),
+                    typ.get_unchecked().get_value_type(),
                     CassValueType::CASS_VALUE_TYPE_BIGINT
                         | CassValueType::CASS_VALUE_TYPE_COUNTER
                         | CassValueType::CASS_VALUE_TYPE_TIMESTAMP
                         | CassValueType::CASS_VALUE_TYPE_TIME
                 )
-            }
-            CassCqlValue::Float(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_FLOAT,
-            CassCqlValue::Double(_) => {
-                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DOUBLE
-            }
-            CassCqlValue::Boolean(_) => {
-                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_BOOLEAN
-            }
-            CassCqlValue::Text(_) => {
+            },
+            CassCqlValue::Float(_) => unsafe {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_FLOAT
+            },
+            CassCqlValue::Double(_) => unsafe {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_DOUBLE
+            },
+            CassCqlValue::Boolean(_) => unsafe {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_BOOLEAN
+            },
+            CassCqlValue::Text(_) => unsafe {
                 matches!(
-                    typ.get_value_type(),
+                    typ.get_unchecked().get_value_type(),
                     CassValueType::CASS_VALUE_TYPE_TEXT
                         | CassValueType::CASS_VALUE_TYPE_VARCHAR
                         | CassValueType::CASS_VALUE_TYPE_ASCII
                         | CassValueType::CASS_VALUE_TYPE_BLOB
                         | CassValueType::CASS_VALUE_TYPE_VARINT
                 )
-            }
-            CassCqlValue::Blob(_) => matches!(
-                typ.get_value_type(),
-                CassValueType::CASS_VALUE_TYPE_BLOB | CassValueType::CASS_VALUE_TYPE_VARINT
-            ),
-            CassCqlValue::Uuid(_) => matches!(
-                typ.get_value_type(),
-                CassValueType::CASS_VALUE_TYPE_UUID | CassValueType::CASS_VALUE_TYPE_TIMEUUID
-            ),
-            CassCqlValue::Date(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DATE,
-            CassCqlValue::Inet(_) => typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_INET,
-            CassCqlValue::Duration(_) => {
-                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DURATION
-            }
-            CassCqlValue::Decimal(_) => {
-                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_DECIMAL
-            }
-            CassCqlValue::Tuple { data_type, .. } => {
+            },
+            CassCqlValue::Blob(_) => unsafe {
+                matches!(
+                    typ.get_unchecked().get_value_type(),
+                    CassValueType::CASS_VALUE_TYPE_BLOB | CassValueType::CASS_VALUE_TYPE_VARINT
+                )
+            },
+            CassCqlValue::Uuid(_) => unsafe {
+                matches!(
+                    typ.get_unchecked().get_value_type(),
+                    CassValueType::CASS_VALUE_TYPE_UUID | CassValueType::CASS_VALUE_TYPE_TIMEUUID
+                )
+            },
+            CassCqlValue::Date(_) => unsafe {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_DATE
+            },
+            CassCqlValue::Inet(_) => unsafe {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_INET
+            },
+            CassCqlValue::Duration(_) => unsafe {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_DURATION
+            },
+            CassCqlValue::Decimal(_) => unsafe {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_DECIMAL
+            },
+            CassCqlValue::Tuple { data_type, .. } => unsafe {
                 if let Some(dt) = data_type {
-                    return dt.typecheck_equals(typ);
+                    return dt.get_unchecked().typecheck_equals(typ.get_unchecked());
                 }
                 // Untyped tuple.
-                typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_TUPLE
-            }
-            CassCqlValue::List { data_type, .. } => {
+                typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_TUPLE
+            },
+            CassCqlValue::List { data_type, .. } => unsafe {
                 if let Some(dt) = data_type {
-                    dt.typecheck_equals(typ)
+                    dt.get_unchecked().typecheck_equals(typ.get_unchecked())
                 } else {
                     // Untyped list.
-                    typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_LIST
+                    typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_LIST
                 }
-            }
-            CassCqlValue::Map { data_type, .. } => {
+            },
+            CassCqlValue::Map { data_type, .. } => unsafe {
                 if let Some(dt) = data_type {
-                    dt.typecheck_equals(typ)
+                    dt.get_unchecked().typecheck_equals(typ.get_unchecked())
                 } else {
                     // Untyped map.
-                    typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_MAP
+                    typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_MAP
                 }
-            }
-            CassCqlValue::Set { data_type, .. } => {
+            },
+            CassCqlValue::Set { data_type, .. } => unsafe {
                 if let Some(dt) = data_type {
-                    dt.typecheck_equals(typ)
+                    dt.get_unchecked().typecheck_equals(typ.get_unchecked())
                 } else {
                     // Untyped set.
-                    typ.get_value_type() == CassValueType::CASS_VALUE_TYPE_SET
+                    typ.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_SET
                 }
-            }
-            CassCqlValue::UserDefinedType { data_type, .. } => data_type.typecheck_equals(typ),
+            },
+            CassCqlValue::UserDefinedType { data_type, .. } => unsafe {
+                data_type
+                    .get_unchecked()
+                    .typecheck_equals(typ.get_unchecked())
+            },
         }
     }
 }
@@ -402,14 +418,14 @@ mod tests {
     use scylla::frame::value::{CqlDate, CqlDecimal, CqlDuration};
 
     use crate::{
-        cass_types::{CassDataType, CassValueType, MapDataType, UDTDataType},
+        cass_types::{CassDataType, CassDataTypeInner, CassValueType, MapDataType, UDTDataType},
         value::{is_type_compatible, CassCqlValue},
     };
 
-    fn all_value_data_types() -> [CassDataType; 26] {
-        let from = |v_typ: CassValueType| CassDataType::Value(v_typ);
+    fn all_value_data_types() -> Vec<CassDataType> {
+        let from = |v_typ: CassValueType| CassDataType::new(CassDataTypeInner::Value(v_typ));
 
-        [
+        vec![
             from(CassValueType::CASS_VALUE_TYPE_TINY_INT),
             from(CassValueType::CASS_VALUE_TYPE_SMALL_INT),
             from(CassValueType::CASS_VALUE_TYPE_INT),
@@ -441,7 +457,7 @@ mod tests {
 
     #[test]
     fn typecheck_simple_test() {
-        let from = |v_typ: CassValueType| CassDataType::Value(v_typ);
+        let from = |v_typ: CassValueType| CassDataType::new(CassDataTypeInner::Value(v_typ));
         struct TestCase {
             value: Option<CassCqlValue>,
             compatible_types: Vec<CassDataType>,
@@ -451,7 +467,7 @@ mod tests {
             // Null -> all types
             TestCase {
                 value: None,
-                compatible_types: all_value_data_types().to_vec(),
+                compatible_types: all_value_data_types(),
             },
             // i8 -> tinyint
             TestCase {
@@ -594,10 +610,15 @@ mod tests {
 
         // Let's make some types accessible for all test cases.
         // To make sure that e.g. Tuple against UDT typecheck fails.
-        let data_type_float = Arc::new(CassDataType::Value(CassValueType::CASS_VALUE_TYPE_FLOAT));
-        let data_type_int = Arc::new(CassDataType::Value(CassValueType::CASS_VALUE_TYPE_INT));
-        let data_type_bool = Arc::new(CassDataType::Value(CassValueType::CASS_VALUE_TYPE_BOOLEAN));
-        let data_type_tuple = Arc::new(CassDataType::Tuple(vec![
+        let data_type_float = CassDataType::new_arced(CassDataTypeInner::Value(
+            CassValueType::CASS_VALUE_TYPE_FLOAT,
+        ));
+        let data_type_int =
+            CassDataType::new_arced(CassDataTypeInner::Value(CassValueType::CASS_VALUE_TYPE_INT));
+        let data_type_bool = CassDataType::new_arced(CassDataTypeInner::Value(
+            CassValueType::CASS_VALUE_TYPE_BOOLEAN,
+        ));
+        let data_type_tuple = CassDataType::new_arced(CassDataTypeInner::Tuple(vec![
             data_type_float.clone(),
             data_type_int.clone(),
             data_type_bool.clone(),
@@ -612,42 +633,44 @@ mod tests {
         let user_udt_name = "user".to_owned();
         let empty_str = "".to_owned();
 
-        let data_type_udt_simple = Arc::new(CassDataType::UDT(UDTDataType {
+        let data_type_udt_simple = CassDataType::new_arced(CassDataTypeInner::UDT(UDTDataType {
             field_types: simple_fields.clone(),
             keyspace: ks_keyspace_name.clone(),
             name: user_udt_name.clone(),
             frozen: false,
         }));
 
-        let data_type_int_list = Arc::new(CassDataType::List {
+        let data_type_int_list = CassDataType::new_arced(CassDataTypeInner::List {
             typ: Some(data_type_int.clone()),
             frozen: false,
         });
 
-        let data_type_int_set = Arc::new(CassDataType::Set {
+        let data_type_int_set = CassDataType::new_arced(CassDataTypeInner::Set {
             typ: Some(data_type_int.clone()),
             frozen: false,
         });
 
-        let data_type_bool_float_map = Arc::new(CassDataType::Map {
+        let data_type_bool_float_map = CassDataType::new_arced(CassDataTypeInner::Map {
             typ: MapDataType::KeyAndValue(data_type_bool.clone(), data_type_float.clone()),
             frozen: false,
         });
 
         // TUPLES
         {
-            let data_type_untyped_tuple = Arc::new(CassDataType::Tuple(vec![]));
-            let data_type_small_tuple = Arc::new(CassDataType::Tuple(vec![data_type_bool.clone()]));
-            let data_type_nested_tuple = Arc::new(CassDataType::Tuple(vec![
+            let data_type_untyped_tuple = CassDataType::new_arced(CassDataTypeInner::Tuple(vec![]));
+            let data_type_small_tuple =
+                CassDataType::new_arced(CassDataTypeInner::Tuple(vec![data_type_bool.clone()]));
+            let data_type_nested_tuple = CassDataType::new_arced(CassDataTypeInner::Tuple(vec![
                 data_type_small_tuple.clone(),
                 data_type_int.clone(),
                 data_type_tuple.clone(),
             ]));
-            let data_type_nested_untyped_tuple = Arc::new(CassDataType::Tuple(vec![
-                data_type_untyped_tuple.clone(),
-                data_type_int.clone(),
-                data_type_untyped_tuple.clone(),
-            ]));
+            let data_type_nested_untyped_tuple =
+                CassDataType::new_arced(CassDataTypeInner::Tuple(vec![
+                    data_type_untyped_tuple.clone(),
+                    data_type_int.clone(),
+                    data_type_untyped_tuple.clone(),
+                ]));
 
             let test_cases = &[
                 // Untyped tuple -> created via `cass_tuple_new`
@@ -748,30 +771,33 @@ mod tests {
 
         // UDT
         {
-            let data_type_udt_simple_empty_keyspace = Arc::new(CassDataType::UDT(UDTDataType {
-                field_types: simple_fields.clone(),
-                keyspace: empty_str.to_owned(),
-                name: user_udt_name.clone(),
-                frozen: false,
-            }));
-            let data_type_udt_simple_empty_name = Arc::new(CassDataType::UDT(UDTDataType {
-                field_types: simple_fields.clone(),
-                keyspace: ks_keyspace_name.clone(),
-                name: empty_str.clone(),
-                frozen: false,
-            }));
+            let data_type_udt_simple_empty_keyspace =
+                CassDataType::new_arced(CassDataTypeInner::UDT(UDTDataType {
+                    field_types: simple_fields.clone(),
+                    keyspace: empty_str.to_owned(),
+                    name: user_udt_name.clone(),
+                    frozen: false,
+                }));
+            let data_type_udt_simple_empty_name =
+                CassDataType::new_arced(CassDataTypeInner::UDT(UDTDataType {
+                    field_types: simple_fields.clone(),
+                    keyspace: ks_keyspace_name.clone(),
+                    name: empty_str.clone(),
+                    frozen: false,
+                }));
 
             // A prefix of simple_fields.
             let small_fields = vec![
                 ("foo".to_owned(), data_type_float.clone()),
                 ("bar".to_owned(), data_type_bool.clone()),
             ];
-            let data_type_udt_small = Arc::new(CassDataType::UDT(UDTDataType {
-                field_types: small_fields.clone(),
-                keyspace: ks_keyspace_name.clone(),
-                name: user_udt_name.clone(),
-                frozen: false,
-            }));
+            let data_type_udt_small =
+                CassDataType::new_arced(CassDataTypeInner::UDT(UDTDataType {
+                    field_types: small_fields.clone(),
+                    keyspace: ks_keyspace_name.clone(),
+                    name: user_udt_name.clone(),
+                    frozen: false,
+                }));
 
             let test_cases = &[TestCase {
                 value: CassCqlValue::UserDefinedType {
@@ -800,34 +826,34 @@ mod tests {
 
         // COLLECTIONS
         {
-            let data_type_untyped_list = Arc::new(CassDataType::List {
+            let data_type_untyped_list = CassDataType::new_arced(CassDataTypeInner::List {
                 typ: None,
                 frozen: false,
             });
-            let data_type_float_list = Arc::new(CassDataType::List {
+            let data_type_float_list = CassDataType::new_arced(CassDataTypeInner::List {
                 typ: Some(data_type_float.clone()),
                 frozen: false,
             });
 
-            let data_type_untyped_set = Arc::new(CassDataType::Set {
+            let data_type_untyped_set = CassDataType::new_arced(CassDataTypeInner::Set {
                 typ: None,
                 frozen: false,
             });
-            let data_type_float_set = Arc::new(CassDataType::Set {
+            let data_type_float_set = CassDataType::new_arced(CassDataTypeInner::Set {
                 typ: Some(data_type_float.clone()),
                 frozen: false,
             });
 
-            let data_type_untyped_map = Arc::new(CassDataType::Map {
+            let data_type_untyped_map = CassDataType::new_arced(CassDataTypeInner::Map {
                 typ: MapDataType::Untyped,
                 frozen: false,
             });
-            let data_type_typed_key_float_map = Arc::new(CassDataType::Map {
+            let data_type_typed_key_float_map = CassDataType::new_arced(CassDataTypeInner::Map {
                 typ: MapDataType::Key(data_type_float.clone()),
 
                 frozen: false,
             });
-            let data_type_float_int_map = Arc::new(CassDataType::Map {
+            let data_type_float_int_map = CassDataType::new_arced(CassDataTypeInner::Map {
                 typ: MapDataType::KeyAndValue(data_type_float.clone(), data_type_int.clone()),
                 frozen: false,
             });


### PR DESCRIPTION
## CassDataType interior mutability
`CassDataType` is the only type that is both shared, and mutable. We use of interior mutability pattern for this type. Even if the current code is sound in this matter, we should wrap the underlying data in `UnsafeCell`, to make (possibly)
invalid accesses to it more verbose and easier to detect by forcing the user to use an explicit `unsafe` block.

## [Box/Arc/Ref]FFI API
The main motivation behind this PR is to:

- reduce the lifetime of reference obtained from the pointer
Current pointer-to-ref conversion API (ptr_to_ref_[mut]) returns a
reference with a static lifetime. New API is parameterized by a lifetime,
which is not 'static.

- ensure that IF the memory associated with the pointer was allocated a certain way,
  the raw pointer will be converted to the corresponding Rust pointer primitive i.e. Box or Arc
  (or reference if the pointer was not obtained from an explicit allocation).

This is achieved, by (in addition, to the new API) disallowing the usage of `[Box/Arc]` API that operates on raw pointers.

However, this does not give us any guarantees about the origin of the pointer.
Consider following example:

// Rust
```rust
impl ArcFFI for Foo {}

fn extern "C" f1() -> *const Foo {
    // a pointer to stack variable
    // Also applies to some valid pointer obtained from the reference
    // to the field of some already heap-allocated object.
    // Decided to go with a stack variable to keep the example simple.
    let foo = Foo;
    &foo
}

fn extern "C" f2(foo: *const Foo) {
    let foo = ArcFFI::cloned_from_ptr(foo);
}
```

// C
```c
Foo *foo = f1();
f2(foo);

// Segfault.
// Even if f1() returned a valid pointer, that points to some
// heap-allocated memory. The pointer was not obtained from an Arc allocation.
// I.e., it was not obtained via Arc::into_raw().
```

To guarantee this, we need to introduce a special type for pointer that
would represent the pointer's properties. This will be done in a follow-up PR.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~