### PR TITLE
safety: introduce pointer types and their restrictions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 endif
 
 ifndef CCM_COMMIT_ID
-	export CCM_COMMIT_ID := master
+	# TODO: change it back to master/next when https://github.com/scylladb/scylla-ccm/issues/646 is fixed.
+	export CCM_COMMIT_ID := 5392dd68
 endif
 
 ifndef SCYLLA_VERSION

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -1,7 +1,9 @@
 use crate::types::size_t;
 use std::cmp::min;
 use std::ffi::CStr;
+use std::marker::PhantomData;
 use std::os::raw::c_char;
+use std::ptr::NonNull;
 use std::sync::Arc;
 
 pub unsafe fn ptr_to_cstr(ptr: *const c_char) -> Option<&'static str> {
@@ -70,6 +72,259 @@ macro_rules! make_c_str {
 
 #[cfg(test)]
 pub(crate) use make_c_str;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A trait representing ownership (i.e. Rust mutability) of the pointer.
+///
+/// Pointer can either be [`Exclusive`] or [`Shared`].
+///
+/// ## Shared pointers
+/// Shared pointers can only be converted to **immutable** Rust referential types.
+/// There is no way to obtain a mutable reference from such pointer.
+///
+/// In some cases, we need to be able to mutate the data behind a shared pointer.
+/// There is an example of such use case - namely [`crate::cass_types::CassDataType`].
+/// argconv API does not provide a way to mutate such pointer - one can only convert the pointer
+/// to [`Arc`] or &. It is the API user's responsibility to implement sound interior mutability
+/// pattern in such case. This is what we currently do - CassDataType wraps CassDataTypeInner
+/// inside an `UnsafeCell` to implement interior mutability for the type.
+/// Other example is [`crate::future::CassFuture`] which uses Mutex.
+///
+/// ## Exclusive pointers
+/// Exclusive pointers can be converted to both immutable and mutable Rust referential types.
+pub trait Ownership: sealed::Sealed {}
+
+/// Represents shared (immutable) pointer.
+pub struct Shared;
+impl sealed::Sealed for Shared {}
+impl Ownership for Shared {}
+
+/// Represents exclusive (mutable) pointer.
+pub struct Exclusive;
+impl sealed::Sealed for Exclusive {}
+impl Ownership for Exclusive {}
+
+/// A trait representing mutability of the pointer in C semantics.
+///
+/// Pointer can be either [`CConst`] or [`CMut`].
+///
+/// The semantics of this property are very simple: it tells whether
+/// the pointer is const or not on the C side. If the pointer is `T*`, then
+/// corresponding [`CassPtr`] is [`CMut`], and if the pointer is `const T*`, then
+/// corresponding [`CassPtr`] is [`CConst`].
+///
+/// ## Why [`Ownership`] property is not enough?
+/// This is because mutability semantics differ between C and Rust.
+/// - In C/C++: mut = logically mutable, const = logically immutable
+/// - In Rust: mut = exclusive ownership (e.g. Box, &mut), const = shared ownership (e.g. Arc, &)
+///
+/// In cpp-driver API there are some types that are both shared and mutable. Take for example `CassDataType`.
+/// From rust perspective, the pointer is always [`Shared`], because it is shared behind an [`Arc`].
+/// But there are some methods, e.g:
+/// ```rust,ignore
+/// cass_data_type_add_sub_type(CassDataType* data_type, const CassDataType* sub_data_type);
+/// ```
+/// which accept a mutable pointer. Such method is implemented by employing interior mutability pattern (mutating a shared object).
+/// If we did not have [`CMutability`] property defined, we would not be able to
+/// distinguish between `CassDataType*` and `const CassDataType*`. In such case, user would be able to obtain
+/// `const CassDataType*` pointer (e.g. from `cass_tuple_data_type`) and pass it to the method that expects `CassDataType*`.
+///
+/// This property comes useful for implementing safe Rust unit tests where we play a role of C API user.
+pub trait CMutability: sealed::Sealed {}
+
+/// Represents const C pointer.
+pub struct CConst;
+impl sealed::Sealed for CConst {}
+impl CMutability for CConst {}
+
+/// Represents mutable (non-const) C pointer.
+pub struct CMut;
+impl sealed::Sealed for CMut {}
+impl CMutability for CMut {}
+
+/// Represents additional properties of the pointer.
+pub trait Properties: sealed::Sealed {
+    type Onwership: Ownership;
+    type CMutability: CMutability;
+}
+
+impl<O: Ownership, CM: CMutability> sealed::Sealed for (O, CM) {}
+impl<O: Ownership, CM: CMutability> Properties for (O, CM) {
+    type Onwership = O;
+    type CMutability = CM;
+}
+
+/// Represents a valid non-dangling pointer.
+///
+/// ## Safety and validity guarantees
+/// Apart from trivial constructors such as [`CassPtr::null()`] and [`CassPtr::null_mut()`], there
+/// is only one way to construct a [`CassPtr`] instance - from raw pointer via [`CassPtr::from_raw()`].
+/// This constructor is `unsafe`. It is user's responsibility to ensure that the raw pointer
+/// provided to the constructor is **valid**. In other words, the pointer comes from some valid
+/// allocation, or from some valid reference.
+///
+/// ## Generic lifetime and aliasing guarantees
+/// We distinguish two types of pointers: shared ([`Shared`]) and exclusive ([`Exclusive`]).
+/// Shared pointers can be converted to immutable (&) references, while exclusive pointers
+/// can be converted to either immutable (&) or mutable (&mut) reference. User needs to pick
+/// the correct mutability property of the pointer during construction. This is yet another
+/// reason why [`CassPtr::from_raw`] is `unsafe`.
+///
+/// Pointer is parameterized by the lifetime. Thanks to that, we can tell whether the pointer
+/// **owns** or **borrows** the pointee. Once again, user is responsible for "picking"
+/// the correct lifetime when creating the pointer. For example, when raw pointer
+/// comes from [`Box::into_raw()`], user could create a [`CassPtr<'static, T, (Exclusive,)>`].
+/// `'static` lifetime represents that user is the exclusive **owner** of the pointee, and
+/// is responsible for freeing the memory (e.g. via [`Box::from_raw()`]).
+/// On the other hand, when pointer is created from some immutable reference `&'a T`,
+/// the correct choice of CassPtr would be [`CassPtr<'a, T, (Shared,)>`]. It means that
+/// holder of the created pointer **borrows** the pointee (with some lifetime `'a`
+/// inherited from the immutable borrow `&'a T`).
+///
+/// Both [`CassPtr::into_ref()`] and [`CassPtr::into_mut_ref()`] consume the pointer.
+/// At first glance, it seems impossible to obtain multiple immutable reference from one pointer.
+/// This is why pointer reborrowing mechanism is introduced. There are two methods: [`CassPtr::borrow()`]
+/// and [`CassPtr::borrow_mut()`]. Both of them cooperate with borrow checker and enforce
+/// aliasing XOR mutability principle at compile time.
+///
+/// ## Safe conversions to referential types
+/// Thanks to the above guarantees, conversions to referential types are **safe**.
+/// See methods [`CassPtr::into_ref()`] and [`CassPtr::into_mut_ref()`].
+///
+/// ## Memory layout
+/// We use repr(transparent), so the struct has the same layout as underlying [`Option<NonNull<T>>`].
+/// Thanks to https://doc.rust-lang.org/std/option/#representation optimization,
+/// we are guaranteed, that for `T: Sized`, our struct has the same layout
+/// and function call ABI as simply [`NonNull<T>`].
+#[repr(transparent)]
+pub struct CassPtr<'a, T: Sized, P: Properties> {
+    ptr: Option<NonNull<T>>,
+    _phantom: PhantomData<&'a P>,
+}
+
+/// Owned shared pointer.
+/// Can be used for pointers with shared ownership - e.g. pointers coming from [`Arc`] allocation.
+pub type CassOwnedSharedPtr<T, CM> = CassPtr<'static, T, (Shared, CM)>;
+
+/// Borrowed shared pointer.
+/// Can be used for pointers created from some immutable reference.
+pub type CassBorrowedSharedPtr<'a, T, CM> = CassPtr<'a, T, (Shared, CM)>;
+
+/// Owned exclusive pointer.
+/// Can be used for pointers with exclusive ownership - e.g. pointers coming from [`Box`] allocation.
+pub type CassOwnedExclusivePtr<T, CM> = CassPtr<'static, T, (Exclusive, CM)>;
+
+/// Borrowed exclusive pointer.
+/// This can be for example obtained from mutable reborrow of some [`CassOwnedExclusivePtr`].
+pub type CassBorrowedExclusivePtr<'a, T, CM> = CassPtr<'a, T, (Exclusive, CM)>;
+
+/// Utility method for tests. Useful when some method returns `T*`,
+/// and then another method accepts `const T*`.
+#[cfg(test)]
+impl<'a, T: Sized, P: Properties> CassPtr<'a, T, P> {
+    pub fn into_c_const(self) -> CassPtr<'a, T, (P::Onwership, CConst)> {
+        CassPtr {
+            ptr: self.ptr,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// Pointer constructors.
+impl<T: Sized, P: Properties> CassPtr<'_, T, P> {
+    fn null() -> Self {
+        CassPtr {
+            ptr: None,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn is_null(&self) -> bool {
+        self.ptr.is_none()
+    }
+
+    /// Constructs [`CassPtr`] from raw pointer.
+    ///
+    /// ## Safety
+    /// User needs to ensure that the pointer is **valid**.
+    /// User is also responsible for picking correct ownership property and lifetime
+    /// of the created pointer. For more information, see the documentation of [`CassPtr`].
+    unsafe fn from_raw(raw: *const T) -> Self {
+        CassPtr {
+            ptr: NonNull::new(raw as *mut T),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// Conversion to raw pointer.
+impl<T: Sized, P: Properties> CassPtr<'_, T, P> {
+    fn to_raw(&self) -> Option<*mut T> {
+        self.ptr.map(|ptr| ptr.as_ptr())
+    }
+}
+
+/// Constructors for to exclusive pointers.
+impl<T: Sized> CassPtr<'_, T, (Exclusive, CMut)> {
+    fn null_mut() -> Self {
+        CassPtr {
+            ptr: None,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T: Sized, P: Properties> CassPtr<'a, T, P> {
+    /// Converts a pointer to an optional valid reference.
+    /// The reference inherits the lifetime of the pointer.
+    fn into_ref(self) -> Option<&'a T> {
+        // SAFETY: Thanks to the validity and aliasing ^ mutability guarantees,
+        // we can safely convert the pointer to valid immutable reference with
+        // correct lifetime.
+        unsafe { self.ptr.map(|p| p.as_ref()) }
+    }
+}
+
+impl<'a, T: Sized, CM: CMutability> CassPtr<'a, T, (Exclusive, CM)> {
+    /// Converts a pointer to an optional valid mutable reference.
+    /// The reference inherits the lifetime of the pointer.
+    fn into_mut_ref(self) -> Option<&'a mut T> {
+        // SAFETY: Thanks to the validity and aliasing ^ mutability guarantees,
+        // we can safely convert the pointer to valid mutable (and exclusive) reference with
+        // correct lifetime.
+        unsafe { self.ptr.map(|mut p| p.as_mut()) }
+    }
+}
+
+impl<T: Sized, P: Properties> CassPtr<'_, T, P> {
+    /// Immutably reborrows the pointer.
+    /// Resulting pointer inherits the lifetime from the immutable borrow
+    /// of original pointer.
+    #[allow(clippy::needless_lifetimes)]
+    pub fn borrow<'a>(&'a self) -> CassPtr<'a, T, (Shared, P::CMutability)> {
+        CassPtr {
+            ptr: self.ptr,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: Sized> CassPtr<'_, T, (Exclusive, CMut)> {
+    /// Mutably reborrows the pointer.
+    /// Resulting pointer inherits the lifetime from the mutable borrow
+    /// of original pointer. Since the method accepts a mutable reference
+    /// to the original pointer, we enforce aliasing ^ mutability principle at compile time.
+    #[allow(clippy::needless_lifetimes)]
+    pub fn borrow_mut<'a>(&'a mut self) -> CassPtr<'a, T, (Exclusive, CMut)> {
+        CassPtr {
+            ptr: self.ptr,
+            _phantom: PhantomData,
+        }
+    }
+}
 
 /// Defines a pointer manipulation API for non-shared heap-allocated data.
 ///

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -1,5 +1,6 @@
 use crate::argconv::{
     ArcFFI, BoxFFI, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr, CassOwnedExclusivePtr,
+    FromBox, FFI,
 };
 use crate::cass_error::CassError;
 use crate::cass_types::CassConsistency;
@@ -21,7 +22,9 @@ pub struct CassBatch {
     pub(crate) exec_profile: Option<PerStatementExecProfile>,
 }
 
-impl BoxFFI for CassBatch {}
+impl FFI for CassBatch {
+    type Origin = FromBox;
+}
 
 #[derive(Clone)]
 pub struct CassBatchState {

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -53,7 +53,7 @@ macro_rules! make_index_binder {
         #[no_mangle]
         #[allow(clippy::redundant_closure_call)]
         pub unsafe extern "C" fn $fn_by_idx(
-            this: *mut $this,
+            this: CassBorrowedExclusivePtr<$this, CMut>,
             index: size_t,
             $($arg: $t), *
         ) -> CassError {
@@ -61,7 +61,7 @@ macro_rules! make_index_binder {
             #[allow(unused_imports)]
             use crate::value::CassCqlValue::*;
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this), index as usize, v),
+                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this).unwrap(), index as usize, v),
                 Err(e) => e,
             }
         }
@@ -73,7 +73,7 @@ macro_rules! make_name_binder {
         #[no_mangle]
         #[allow(clippy::redundant_closure_call)]
         pub unsafe extern "C" fn $fn_by_name(
-            this: *mut $this,
+            this: CassBorrowedExclusivePtr<$this, CMut>,
             name: *const c_char,
             $($arg: $t), *
         ) -> CassError {
@@ -82,7 +82,7 @@ macro_rules! make_name_binder {
             use crate::value::CassCqlValue::*;
             let name = ptr_to_cstr(name).unwrap();
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this), name, v),
+                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this).unwrap(), name, v),
                 Err(e) => e,
             }
         }
@@ -94,7 +94,7 @@ macro_rules! make_name_n_binder {
         #[no_mangle]
         #[allow(clippy::redundant_closure_call)]
         pub unsafe extern "C" fn $fn_by_name_n(
-            this: *mut $this,
+            this: CassBorrowedExclusivePtr<$this, CMut>,
             name: *const c_char,
             name_length: size_t,
             $($arg: $t), *
@@ -104,7 +104,7 @@ macro_rules! make_name_n_binder {
             use crate::value::CassCqlValue::*;
             let name = ptr_to_cstr_n(name, name_length).unwrap();
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this), name, v),
+                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this).unwrap(), name, v),
                 Err(e) => e,
             }
         }
@@ -116,14 +116,14 @@ macro_rules! make_appender {
         #[no_mangle]
         #[allow(clippy::redundant_closure_call)]
         pub unsafe extern "C" fn $fn_append(
-            this: *mut $this,
+            this: CassBorrowedExclusivePtr<$this, CMut>,
             $($arg: $t), *
         ) -> CassError {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
             use crate::value::CassCqlValue::*;
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this), v),
+                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this).unwrap(), v),
                 Err(e) => e,
             }
         }
@@ -302,13 +302,13 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |p: *const crate::collection::CassCollection| {
-                match std::convert::TryInto::try_into(BoxFFI::as_ref(p)) {
+            |p: CassBorrowedSharedPtr<crate::collection::CassCollection, CConst>| {
+                match std::convert::TryInto::try_into(BoxFFI::as_ref(p).unwrap()) {
                     Ok(v) => Ok(Some(v)),
                     Err(_) => Err(CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE),
                 }
             },
-            [p @ *const crate::collection::CassCollection]
+            [p @ CassBorrowedSharedPtr<crate::collection::CassCollection, CConst>]
         );
     };
     (tuple, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
@@ -316,10 +316,10 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |p: *const crate::tuple::CassTuple| {
-                Ok(Some(BoxFFI::as_ref(p).into()))
+            |p: CassBorrowedSharedPtr<crate::tuple::CassTuple, CConst>| {
+                Ok(Some(BoxFFI::as_ref(p).unwrap().into()))
             },
-            [p @ *const crate::tuple::CassTuple]
+            [p @ CassBorrowedSharedPtr<crate::tuple::CassTuple, CConst>]
         );
     };
     (user_type, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
@@ -327,8 +327,10 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |p: *const crate::user_type::CassUserType| Ok(Some(BoxFFI::as_ref(p).into())),
-            [p @ *const crate::user_type::CassUserType]
+            |p: CassBorrowedSharedPtr<crate::user_type::CassUserType, CConst>| {
+                Ok(Some(BoxFFI::as_ref(p).unwrap().into()))
+            },
+            [p @ CassBorrowedSharedPtr<crate::user_type::CassUserType, CConst>]
         );
     };
 }

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -145,7 +145,9 @@ pub enum CassDataTypeInner {
     Custom(String),
 }
 
-impl ArcFFI for CassDataType {}
+impl FFI for CassDataType {
+    type Origin = FromArc;
+}
 
 impl CassDataTypeInner {
     /// Checks for equality during typechecks.

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -8,7 +8,6 @@ use scylla::statement::batch::BatchType;
 use std::cell::UnsafeCell;
 use std::convert::TryFrom;
 use std::os::raw::c_char;
-use std::ptr;
 use std::sync::Arc;
 
 pub(crate) use crate::cass_batch_types::CassBatchType;
@@ -447,7 +446,9 @@ pub fn get_column_type(column_type: &ColumnType) -> CassDataType {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_new(value_type: CassValueType) -> *mut CassDataType {
+pub unsafe extern "C" fn cass_data_type_new(
+    value_type: CassValueType,
+) -> CassOwnedSharedPtr<CassDataType, CMut> {
     let inner = match value_type {
         CassValueType::CASS_VALUE_TYPE_LIST => CassDataTypeInner::List {
             typ: None,
@@ -464,49 +465,57 @@ pub unsafe extern "C" fn cass_data_type_new(value_type: CassValueType) -> *mut C
         },
         CassValueType::CASS_VALUE_TYPE_UDT => CassDataTypeInner::UDT(UDTDataType::new()),
         CassValueType::CASS_VALUE_TYPE_CUSTOM => CassDataTypeInner::Custom("".to_string()),
-        CassValueType::CASS_VALUE_TYPE_UNKNOWN => return ptr::null_mut(),
+        CassValueType::CASS_VALUE_TYPE_UNKNOWN => return ArcFFI::null(),
         t if t < CassValueType::CASS_VALUE_TYPE_LAST_ENTRY => CassDataTypeInner::Value(t),
-        _ => return ptr::null_mut(),
+        _ => return ArcFFI::null(),
     };
-    ArcFFI::into_ptr(CassDataType::new_arced(inner)) as *mut _
+    ArcFFI::into_ptr(CassDataType::new_arced(inner))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_new_from_existing(
-    data_type: *const CassDataType,
-) -> *mut CassDataType {
-    let data_type = ArcFFI::as_ref(data_type);
-    ArcFFI::into_ptr(CassDataType::new_arced(data_type.get_unchecked().clone())) as *mut _
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
+) -> CassOwnedSharedPtr<CassDataType, CMut> {
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    ArcFFI::into_ptr(CassDataType::new_arced(data_type.get_unchecked().clone()))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_new_tuple(item_count: size_t) -> *mut CassDataType {
+pub unsafe extern "C" fn cass_data_type_new_tuple(
+    item_count: size_t,
+) -> CassOwnedSharedPtr<CassDataType, CMut> {
     ArcFFI::into_ptr(CassDataType::new_arced(CassDataTypeInner::Tuple(
         Vec::with_capacity(item_count as usize),
-    ))) as *mut _
+    )))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_new_udt(field_count: size_t) -> *mut CassDataType {
+pub unsafe extern "C" fn cass_data_type_new_udt(
+    field_count: size_t,
+) -> CassOwnedSharedPtr<CassDataType, CMut> {
     ArcFFI::into_ptr(CassDataType::new_arced(CassDataTypeInner::UDT(
         UDTDataType::with_capacity(field_count as usize),
-    ))) as *mut _
+    )))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_free(data_type: *mut CassDataType) {
+pub unsafe extern "C" fn cass_data_type_free(data_type: CassOwnedSharedPtr<CassDataType, CMut>) {
     ArcFFI::free(data_type);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_type(data_type: *const CassDataType) -> CassValueType {
-    let data_type = ArcFFI::as_ref(data_type);
+pub unsafe extern "C" fn cass_data_type_type(
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
+) -> CassValueType {
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     data_type.get_unchecked().get_value_type()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_is_frozen(data_type: *const CassDataType) -> cass_bool_t {
-    let data_type = ArcFFI::as_ref(data_type);
+pub unsafe extern "C" fn cass_data_type_is_frozen(
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
+) -> cass_bool_t {
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     let is_frozen = match data_type.get_unchecked() {
         CassDataTypeInner::UDT(udt) => udt.frozen,
         CassDataTypeInner::List { frozen, .. } => *frozen,
@@ -520,11 +529,11 @@ pub unsafe extern "C" fn cass_data_type_is_frozen(data_type: *const CassDataType
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_type_name(
-    data_type: *const CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     type_name: *mut *const c_char,
     type_name_length: *mut size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type);
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     match data_type.get_unchecked() {
         CassDataTypeInner::UDT(UDTDataType { name, .. }) => {
             write_str_to_c(name, type_name, type_name_length);
@@ -536,7 +545,7 @@ pub unsafe extern "C" fn cass_data_type_type_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_type_name(
-    data_type: *mut CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     type_name: *const c_char,
 ) -> CassError {
     cass_data_type_set_type_name_n(data_type, type_name, strlen(type_name))
@@ -544,11 +553,11 @@ pub unsafe extern "C" fn cass_data_type_set_type_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_type_name_n(
-    data_type_raw: *mut CassDataType,
+    data_type_raw: CassBorrowedSharedPtr<CassDataType, CMut>,
     type_name: *const c_char,
     type_name_length: size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type_raw);
+    let data_type = ArcFFI::as_ref(data_type_raw).unwrap();
     let type_name_string = ptr_to_cstr_n(type_name, type_name_length)
         .unwrap()
         .to_string();
@@ -564,11 +573,11 @@ pub unsafe extern "C" fn cass_data_type_set_type_name_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_keyspace(
-    data_type: *const CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     keyspace: *mut *const c_char,
     keyspace_length: *mut size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type);
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     match data_type.get_unchecked() {
         CassDataTypeInner::UDT(UDTDataType { name, .. }) => {
             write_str_to_c(name, keyspace, keyspace_length);
@@ -580,7 +589,7 @@ pub unsafe extern "C" fn cass_data_type_keyspace(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_keyspace(
-    data_type: *mut CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     keyspace: *const c_char,
 ) -> CassError {
     cass_data_type_set_keyspace_n(data_type, keyspace, strlen(keyspace))
@@ -588,11 +597,11 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
-    data_type: *mut CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     keyspace: *const c_char,
     keyspace_length: size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type);
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     let keyspace_string = ptr_to_cstr_n(keyspace, keyspace_length)
         .unwrap()
         .to_string();
@@ -608,11 +617,11 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_class_name(
-    data_type: *const CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     class_name: *mut *const ::std::os::raw::c_char,
     class_name_length: *mut size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type);
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     match data_type.get_unchecked() {
         CassDataTypeInner::Custom(name) => {
             write_str_to_c(name, class_name, class_name_length);
@@ -624,7 +633,7 @@ pub unsafe extern "C" fn cass_data_type_class_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_class_name(
-    data_type: *mut CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     class_name: *const ::std::os::raw::c_char,
 ) -> CassError {
     cass_data_type_set_class_name_n(data_type, class_name, strlen(class_name))
@@ -632,11 +641,11 @@ pub unsafe extern "C" fn cass_data_type_set_class_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_class_name_n(
-    data_type: *mut CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     class_name: *const ::std::os::raw::c_char,
     class_name_length: size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type);
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     let class_string = ptr_to_cstr_n(class_name, class_name_length)
         .unwrap()
         .to_string();
@@ -650,8 +659,10 @@ pub unsafe extern "C" fn cass_data_type_set_class_name_n(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_sub_type_count(data_type: *const CassDataType) -> size_t {
-    let data_type = ArcFFI::as_ref(data_type);
+pub unsafe extern "C" fn cass_data_type_sub_type_count(
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
+) -> size_t {
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     match data_type.get_unchecked() {
         CassDataTypeInner::Value(..) => 0,
         CassDataTypeInner::UDT(udt_data_type) => udt_data_type.field_types.len() as size_t,
@@ -669,21 +680,23 @@ pub unsafe extern "C" fn cass_data_type_sub_type_count(data_type: *const CassDat
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_sub_type_count(data_type: *const CassDataType) -> size_t {
+pub unsafe extern "C" fn cass_data_sub_type_count(
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
+) -> size_t {
     cass_data_type_sub_type_count(data_type)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_sub_data_type(
-    data_type: *const CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     index: size_t,
-) -> *const CassDataType {
-    let data_type = ArcFFI::as_ref(data_type);
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     let sub_type: Option<&Arc<CassDataType>> =
         data_type.get_unchecked().get_sub_data_type(index as usize);
 
     match sub_type {
-        None => std::ptr::null(),
+        None => ArcFFI::null(),
         // Semantic from cppdriver which also returns non-owning pointer
         Some(arc) => ArcFFI::as_ptr(arc),
     }
@@ -691,37 +704,37 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name(
-    data_type: *const CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     name: *const ::std::os::raw::c_char,
-) -> *const CassDataType {
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
     cass_data_type_sub_data_type_by_name_n(data_type, name, strlen(name))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n(
-    data_type: *const CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     name: *const ::std::os::raw::c_char,
     name_length: size_t,
-) -> *const CassDataType {
-    let data_type = ArcFFI::as_ref(data_type);
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     let name_str = ptr_to_cstr_n(name, name_length).unwrap();
     match data_type.get_unchecked() {
         CassDataTypeInner::UDT(udt) => match udt.get_field_by_name(name_str) {
-            None => std::ptr::null(),
+            None => ArcFFI::null(),
             Some(t) => ArcFFI::as_ptr(t),
         },
-        _ => std::ptr::null(),
+        _ => ArcFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_sub_type_name(
-    data_type: *const CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     index: size_t,
     name: *mut *const ::std::os::raw::c_char,
     name_length: *mut size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type);
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     match data_type.get_unchecked() {
         CassDataTypeInner::UDT(udt) => match udt.field_types.get(index as usize) {
             None => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
@@ -736,13 +749,13 @@ pub unsafe extern "C" fn cass_data_type_sub_type_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_type(
-    data_type: *mut CassDataType,
-    sub_data_type: *const CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
+    sub_data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type);
+    let data_type = ArcFFI::as_ref(data_type).unwrap();
     match data_type
         .get_mut_unchecked()
-        .add_sub_data_type(ArcFFI::cloned_from_ptr(sub_data_type))
+        .add_sub_data_type(ArcFFI::cloned_from_ptr(sub_data_type).unwrap())
     {
         Ok(()) => CassError::CASS_OK,
         Err(e) => e,
@@ -751,24 +764,24 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
-    data_type: *mut CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     name: *const c_char,
-    sub_data_type: *const CassDataType,
+    sub_data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassError {
     cass_data_type_add_sub_type_by_name_n(data_type, name, strlen(name), sub_data_type)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
-    data_type_raw: *mut CassDataType,
+    data_type_raw: CassBorrowedSharedPtr<CassDataType, CMut>,
     name: *const c_char,
     name_length: size_t,
-    sub_data_type_raw: *const CassDataType,
+    sub_data_type_raw: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassError {
     let name_string = ptr_to_cstr_n(name, name_length).unwrap().to_string();
-    let sub_data_type = ArcFFI::cloned_from_ptr(sub_data_type_raw);
+    let sub_data_type = ArcFFI::cloned_from_ptr(sub_data_type_raw).unwrap();
 
-    let data_type = ArcFFI::as_ref(data_type_raw);
+    let data_type = ArcFFI::as_ref(data_type_raw).unwrap();
     match data_type.get_mut_unchecked() {
         CassDataTypeInner::UDT(udt_data_type) => {
             // The Cpp Driver does not check whether field_types size
@@ -782,7 +795,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_value_type(
-    data_type: *mut CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     sub_value_type: CassValueType,
 ) -> CassError {
     let sub_data_type = CassDataType::new_arced(CassDataTypeInner::Value(sub_value_type));
@@ -791,7 +804,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
-    data_type: *mut CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     name: *const c_char,
     sub_value_type: CassValueType,
 ) -> CassError {
@@ -801,7 +814,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
-    data_type: *mut CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     name: *const c_char,
     name_length: size_t,
     sub_value_type: CassValueType,

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -196,7 +196,7 @@ pub fn build_session_builder(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
+pub unsafe extern "C" fn cass_cluster_new() -> CassOwnedExclusivePtr<CassCluster, CMut> {
     let default_execution_profile_builder = ExecutionProfileBuilder::default()
         .consistency(DEFAULT_CONSISTENCY)
         .request_timeout(Some(DEFAULT_REQUEST_TIMEOUT));
@@ -236,13 +236,13 @@ pub unsafe extern "C" fn cass_cluster_new() -> *mut CassCluster {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_cluster_free(cluster: *mut CassCluster) {
+pub unsafe extern "C" fn cass_cluster_free(cluster: CassOwnedExclusivePtr<CassCluster, CMut>) {
     BoxFFI::free(cluster);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_contact_points(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     contact_points: *const c_char,
 ) -> CassError {
     cass_cluster_set_contact_points_n(cluster, contact_points, strlen(contact_points))
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn cass_cluster_set_contact_points(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_contact_points_n(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     contact_points: *const c_char,
     contact_points_length: size_t,
 ) -> CassError {
@@ -261,11 +261,11 @@ pub unsafe extern "C" fn cass_cluster_set_contact_points_n(
 }
 
 unsafe fn cluster_set_contact_points(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     contact_points_raw: *const c_char,
     contact_points_length: size_t,
 ) -> Result<(), CassError> {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     let mut contact_points = ptr_to_cstr_n(contact_points_raw, contact_points_length)
         .ok_or(CassError::CASS_ERROR_LIB_BAD_PARAMS)?
         .split(',')
@@ -291,7 +291,7 @@ unsafe fn cluster_set_contact_points(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_use_randomized_contact_points(
-    _cluster_raw: *mut CassCluster,
+    _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     _enabled: cass_bool_t,
 ) -> CassError {
     // FIXME: should set `use_randomized_contact_points` flag in cluster config
@@ -301,7 +301,7 @@ pub unsafe extern "C" fn cass_cluster_set_use_randomized_contact_points(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_application_name(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     app_name: *const c_char,
 ) {
     cass_cluster_set_application_name_n(cluster_raw, app_name, strlen(app_name))
@@ -309,11 +309,11 @@ pub unsafe extern "C" fn cass_cluster_set_application_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_application_name_n(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     app_name: *const c_char,
     app_name_len: size_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     let app_name = ptr_to_cstr_n(app_name, app_name_len).unwrap().to_string();
 
     cluster
@@ -325,7 +325,7 @@ pub unsafe extern "C" fn cass_cluster_set_application_name_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_application_version(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     app_version: *const c_char,
 ) {
     cass_cluster_set_application_version_n(cluster_raw, app_version, strlen(app_version))
@@ -333,11 +333,11 @@ pub unsafe extern "C" fn cass_cluster_set_application_version(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_application_version_n(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     app_version: *const c_char,
     app_version_len: size_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     let app_version = ptr_to_cstr_n(app_version, app_version_len)
         .unwrap()
         .to_string();
@@ -351,10 +351,10 @@ pub unsafe extern "C" fn cass_cluster_set_application_version_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_client_id(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     client_id: CassUuid,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
     let client_uuid: uuid::Uuid = client_id.into();
     let client_uuid_str = client_uuid.to_string();
@@ -369,29 +369,29 @@ pub unsafe extern "C" fn cass_cluster_set_client_id(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_use_schema(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     cluster.session_builder.config.fetch_schema_metadata = enabled != 0;
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_tcp_nodelay(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     cluster.session_builder.config.tcp_nodelay = enabled != 0;
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_tcp_keepalive(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
     delay_secs: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     let enabled = enabled != 0;
     let tcp_keepalive_interval = enabled.then(|| Duration::from_secs(delay_secs as u64));
 
@@ -400,10 +400,10 @@ pub unsafe extern "C" fn cass_cluster_set_tcp_keepalive(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_connection_heartbeat_interval(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     interval_secs: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     let keepalive_interval = (interval_secs > 0).then(|| Duration::from_secs(interval_secs as u64));
 
     cluster.session_builder.config.keepalive_interval = keepalive_interval;
@@ -411,10 +411,10 @@ pub unsafe extern "C" fn cass_cluster_set_connection_heartbeat_interval(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_connection_idle_timeout(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     timeout_secs: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     let keepalive_timeout = (timeout_secs > 0).then(|| Duration::from_secs(timeout_secs as u64));
 
     cluster.session_builder.config.keepalive_timeout = keepalive_timeout;
@@ -422,19 +422,19 @@ pub unsafe extern "C" fn cass_cluster_set_connection_idle_timeout(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_connect_timeout(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     timeout_ms: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     cluster.session_builder.config.connect_timeout = Duration::from_millis(timeout_ms.into());
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_request_timeout(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     timeout_ms: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
     exec_profile_builder_modify(&mut cluster.default_execution_profile_builder, |builder| {
         // 0 -> no timeout
@@ -444,10 +444,10 @@ pub unsafe extern "C" fn cass_cluster_set_request_timeout(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_max_schema_wait_time(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     wait_time_ms: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
     cluster.session_builder.config.schema_agreement_timeout =
         Duration::from_millis(wait_time_ms.into());
@@ -455,10 +455,10 @@ pub unsafe extern "C" fn cass_cluster_set_max_schema_wait_time(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_schema_agreement_interval(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     interval_ms: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
     cluster.session_builder.config.schema_agreement_interval =
         Duration::from_millis(interval_ms.into());
@@ -466,21 +466,21 @@ pub unsafe extern "C" fn cass_cluster_set_schema_agreement_interval(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_port(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     port: c_int,
 ) -> CassError {
     if port <= 0 {
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
 
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     cluster.port = port as u16;
     CassError::CASS_OK
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_credentials(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     username: *const c_char,
     password: *const c_char,
 ) {
@@ -495,7 +495,7 @@ pub unsafe extern "C" fn cass_cluster_set_credentials(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_credentials_n(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     username_raw: *const c_char,
     username_length: size_t,
     password_raw: *const c_char,
@@ -505,20 +505,22 @@ pub unsafe extern "C" fn cass_cluster_set_credentials_n(
     let username = ptr_to_cstr_n(username_raw, username_length).unwrap();
     let password = ptr_to_cstr_n(password_raw, password_length).unwrap();
 
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     cluster.auth_username = Some(username.to_string());
     cluster.auth_password = Some(password.to_string());
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_cluster_set_load_balance_round_robin(cluster_raw: *mut CassCluster) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+pub unsafe extern "C" fn cass_cluster_set_load_balance_round_robin(
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
+) {
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     cluster.load_balancing_config.load_balancing_kind = Some(LoadBalancingKind::RoundRobin);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     local_dc: *const c_char,
     used_hosts_per_remote_dc: c_uint,
     allow_remote_dcs_for_local_cl: cass_bool_t,
@@ -559,13 +561,13 @@ pub(crate) unsafe fn set_load_balance_dc_aware_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     local_dc_raw: *const c_char,
     local_dc_length: size_t,
     used_hosts_per_remote_dc: c_uint,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
     set_load_balance_dc_aware_n(
         &mut cluster.load_balancing_config,
@@ -578,7 +580,7 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     local_dc_raw: *const c_char,
     local_rack_raw: *const c_char,
 ) -> CassError {
@@ -593,13 +595,13 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware_n(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     local_dc_raw: *const c_char,
     local_dc_length: size_t,
     local_rack_raw: *const c_char,
     local_rack_length: size_t,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
     set_load_balance_rack_aware_n(
         &mut cluster.load_balancing_config,
@@ -640,7 +642,7 @@ pub(crate) unsafe fn set_load_balance_rack_aware_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_cloud_secure_connection_bundle_n(
-    _cluster_raw: *mut CassCluster,
+    _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     path: *const c_char,
     path_length: size_t,
 ) -> CassError {
@@ -656,7 +658,7 @@ pub unsafe extern "C" fn cass_cluster_set_cloud_secure_connection_bundle_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_exponential_reconnect(
-    _cluster_raw: *mut CassCluster,
+    _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     base_delay_ms: cass_uint64_t,
     max_delay_ms: cass_uint64_t,
 ) -> CassError {
@@ -691,7 +693,7 @@ pub extern "C" fn cass_custom_payload_new() -> *const CassCustomPayload {
 
 #[no_mangle]
 pub extern "C" fn cass_future_custom_payload_item(
-    _future: *mut CassFuture,
+    _future: CassBorrowedExclusivePtr<CassFuture, CMut>,
     _i: size_t,
     _name: *const c_char,
     _name_length: size_t,
@@ -702,16 +704,18 @@ pub extern "C" fn cass_future_custom_payload_item(
 }
 
 #[no_mangle]
-pub extern "C" fn cass_future_custom_payload_item_count(_future: *mut CassFuture) -> size_t {
+pub extern "C" fn cass_future_custom_payload_item_count(
+    _future: CassBorrowedExclusivePtr<CassFuture, CMut>,
+) -> size_t {
     0
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_use_beta_protocol_version(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enable: cass_bool_t,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     cluster.use_beta_protocol_version = enable == cass_true;
 
     CassError::CASS_OK
@@ -719,10 +723,10 @@ pub unsafe extern "C" fn cass_cluster_set_use_beta_protocol_version(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_protocol_version(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     protocol_version: c_int,
 ) -> CassError {
-    let cluster = BoxFFI::as_ref(cluster_raw);
+    let cluster = BoxFFI::as_ref(cluster_raw).unwrap();
 
     if protocol_version == 4 && !cluster.use_beta_protocol_version {
         // Rust Driver supports only protocol version 4
@@ -734,7 +738,7 @@ pub unsafe extern "C" fn cass_cluster_set_protocol_version(
 
 #[no_mangle]
 pub extern "C" fn cass_cluster_set_queue_size_event(
-    _cluster: *mut CassCluster,
+    _cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     _queue_size: c_uint,
 ) -> CassError {
     // In Cpp Driver this function is also a no-op...
@@ -743,7 +747,7 @@ pub extern "C" fn cass_cluster_set_queue_size_event(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_constant_speculative_execution_policy(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     constant_delay_ms: cass_int64_t,
     max_speculative_executions: c_int,
 ) -> CassError {
@@ -751,7 +755,7 @@ pub unsafe extern "C" fn cass_cluster_set_constant_speculative_execution_policy(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
 
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
     let policy = SimpleSpeculativeExecutionPolicy {
         max_retry_count: max_speculative_executions as usize,
@@ -767,9 +771,9 @@ pub unsafe extern "C" fn cass_cluster_set_constant_speculative_execution_policy(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_no_speculative_execution_policy(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
     exec_profile_builder_modify(&mut cluster.default_execution_profile_builder, |builder| {
         builder.speculative_execution_policy(None)
@@ -780,19 +784,19 @@ pub unsafe extern "C" fn cass_cluster_set_no_speculative_execution_policy(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_token_aware_routing(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     cluster.load_balancing_config.token_awareness_enabled = enabled != 0;
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_token_aware_routing_shuffle_replicas(
-    cluster_raw: *mut CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
     cluster
         .load_balancing_config
@@ -801,12 +805,12 @@ pub unsafe extern "C" fn cass_cluster_set_token_aware_routing_shuffle_replicas(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_retry_policy(
-    cluster_raw: *mut CassCluster,
-    retry_policy: *const CassRetryPolicy,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
+    retry_policy: CassBorrowedSharedPtr<CassRetryPolicy, CMut>,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw);
+    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
-    let retry_policy: Arc<dyn RetryPolicy> = match ArcFFI::as_ref(retry_policy) {
+    let retry_policy: Arc<dyn RetryPolicy> = match ArcFFI::as_ref(retry_policy).unwrap() {
         DefaultRetryPolicy(default) => Arc::clone(default) as _,
         FallthroughRetryPolicy(fallthrough) => Arc::clone(fallthrough) as _,
         DowngradingConsistencyRetryPolicy(downgrading) => Arc::clone(downgrading) as _,
@@ -818,9 +822,12 @@ pub unsafe extern "C" fn cass_cluster_set_retry_policy(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_cluster_set_ssl(cluster: *mut CassCluster, ssl: *mut CassSsl) {
-    let cluster_from_raw = BoxFFI::as_mut_ref(cluster);
-    let cass_ssl = ArcFFI::cloned_from_ptr(ssl);
+pub unsafe extern "C" fn cass_cluster_set_ssl(
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
+    ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
+) {
+    let cluster_from_raw = BoxFFI::as_mut_ref(cluster).unwrap();
+    let cass_ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
 
     let ssl_context_builder = SslContextBuilder::from_ptr(cass_ssl.ssl_context);
     // Reference count is increased as tokio_openssl will try to free `ssl_context` when calling `SSL_free`.
@@ -831,10 +838,10 @@ pub unsafe extern "C" fn cass_cluster_set_ssl(cluster: *mut CassCluster, ssl: *m
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_compression(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     compression_type: CassCompressionType,
 ) {
-    let cluster_from_raw = BoxFFI::as_mut_ref(cluster);
+    let cluster_from_raw = BoxFFI::as_mut_ref(cluster).unwrap();
     let compression = match compression_type {
         CassCompressionType::CASS_COMPRESSION_LZ4 => Some(Compression::Lz4),
         CassCompressionType::CASS_COMPRESSION_SNAPPY => Some(Compression::Snappy),
@@ -846,23 +853,23 @@ pub unsafe extern "C" fn cass_cluster_set_compression(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster);
+    let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
     cluster.load_balancing_config.latency_awareness_enabled = enabled != 0;
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing_settings(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     exclusion_threshold: cass_double_t,
     scale_ms: cass_uint64_t,
     retry_period_ms: cass_uint64_t,
     update_rate_ms: cass_uint64_t,
     min_measured: cass_uint64_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster);
+    let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
     cluster.load_balancing_config.latency_awareness_builder = LatencyAwarenessBuilder::new()
         .exclusion_threshold(exclusion_threshold)
         .scale(Duration::from_millis(scale_ms))
@@ -873,10 +880,10 @@ pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing_settings(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_consistency(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     consistency: CassConsistency,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster);
+    let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
     let consistency: Consistency = match consistency.try_into() {
         Ok(c) => c,
         Err(_) => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
@@ -891,10 +898,10 @@ pub unsafe extern "C" fn cass_cluster_set_consistency(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_serial_consistency(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     serial_consistency: CassConsistency,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster);
+    let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
     let serial_consistency: SerialConsistency = match serial_consistency.try_into() {
         Ok(c) => c,
         Err(_) => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
@@ -909,21 +916,21 @@ pub unsafe extern "C" fn cass_cluster_set_serial_consistency(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_execution_profile(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     name: *const c_char,
-    profile: *const CassExecProfile,
+    profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
 ) -> CassError {
     cass_cluster_set_execution_profile_n(cluster, name, strlen(name), profile)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
-    cluster: *mut CassCluster,
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     name: *const c_char,
     name_length: size_t,
-    profile: *const CassExecProfile,
+    profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster);
+    let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
     let name = if let Some(name) =
         ptr_to_cstr_n(name, name_length).and_then(|name| name.to_owned().try_into().ok())
     {
@@ -932,7 +939,7 @@ pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
         // Got NULL or empty string, which is invalid name for a profile.
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
-    let profile = if let Some(profile) = BoxFFI::as_maybe_ref(profile) {
+    let profile = if let Some(profile) = BoxFFI::as_ref(profile) {
         profile.clone()
     } else {
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
@@ -964,26 +971,31 @@ mod tests {
     #[ntest::timeout(100)]
     fn test_load_balancing_config() {
         unsafe {
-            let cluster_raw = cass_cluster_new();
+            let mut cluster_raw = cass_cluster_new();
             {
                 /* Test valid configurations */
-                let cluster = BoxFFI::as_ref(cluster_raw);
                 {
+                    let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                     assert_matches!(cluster.load_balancing_config.load_balancing_kind, None);
                     assert!(cluster.load_balancing_config.token_awareness_enabled);
                     assert!(!cluster.load_balancing_config.latency_awareness_enabled);
                 }
                 {
-                    cass_cluster_set_token_aware_routing(cluster_raw, 0);
+                    cass_cluster_set_token_aware_routing(cluster_raw.borrow_mut(), 0);
                     assert_cass_error_eq!(
-                        cass_cluster_set_load_balance_dc_aware(cluster_raw, c"eu".as_ptr(), 0, 0),
+                        cass_cluster_set_load_balance_dc_aware(
+                            cluster_raw.borrow_mut(),
+                            c"eu".as_ptr(),
+                            0,
+                            0
+                        ),
                         CassError::CASS_OK
                     );
-                    cass_cluster_set_latency_aware_routing(cluster_raw, 1);
+                    cass_cluster_set_latency_aware_routing(cluster_raw.borrow_mut(), 1);
                     // These values cannot currently be tested to be set properly in the latency awareness builder,
                     // but at least we test that the function completed successfully.
                     cass_cluster_set_latency_aware_routing_settings(
-                        cluster_raw,
+                        cluster_raw.borrow_mut(),
                         2.,
                         1,
                         2000,
@@ -991,6 +1003,7 @@ mod tests {
                         40,
                     );
 
+                    let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                     let load_balancing_kind = &cluster.load_balancing_config.load_balancing_kind;
                     match load_balancing_kind {
                         Some(LoadBalancingKind::DcAware { local_dc }) => {
@@ -1004,13 +1017,14 @@ mod tests {
                     // set preferred rack+dc
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_rack_aware(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             c"eu-east".as_ptr(),
                             c"rack1".as_ptr(),
                         ),
                         CassError::CASS_OK
                     );
 
+                    let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                     let node_location_preference =
                         &cluster.load_balancing_config.load_balancing_kind;
                     match node_location_preference {
@@ -1026,10 +1040,16 @@ mod tests {
 
                     // set back to preferred dc
                     assert_cass_error_eq!(
-                        cass_cluster_set_load_balance_dc_aware(cluster_raw, c"eu".as_ptr(), 0, 0),
+                        cass_cluster_set_load_balance_dc_aware(
+                            cluster_raw.borrow_mut(),
+                            c"eu".as_ptr(),
+                            0,
+                            0
+                        ),
                         CassError::CASS_OK
                     );
 
+                    let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                     let node_location_preference =
                         &cluster.load_balancing_config.load_balancing_kind;
                     match node_location_preference {
@@ -1043,22 +1063,37 @@ mod tests {
                 {
                     // Nonzero deprecated parameters
                     assert_cass_error_eq!(
-                        cass_cluster_set_load_balance_dc_aware(cluster_raw, c"eu".as_ptr(), 1, 0),
+                        cass_cluster_set_load_balance_dc_aware(
+                            cluster_raw.borrow_mut(),
+                            c"eu".as_ptr(),
+                            1,
+                            0
+                        ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
                     assert_cass_error_eq!(
-                        cass_cluster_set_load_balance_dc_aware(cluster_raw, c"eu".as_ptr(), 0, 1),
+                        cass_cluster_set_load_balance_dc_aware(
+                            cluster_raw.borrow_mut(),
+                            c"eu".as_ptr(),
+                            0,
+                            1
+                        ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
 
                     // null pointers
                     assert_cass_error_eq!(
-                        cass_cluster_set_load_balance_dc_aware(cluster_raw, std::ptr::null(), 0, 0),
+                        cass_cluster_set_load_balance_dc_aware(
+                            cluster_raw.borrow_mut(),
+                            std::ptr::null(),
+                            0,
+                            0
+                        ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_rack_aware(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             c"eu".as_ptr(),
                             std::ptr::null(),
                         ),
@@ -1066,7 +1101,7 @@ mod tests {
                     );
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_rack_aware(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             std::ptr::null(),
                             c"rack".as_ptr(),
                         ),
@@ -1078,12 +1113,17 @@ mod tests {
                     #[allow(clippy::manual_c_str_literals)]
                     let empty_str = "\0".as_ptr() as *const i8;
                     assert_cass_error_eq!(
-                        cass_cluster_set_load_balance_dc_aware(cluster_raw, std::ptr::null(), 0, 0),
+                        cass_cluster_set_load_balance_dc_aware(
+                            cluster_raw.borrow_mut(),
+                            std::ptr::null(),
+                            0,
+                            0
+                        ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_rack_aware(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             c"eu".as_ptr(),
                             empty_str,
                         ),
@@ -1091,7 +1131,7 @@ mod tests {
                     );
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_rack_aware(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             empty_str,
                             c"rack".as_ptr(),
                         ),
@@ -1108,23 +1148,25 @@ mod tests {
     #[ntest::timeout(100)]
     fn test_register_exec_profile() {
         unsafe {
-            let cluster_raw = cass_cluster_new();
-            let exec_profile_raw = cass_execution_profile_new();
+            let mut cluster_raw = cass_cluster_new();
+            let mut exec_profile_raw = cass_execution_profile_new();
             {
                 /* Test valid configurations */
-                let cluster = BoxFFI::as_ref(cluster_raw);
                 {
+                    let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                     assert!(cluster.execution_profile_map.is_empty());
                 }
                 {
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             make_c_str!("profile1"),
-                            exec_profile_raw
+                            exec_profile_raw.borrow_mut()
                         ),
                         CassError::CASS_OK
                     );
+
+                    let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                     assert!(cluster.execution_profile_map.len() == 1);
                     let _profile = cluster
                         .execution_profile_map
@@ -1134,13 +1176,15 @@ mod tests {
                     let (c_str, c_strlen) = str_to_c_str_n("profile1");
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile_n(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             c_str,
                             c_strlen,
-                            exec_profile_raw
+                            exec_profile_raw.borrow_mut()
                         ),
                         CassError::CASS_OK
                     );
+
+                    let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                     assert!(cluster.execution_profile_map.len() == 1);
                     let _profile = cluster
                         .execution_profile_map
@@ -1149,12 +1193,14 @@ mod tests {
 
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             make_c_str!("profile2"),
-                            exec_profile_raw
+                            exec_profile_raw.borrow_mut()
                         ),
                         CassError::CASS_OK
                     );
+
+                    let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                     assert!(cluster.execution_profile_map.len() == 2);
                     let _profile = cluster
                         .execution_profile_map
@@ -1167,9 +1213,9 @@ mod tests {
                     // NULL name
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             std::ptr::null(),
-                            exec_profile_raw
+                            exec_profile_raw.borrow_mut()
                         ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
@@ -1178,9 +1224,9 @@ mod tests {
                     // empty name
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             make_c_str!(""),
-                            exec_profile_raw
+                            exec_profile_raw.borrow_mut()
                         ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
@@ -1189,14 +1235,16 @@ mod tests {
                     // NULL profile
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile(
-                            cluster_raw,
+                            cluster_raw.borrow_mut(),
                             make_c_str!("profile1"),
-                            std::ptr::null()
+                            BoxFFI::null_mut(),
                         ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
                 }
                 // Make sure that invalid configuration did not influence the profile map
+
+                let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                 assert_eq!(
                     cluster
                         .execution_profile_map

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -167,7 +167,9 @@ impl CassCluster {
     }
 }
 
-impl BoxFFI for CassCluster {}
+impl FFI for CassCluster {
+    type Origin = FromBox;
+}
 
 pub struct CassCustomPayload;
 

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -36,7 +36,9 @@ pub struct CassCollection {
     pub items: Vec<CassCqlValue>,
 }
 
-impl BoxFFI for CassCollection {}
+impl FFI for CassCollection {
+    type Origin = FromBox;
+}
 
 impl CassCollection {
     fn typecheck_on_append(&self, value: &Option<CassCqlValue>) -> CassError {

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -137,7 +137,7 @@ impl TryFrom<&CassCollection> for CassCqlValue {
 pub unsafe extern "C" fn cass_collection_new(
     collection_type: CassCollectionType,
     item_count: size_t,
-) -> *mut CassCollection {
+) -> CassOwnedExclusivePtr<CassCollection, CMut> {
     let capacity = match collection_type {
         // Maps consist of a key and a value, so twice
         // the number of CassCqlValue will be stored.
@@ -155,10 +155,10 @@ pub unsafe extern "C" fn cass_collection_new(
 
 #[no_mangle]
 unsafe extern "C" fn cass_collection_new_from_data_type(
-    data_type: *const CassDataType,
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     item_count: size_t,
-) -> *mut CassCollection {
-    let data_type = ArcFFI::cloned_from_ptr(data_type);
+) -> CassOwnedExclusivePtr<CassCollection, CMut> {
+    let data_type = ArcFFI::cloned_from_ptr(data_type).unwrap();
     let (capacity, collection_type) = match data_type.get_unchecked() {
         CassDataTypeInner::List { .. } => {
             (item_count, CassCollectionType::CASS_COLLECTION_TYPE_LIST)
@@ -169,7 +169,7 @@ unsafe extern "C" fn cass_collection_new_from_data_type(
         CassDataTypeInner::Map { .. } => {
             (item_count * 2, CassCollectionType::CASS_COLLECTION_TYPE_MAP)
         }
-        _ => return std::ptr::null_mut(),
+        _ => return BoxFFI::null_mut(),
     };
     let capacity = capacity as usize;
 
@@ -183,9 +183,9 @@ unsafe extern "C" fn cass_collection_new_from_data_type(
 
 #[no_mangle]
 unsafe extern "C" fn cass_collection_data_type(
-    collection: *const CassCollection,
-) -> *const CassDataType {
-    let collection_ref = BoxFFI::as_ref(collection);
+    collection: CassBorrowedSharedPtr<CassCollection, CConst>,
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+    let collection_ref = BoxFFI::as_ref(collection).unwrap();
 
     match &collection_ref.data_type {
         Some(dt) => ArcFFI::as_ptr(dt),
@@ -203,7 +203,9 @@ unsafe extern "C" fn cass_collection_data_type(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_collection_free(collection: *mut CassCollection) {
+pub unsafe extern "C" fn cass_collection_free(
+    collection: CassOwnedExclusivePtr<CassCollection, CMut>,
+) {
     BoxFFI::free(collection);
 }
 
@@ -253,22 +255,22 @@ mod tests {
         unsafe {
             // untyped map (via cass_collection_new, Collection's data type is None).
             {
-                let untyped_map =
+                let mut untyped_map =
                     cass_collection_new(CassCollectionType::CASS_COLLECTION_TYPE_MAP, 2);
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(untyped_map, false as cass_bool_t),
+                    cass_collection_append_bool(untyped_map.borrow_mut(), false as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_int16(untyped_map, 42),
+                    cass_collection_append_int16(untyped_map.borrow_mut(), 42),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_double(untyped_map, 42.42),
+                    cass_collection_append_double(untyped_map.borrow_mut(), 42.42),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_float(untyped_map, 42.42),
+                    cass_collection_append_float(untyped_map.borrow_mut(), 42.42),
                     CassError::CASS_OK
                 );
                 cass_collection_free(untyped_map);
@@ -282,22 +284,22 @@ mod tests {
                 });
 
                 let dt_ptr = ArcFFI::into_ptr(dt);
-                let untyped_map = cass_collection_new_from_data_type(dt_ptr, 2);
+                let mut untyped_map = cass_collection_new_from_data_type(dt_ptr.borrow(), 2);
 
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(untyped_map, false as cass_bool_t),
+                    cass_collection_append_bool(untyped_map.borrow_mut(), false as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_int16(untyped_map, 42),
+                    cass_collection_append_int16(untyped_map.borrow_mut(), 42),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_double(untyped_map, 42.42),
+                    cass_collection_append_double(untyped_map.borrow_mut(), 42.42),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_float(untyped_map, 42.42),
+                    cass_collection_append_float(untyped_map.borrow_mut(), 42.42),
                     CassError::CASS_OK
                 );
                 cass_collection_free(untyped_map);
@@ -313,30 +315,30 @@ mod tests {
                 });
 
                 let dt_ptr = ArcFFI::into_ptr(dt);
-                let half_typed_map = cass_collection_new_from_data_type(dt_ptr, 2);
+                let mut half_typed_map = cass_collection_new_from_data_type(dt_ptr.borrow(), 2);
 
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(half_typed_map, false as cass_bool_t),
+                    cass_collection_append_bool(half_typed_map.borrow_mut(), false as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_int16(half_typed_map, 42),
+                    cass_collection_append_int16(half_typed_map.borrow_mut(), 42),
                     CassError::CASS_OK
                 );
 
                 // Second entry -> key typecheck failed.
                 assert_cass_error_eq!(
-                    cass_collection_append_double(half_typed_map, 42.42),
+                    cass_collection_append_double(half_typed_map.borrow_mut(), 42.42),
                     CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE
                 );
 
                 // Second entry -> typecheck succesful.
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(half_typed_map, true as cass_bool_t),
+                    cass_collection_append_bool(half_typed_map.borrow_mut(), true as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_double(half_typed_map, 42.42),
+                    cass_collection_append_double(half_typed_map.borrow_mut(), 42.42),
                     CassError::CASS_OK
                 );
                 cass_collection_free(half_typed_map);
@@ -356,31 +358,31 @@ mod tests {
                     frozen: false,
                 });
                 let dt_ptr = ArcFFI::into_ptr(dt);
-                let bool_to_i16_map = cass_collection_new_from_data_type(dt_ptr, 2);
+                let mut bool_to_i16_map = cass_collection_new_from_data_type(dt_ptr.borrow(), 2);
 
                 // First entry -> typecheck successful.
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(bool_to_i16_map, false as cass_bool_t),
+                    cass_collection_append_bool(bool_to_i16_map.borrow_mut(), false as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_int16(bool_to_i16_map, 42),
+                    cass_collection_append_int16(bool_to_i16_map.borrow_mut(), 42),
                     CassError::CASS_OK
                 );
 
                 // Second entry -> key typecheck failed.
                 assert_cass_error_eq!(
-                    cass_collection_append_float(bool_to_i16_map, 42.42),
+                    cass_collection_append_float(bool_to_i16_map.borrow_mut(), 42.42),
                     CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE
                 );
 
                 // Third entry -> value typecheck failed.
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(bool_to_i16_map, true as cass_bool_t),
+                    cass_collection_append_bool(bool_to_i16_map.borrow_mut(), true as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_float(bool_to_i16_map, 42.42),
+                    cass_collection_append_float(bool_to_i16_map.borrow_mut(), 42.42),
                     CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE
                 );
 
@@ -390,14 +392,14 @@ mod tests {
 
             // untyped set (via cass_collection_new, collection's type is None)
             {
-                let untyped_set =
+                let mut untyped_set =
                     cass_collection_new(CassCollectionType::CASS_COLLECTION_TYPE_SET, 2);
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(untyped_set, false as cass_bool_t),
+                    cass_collection_append_bool(untyped_set.borrow_mut(), false as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_int16(untyped_set, 42),
+                    cass_collection_append_int16(untyped_set.borrow_mut(), 42),
                     CassError::CASS_OK
                 );
                 cass_collection_free(untyped_set);
@@ -411,14 +413,14 @@ mod tests {
                 });
 
                 let dt_ptr = ArcFFI::into_ptr(dt);
-                let untyped_set = cass_collection_new_from_data_type(dt_ptr, 2);
+                let mut untyped_set = cass_collection_new_from_data_type(dt_ptr.borrow(), 2);
 
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(untyped_set, false as cass_bool_t),
+                    cass_collection_append_bool(untyped_set.borrow_mut(), false as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_int16(untyped_set, 42),
+                    cass_collection_append_int16(untyped_set.borrow_mut(), 42),
                     CassError::CASS_OK
                 );
                 cass_collection_free(untyped_set);
@@ -433,14 +435,14 @@ mod tests {
                     frozen: false,
                 });
                 let dt_ptr = ArcFFI::into_ptr(dt);
-                let bool_set = cass_collection_new_from_data_type(dt_ptr, 2);
+                let mut bool_set = cass_collection_new_from_data_type(dt_ptr.borrow(), 2);
 
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(bool_set, true as cass_bool_t),
+                    cass_collection_append_bool(bool_set.borrow_mut(), true as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_float(bool_set, 42.42),
+                    cass_collection_append_float(bool_set.borrow_mut(), 42.42),
                     CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE
                 );
 
@@ -450,14 +452,14 @@ mod tests {
 
             // untyped list (via cass_collection_new, collection's type is None)
             {
-                let untyped_list =
+                let mut untyped_list =
                     cass_collection_new(CassCollectionType::CASS_COLLECTION_TYPE_LIST, 2);
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(untyped_list, false as cass_bool_t),
+                    cass_collection_append_bool(untyped_list.borrow_mut(), false as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_int16(untyped_list, 42),
+                    cass_collection_append_int16(untyped_list.borrow_mut(), 42),
                     CassError::CASS_OK
                 );
                 cass_collection_free(untyped_list);
@@ -471,14 +473,14 @@ mod tests {
                 });
 
                 let dt_ptr = ArcFFI::into_ptr(dt);
-                let untyped_list = cass_collection_new_from_data_type(dt_ptr, 2);
+                let mut untyped_list = cass_collection_new_from_data_type(dt_ptr.borrow(), 2);
 
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(untyped_list, false as cass_bool_t),
+                    cass_collection_append_bool(untyped_list.borrow_mut(), false as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_int16(untyped_list, 42),
+                    cass_collection_append_int16(untyped_list.borrow_mut(), 42),
                     CassError::CASS_OK
                 );
                 cass_collection_free(untyped_list);
@@ -493,14 +495,14 @@ mod tests {
                     frozen: false,
                 });
                 let dt_ptr = ArcFFI::into_ptr(dt);
-                let bool_list = cass_collection_new_from_data_type(dt_ptr, 2);
+                let mut bool_list = cass_collection_new_from_data_type(dt_ptr.borrow(), 2);
 
                 assert_cass_error_eq!(
-                    cass_collection_append_bool(bool_list, true as cass_bool_t),
+                    cass_collection_append_bool(bool_list.borrow_mut(), true as cass_bool_t),
                     CassError::CASS_OK
                 );
                 assert_cass_error_eq!(
-                    cass_collection_append_float(bool_list, 42.42),
+                    cass_collection_append_float(bool_list.borrow_mut(), 42.42),
                     CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE
                 );
 
@@ -519,12 +521,12 @@ mod tests {
             let empty_list = cass_collection_new(CassCollectionType::CASS_COLLECTION_TYPE_LIST, 2);
 
             // This would previously return a non Arc-based pointer.
-            let empty_list_dt = cass_collection_data_type(empty_list);
+            let empty_list_dt = cass_collection_data_type(empty_list.borrow().into_c_const());
 
             let empty_set_dt = cass_data_type_new(CassValueType::CASS_VALUE_TYPE_SET);
             // This will try to increment the reference count of `empty_list_dt`.
             // Previously, this would fail, because `empty_list_dt` did not originate from an Arc allocation.
-            cass_data_type_add_sub_type(empty_set_dt, empty_list_dt);
+            cass_data_type_add_sub_type(empty_set_dt.borrow(), empty_list_dt);
 
             cass_data_type_free(empty_set_dt)
         }

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -15,7 +15,7 @@ use scylla::statement::Consistency;
 
 use crate::argconv::{
     ptr_to_cstr_n, strlen, ArcFFI, BoxFFI, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr,
-    CassOwnedExclusivePtr,
+    CassOwnedExclusivePtr, FromBox, FFI,
 };
 use crate::batch::CassBatch;
 use crate::cass_error::CassError;
@@ -40,7 +40,9 @@ pub struct CassExecProfile {
     load_balancing_config: LoadBalancingConfig,
 }
 
-impl BoxFFI for CassExecProfile {}
+impl FFI for CassExecProfile {
+    type Origin = FromBox;
+}
 
 impl CassExecProfile {
     fn new() -> Self {

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -27,8 +27,9 @@ type CassFutureError = (CassError, String);
 
 pub type CassFutureResult = Result<CassResultValue, CassFutureError>;
 
-pub type CassFutureCallback =
-    Option<unsafe extern "C" fn(future: *mut CassFuture, data: *mut c_void)>;
+pub type CassFutureCallback = Option<
+    unsafe extern "C" fn(future: CassBorrowedSharedPtr<CassFuture, CMut>, data: *mut c_void),
+>;
 
 struct BoundCallback {
     pub cb: CassFutureCallback,
@@ -40,8 +41,10 @@ struct BoundCallback {
 unsafe impl Send for BoundCallback {}
 
 impl BoundCallback {
-    unsafe fn invoke(self, fut_ptr: *mut CassFuture) {
-        self.cb.unwrap()(fut_ptr, self.data);
+    fn invoke(self, fut_ptr: CassBorrowedSharedPtr<CassFuture, CMut>) {
+        unsafe {
+            self.cb.unwrap()(fut_ptr, self.data);
+        }
     }
 }
 
@@ -73,8 +76,8 @@ struct JoinHandleTimeout(JoinHandle<()>);
 impl CassFuture {
     pub fn make_raw(
         fut: impl Future<Output = CassFutureResult> + Send + 'static,
-    ) -> *mut CassFuture {
-        Self::new_from_future(fut).into_raw() as *mut _
+    ) -> CassOwnedSharedPtr<CassFuture, CMut> {
+        Self::new_from_future(fut).into_raw()
     }
 
     pub fn new_from_future(
@@ -94,11 +97,9 @@ impl CassFuture {
                 guard.callback.take()
             };
             if let Some(bound_cb) = maybe_cb {
-                let fut_ptr = ArcFFI::as_ptr(&cass_fut_clone) as *mut _;
+                let fut_ptr = ArcFFI::as_ptr::<CMut>(&cass_fut_clone);
                 // Safety: pointer is valid, because we get it from arc allocation.
-                unsafe {
-                    bound_cb.invoke(fut_ptr);
-                }
+                bound_cb.invoke(fut_ptr);
             }
 
             cass_fut_clone.wait_for_value.notify_all();
@@ -262,7 +263,7 @@ impl CassFuture {
 
     pub unsafe fn set_callback(
         &self,
-        self_ptr: *mut CassFuture,
+        self_ptr: CassBorrowedSharedPtr<CassFuture, CMut>,
         cb: CassFutureCallback,
         data: *mut c_void,
     ) -> CassError {
@@ -283,7 +284,7 @@ impl CassFuture {
         CassError::CASS_OK
     }
 
-    fn into_raw(self: Arc<Self>) -> *const Self {
+    fn into_raw(self: Arc<Self>) -> CassOwnedSharedPtr<Self, CMut> {
         ArcFFI::into_ptr(self)
     }
 }
@@ -296,31 +297,38 @@ impl CheckSendSync for CassFuture {}
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_future_set_callback(
-    future_raw: *mut CassFuture,
+    future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
     callback: CassFutureCallback,
     data: *mut ::std::os::raw::c_void,
 ) -> CassError {
-    ArcFFI::as_ref(future_raw).set_callback(future_raw, callback, data)
+    ArcFFI::as_ref(future_raw.borrow())
+        .unwrap()
+        .set_callback(future_raw.borrow(), callback, data)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_future_wait(future_raw: *mut CassFuture) {
-    ArcFFI::as_ref(future_raw).with_waited_result(|_| ());
+pub unsafe extern "C" fn cass_future_wait(future_raw: CassBorrowedSharedPtr<CassFuture, CMut>) {
+    ArcFFI::as_ref(future_raw)
+        .unwrap()
+        .with_waited_result(|_| ());
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_future_wait_timed(
-    future_raw: *mut CassFuture,
+    future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
     timeout_us: cass_duration_t,
 ) -> cass_bool_t {
     ArcFFI::as_ref(future_raw)
+        .unwrap()
         .with_waited_result_timed(|_| (), Duration::from_micros(timeout_us))
         .is_ok() as cass_bool_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_future_ready(future_raw: *mut CassFuture) -> cass_bool_t {
-    let state_guard = ArcFFI::as_ref(future_raw).state.lock().unwrap();
+pub unsafe extern "C" fn cass_future_ready(
+    future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
+) -> cass_bool_t {
+    let state_guard = ArcFFI::as_ref(future_raw).unwrap().state.lock().unwrap();
     match state_guard.value {
         None => cass_false,
         Some(_) => cass_true,
@@ -328,93 +336,106 @@ pub unsafe extern "C" fn cass_future_ready(future_raw: *mut CassFuture) -> cass_
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_future_error_code(future_raw: *mut CassFuture) -> CassError {
-    ArcFFI::as_ref(future_raw).with_waited_result(|r: &mut CassFutureResult| match r {
-        Ok(CassResultValue::QueryError(err)) => err.to_cass_error(),
-        Err((err, _)) => *err,
-        _ => CassError::CASS_OK,
-    })
+pub unsafe extern "C" fn cass_future_error_code(
+    future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
+) -> CassError {
+    ArcFFI::as_ref(future_raw)
+        .unwrap()
+        .with_waited_result(|r: &mut CassFutureResult| match r {
+            Ok(CassResultValue::QueryError(err)) => err.to_cass_error(),
+            Err((err, _)) => *err,
+            _ => CassError::CASS_OK,
+        })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_future_error_message(
-    future: *mut CassFuture,
+    future: CassBorrowedSharedPtr<CassFuture, CMut>,
     message: *mut *const ::std::os::raw::c_char,
     message_length: *mut size_t,
 ) {
-    ArcFFI::as_ref(future).with_waited_state(|state: &mut CassFutureState| {
-        let value = &state.value;
-        let msg = state
-            .err_string
-            .get_or_insert_with(|| match value.as_ref().unwrap() {
-                Ok(CassResultValue::QueryError(err)) => err.msg(),
-                Err((_, s)) => s.msg(),
-                _ => "".to_string(),
-            });
-        write_str_to_c(msg.as_str(), message, message_length);
-    });
+    ArcFFI::as_ref(future)
+        .unwrap()
+        .with_waited_state(|state: &mut CassFutureState| {
+            let value = &state.value;
+            let msg = state
+                .err_string
+                .get_or_insert_with(|| match value.as_ref().unwrap() {
+                    Ok(CassResultValue::QueryError(err)) => err.msg(),
+                    Err((_, s)) => s.msg(),
+                    _ => "".to_string(),
+                });
+            write_str_to_c(msg.as_str(), message, message_length);
+        });
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_future_free(future_raw: *mut CassFuture) {
+pub unsafe extern "C" fn cass_future_free(future_raw: CassOwnedSharedPtr<CassFuture, CMut>) {
     ArcFFI::free(future_raw);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_future_get_result(future_raw: *mut CassFuture) -> *const CassResult {
+pub unsafe extern "C" fn cass_future_get_result(
+    future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
+) -> CassOwnedSharedPtr<CassResult, CConst> {
     ArcFFI::as_ref(future_raw)
+        .unwrap()
         .with_waited_result(|r: &mut CassFutureResult| -> Option<Arc<CassResult>> {
             match r.as_ref().ok()? {
                 CassResultValue::QueryResult(qr) => Some(Arc::clone(qr)),
                 _ => None,
             }
         })
-        .map_or(std::ptr::null(), ArcFFI::into_ptr)
+        .map_or(ArcFFI::null(), ArcFFI::into_ptr)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_future_get_error_result(
-    future_raw: *mut CassFuture,
-) -> *const CassErrorResult {
+    future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
+) -> CassOwnedSharedPtr<CassErrorResult, CConst> {
     ArcFFI::as_ref(future_raw)
+        .unwrap()
         .with_waited_result(|r: &mut CassFutureResult| -> Option<Arc<CassErrorResult>> {
             match r.as_ref().ok()? {
                 CassResultValue::QueryError(qr) => Some(Arc::clone(qr)),
                 _ => None,
             }
         })
-        .map_or(std::ptr::null(), ArcFFI::into_ptr)
+        .map_or(ArcFFI::null(), ArcFFI::into_ptr)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_future_get_prepared(
-    future_raw: *mut CassFuture,
-) -> *const CassPrepared {
+    future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
+) -> CassOwnedSharedPtr<CassPrepared, CConst> {
     ArcFFI::as_ref(future_raw)
+        .unwrap()
         .with_waited_result(|r: &mut CassFutureResult| -> Option<Arc<CassPrepared>> {
             match r.as_ref().ok()? {
                 CassResultValue::Prepared(p) => Some(Arc::clone(p)),
                 _ => None,
             }
         })
-        .map_or(std::ptr::null(), ArcFFI::into_ptr)
+        .map_or(ArcFFI::null(), ArcFFI::into_ptr)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_future_tracing_id(
-    future: *mut CassFuture,
+    future: CassBorrowedSharedPtr<CassFuture, CMut>,
     tracing_id: *mut CassUuid,
 ) -> CassError {
-    ArcFFI::as_ref(future).with_waited_result(|r: &mut CassFutureResult| match r {
-        Ok(CassResultValue::QueryResult(result)) => match result.tracing_id {
-            Some(id) => {
-                *tracing_id = CassUuid::from(id);
-                CassError::CASS_OK
-            }
-            None => CassError::CASS_ERROR_LIB_NO_TRACING_ID,
-        },
-        _ => CassError::CASS_ERROR_LIB_INVALID_FUTURE_TYPE,
-    })
+    ArcFFI::as_ref(future)
+        .unwrap()
+        .with_waited_result(|r: &mut CassFutureResult| match r {
+            Ok(CassResultValue::QueryResult(result)) => match result.tracing_id {
+                Some(id) => {
+                    *tracing_id = CassUuid::from(id);
+                    CassError::CASS_OK
+                }
+                None => CassError::CASS_ERROR_LIB_NO_TRACING_ID,
+            },
+            _ => CassError::CASS_ERROR_LIB_INVALID_FUTURE_TYPE,
+        })
 }
 
 #[cfg(test)]
@@ -442,12 +463,18 @@ mod tests {
         };
         let cass_fut = CassFuture::make_raw(fut);
 
-        struct PtrWrapper(*mut CassFuture);
+        struct PtrWrapper(CassBorrowedSharedPtr<'static, CassFuture, CMut>);
         unsafe impl Send for PtrWrapper {}
-        let wrapped_cass_fut = PtrWrapper(cass_fut);
         unsafe {
+            // transmute to erase the lifetime to 'static, so the reference
+            // can be passed to an async block.
+            let static_cass_fut_ref = std::mem::transmute::<
+                CassBorrowedSharedPtr<'_, CassFuture, CMut>,
+                CassBorrowedSharedPtr<'static, CassFuture, CMut>,
+            >(cass_fut.borrow());
+            let wrapped_cass_fut = PtrWrapper(static_cass_fut_ref);
             let handle = thread::spawn(move || {
-                let wrapper = wrapped_cass_fut;
+                let wrapper = &wrapped_cass_fut;
                 let PtrWrapper(cass_fut) = wrapper;
                 assert_cass_future_error_message_eq!(cass_fut, Some(ERROR_MSG));
             });
@@ -473,11 +500,13 @@ mod tests {
 
         unsafe {
             // This should timeout on tokio::time::timeout.
-            let timed_result = cass_future_wait_timed(cass_fut, HUNDRED_MILLIS_IN_MICROS / 5);
+            let timed_result =
+                cass_future_wait_timed(cass_fut.borrow(), HUNDRED_MILLIS_IN_MICROS / 5);
             assert_eq!(0, timed_result);
 
             // This should timeout as well.
-            let timed_result = cass_future_wait_timed(cass_fut, HUNDRED_MILLIS_IN_MICROS / 5);
+            let timed_result =
+                cass_future_wait_timed(cass_fut.borrow(), HUNDRED_MILLIS_IN_MICROS / 5);
             assert_eq!(0, timed_result);
 
             // Verify that future eventually resolves, even though timeouts occurred before.
@@ -501,7 +530,10 @@ mod tests {
             const HUNDRED_MILLIS_IN_MICROS: u64 = 100 * 1000;
 
             let create_future_and_flag = || {
-                unsafe extern "C" fn mark_flag_cb(_fut: *mut CassFuture, data: *mut c_void) {
+                unsafe extern "C" fn mark_flag_cb(
+                    _fut: CassBorrowedSharedPtr<CassFuture, CMut>,
+                    data: *mut c_void,
+                ) {
                     let flag = data as *mut bool;
                     *flag = true;
                 }
@@ -515,7 +547,11 @@ mod tests {
                 let flag_ptr = Box::into_raw(flag);
 
                 assert_cass_error_eq!(
-                    cass_future_set_callback(cass_fut, Some(mark_flag_cb), flag_ptr as *mut c_void),
+                    cass_future_set_callback(
+                        cass_fut.borrow(),
+                        Some(mark_flag_cb),
+                        flag_ptr as *mut c_void
+                    ),
                     CassError::CASS_OK
                 );
 
@@ -525,7 +561,7 @@ mod tests {
             // Callback executed after awaiting.
             {
                 let (cass_fut, flag_ptr) = create_future_and_flag();
-                cass_future_wait(cass_fut);
+                cass_future_wait(cass_fut.borrow());
 
                 assert_cass_future_error_message_eq!(cass_fut, Some(ERROR_MSG));
                 assert!(*flag_ptr);
@@ -550,10 +586,12 @@ mod tests {
                 let (cass_fut, flag_ptr) = create_future_and_flag();
 
                 // This should timeout on tokio::time::timeout.
-                let timed_result = cass_future_wait_timed(cass_fut, HUNDRED_MILLIS_IN_MICROS / 5);
+                let timed_result =
+                    cass_future_wait_timed(cass_fut.borrow(), HUNDRED_MILLIS_IN_MICROS / 5);
                 assert_eq!(0, timed_result);
                 // This should timeout as well.
-                let timed_result = cass_future_wait_timed(cass_fut, HUNDRED_MILLIS_IN_MICROS / 5);
+                let timed_result =
+                    cass_future_wait_timed(cass_fut.borrow(), HUNDRED_MILLIS_IN_MICROS / 5);
                 assert_eq!(0, timed_result);
 
                 // Await and check result.

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -61,7 +61,9 @@ pub struct CassFuture {
     wait_for_value: Condvar,
 }
 
-impl ArcFFI for CassFuture {}
+impl FFI for CassFuture {
+    type Origin = FromArc;
+}
 
 /// An error that can appear during `cass_future_wait_timed`.
 enum FutureError {

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -1,34 +1,34 @@
 use std::ffi::{c_char, CString};
 
-use crate::{
-    argconv::BoxFFI,
-    cluster::CassCluster,
-    types::{cass_int32_t, cass_uint16_t, size_t},
-};
+use crate::argconv::{BoxFFI, CMut, CassBorrowedExclusivePtr};
+use crate::cluster::CassCluster;
+use crate::types::{cass_int32_t, cass_uint16_t, size_t};
 
 #[no_mangle]
 pub unsafe extern "C" fn testing_cluster_get_connect_timeout(
-    cluster_raw: *const CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
 ) -> cass_uint16_t {
-    let cluster = BoxFFI::as_ref(cluster_raw);
+    let cluster = BoxFFI::as_ref(cluster_raw).unwrap();
 
     cluster.get_session_config().connect_timeout.as_millis() as cass_uint16_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn testing_cluster_get_port(cluster_raw: *const CassCluster) -> cass_int32_t {
-    let cluster = BoxFFI::as_ref(cluster_raw);
+pub unsafe extern "C" fn testing_cluster_get_port(
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
+) -> cass_int32_t {
+    let cluster = BoxFFI::as_ref(cluster_raw).unwrap();
 
     cluster.get_port() as cass_int32_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn testing_cluster_get_contact_points(
-    cluster_raw: *const CassCluster,
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     contact_points: *mut *mut c_char,
     contact_points_length: *mut size_t,
 ) {
-    let cluster = BoxFFI::as_ref(cluster_raw);
+    let cluster = BoxFFI::as_ref(cluster_raw).unwrap();
 
     let contact_points_string = cluster.get_contact_points().join(",");
     let length = contact_points_string.len();

--- a/scylla-rust-wrapper/src/iterator.rs
+++ b/scylla-rust-wrapper/src/iterator.rs
@@ -1,6 +1,6 @@
 use crate::argconv::{
     write_str_to_c, ArcFFI, BoxFFI, CConst, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr,
-    CassOwnedExclusivePtr, RefFFI,
+    CassOwnedExclusivePtr, FromBox, RefFFI, FFI,
 };
 use crate::cass_error::CassError;
 use crate::cass_types::{CassDataType, CassValueType};
@@ -117,7 +117,9 @@ pub enum CassIterator<'result_or_schema> {
     ColumnsMeta(CassColumnsMetaIterator<'result_or_schema>),
 }
 
-impl BoxFFI for CassIterator<'_> {}
+impl FFI for CassIterator<'_> {
+    type Origin = FromBox;
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_iterator_free(iterator: CassOwnedExclusivePtr<CassIterator, CMut>) {

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -8,7 +8,8 @@ use tokio::runtime::Runtime;
 
 #[macro_use]
 mod binding;
-mod argconv;
+// pub, because doctests defined in `argconv` module need to access it.
+pub mod argconv;
 pub mod batch;
 pub mod cass_error;
 pub mod cass_types;

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -1,4 +1,4 @@
-use crate::argconv::{arr_to_cstr, ptr_to_cstr, str_to_arr, RefFFI};
+use crate::argconv::{arr_to_cstr, ptr_to_cstr, str_to_arr, CConst, CassBorrowedSharedPtr, RefFFI};
 use crate::cass_log_types::{CassLogLevel, CassLogMessage};
 use crate::types::size_t;
 use crate::LOGGER;
@@ -16,10 +16,15 @@ use tracing_subscriber::Layer;
 
 impl RefFFI for CassLogMessage {}
 
-pub type CassLogCallback =
-    Option<unsafe extern "C" fn(message: *const CassLogMessage, data: *mut c_void)>;
+pub type CassLogCallback = Option<
+    unsafe extern "C" fn(message: CassBorrowedSharedPtr<CassLogMessage, CConst>, data: *mut c_void),
+>;
 
-unsafe extern "C" fn noop_log_callback(_message: *const CassLogMessage, _data: *mut c_void) {}
+unsafe extern "C" fn noop_log_callback(
+    _message: CassBorrowedSharedPtr<CassLogMessage, CConst>,
+    _data: *mut c_void,
+) {
+}
 
 pub struct Logger {
     pub cb: CassLogCallback,
@@ -64,8 +69,11 @@ impl TryFrom<CassLogLevel> for Level {
 
 pub const CASS_LOG_MAX_MESSAGE_SIZE: usize = 1024;
 
-pub unsafe extern "C" fn stderr_log_callback(message: *const CassLogMessage, _data: *mut c_void) {
-    let message = RefFFI::as_ref(message);
+pub unsafe extern "C" fn stderr_log_callback(
+    message: CassBorrowedSharedPtr<CassLogMessage, CConst>,
+    _data: *mut c_void,
+) {
+    let message = RefFFI::as_ref(message).unwrap();
 
     eprintln!(
         "{} [{}] ({}:{}) {}",
@@ -132,7 +140,7 @@ where
 
         if let Some(log_cb) = logger.cb {
             unsafe {
-                log_cb(&log_message as *const CassLogMessage, logger.data);
+                log_cb(RefFFI::as_ptr(&log_message), logger.data);
             }
         }
     }

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -1,4 +1,6 @@
-use crate::argconv::{arr_to_cstr, ptr_to_cstr, str_to_arr, CConst, CassBorrowedSharedPtr, RefFFI};
+use crate::argconv::{
+    arr_to_cstr, ptr_to_cstr, str_to_arr, CConst, CassBorrowedSharedPtr, FromRef, RefFFI, FFI,
+};
 use crate::cass_log_types::{CassLogLevel, CassLogMessage};
 use crate::types::size_t;
 use crate::LOGGER;
@@ -14,7 +16,9 @@ use tracing_subscriber::layer::Context;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::Layer;
 
-impl RefFFI for CassLogMessage {}
+impl FFI for CassLogMessage {
+    type Origin = FromRef;
+}
 
 pub type CassLogCallback = Option<
     unsafe extern "C" fn(message: CassBorrowedSharedPtr<CassLogMessage, CConst>, data: *mut c_void),

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -107,68 +107,70 @@ pub fn create_table_metadata(table_name: &str, table_metadata: &Table) -> CassTa
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_schema_meta_free(schema_meta: *mut CassSchemaMeta) {
+pub unsafe extern "C" fn cass_schema_meta_free(
+    schema_meta: CassOwnedExclusivePtr<CassSchemaMeta, CConst>,
+) {
     BoxFFI::free(schema_meta);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name(
-    schema_meta: *const CassSchemaMeta,
+    schema_meta: CassBorrowedSharedPtr<CassSchemaMeta, CConst>,
     keyspace_name: *const c_char,
-) -> *const CassKeyspaceMeta {
+) -> CassBorrowedSharedPtr<CassKeyspaceMeta, CConst> {
     cass_schema_meta_keyspace_by_name_n(schema_meta, keyspace_name, strlen(keyspace_name))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name_n(
-    schema_meta: *const CassSchemaMeta,
+    schema_meta: CassBorrowedSharedPtr<CassSchemaMeta, CConst>,
     keyspace_name: *const c_char,
     keyspace_name_length: size_t,
-) -> *const CassKeyspaceMeta {
+) -> CassBorrowedSharedPtr<CassKeyspaceMeta, CConst> {
     if keyspace_name.is_null() {
-        return std::ptr::null();
+        return RefFFI::null();
     }
 
-    let metadata = BoxFFI::as_ref(schema_meta);
+    let metadata = BoxFFI::as_ref(schema_meta).unwrap();
     let keyspace = ptr_to_cstr_n(keyspace_name, keyspace_name_length).unwrap();
 
     let keyspace_meta = metadata.keyspaces.get(keyspace);
 
     match keyspace_meta {
-        Some(meta) => meta as *const CassKeyspaceMeta,
-        None => std::ptr::null(),
+        Some(meta) => RefFFI::as_ptr(meta),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_keyspace_meta_name(
-    keyspace_meta: *const CassKeyspaceMeta,
+    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) {
-    let keyspace_meta = RefFFI::as_ref(keyspace_meta);
+    let keyspace_meta = RefFFI::as_ref(keyspace_meta).unwrap();
     write_str_to_c(keyspace_meta.name.as_str(), name, name_length)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name(
-    keyspace_meta: *const CassKeyspaceMeta,
+    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     type_: *const c_char,
-) -> *const CassDataType {
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
     cass_keyspace_meta_user_type_by_name_n(keyspace_meta, type_, strlen(type_))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
-    keyspace_meta: *const CassKeyspaceMeta,
+    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     type_: *const c_char,
     type_length: size_t,
-) -> *const CassDataType {
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
     if type_.is_null() {
-        return std::ptr::null();
+        return ArcFFI::null();
     }
 
-    let keyspace_meta = RefFFI::as_ref(keyspace_meta);
+    let keyspace_meta = RefFFI::as_ref(keyspace_meta).unwrap();
     let user_type_name = ptr_to_cstr_n(type_, type_length).unwrap();
 
     match keyspace_meta
@@ -176,60 +178,62 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
         .get(user_type_name)
     {
         Some(udt) => ArcFFI::as_ptr(udt),
-        None => std::ptr::null(),
+        None => ArcFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_keyspace_meta_table_by_name(
-    keyspace_meta: *const CassKeyspaceMeta,
+    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     table: *const c_char,
-) -> *const CassTableMeta {
+) -> CassBorrowedSharedPtr<CassTableMeta, CConst> {
     cass_keyspace_meta_table_by_name_n(keyspace_meta, table, strlen(table))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_keyspace_meta_table_by_name_n(
-    keyspace_meta: *const CassKeyspaceMeta,
+    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     table: *const c_char,
     table_length: size_t,
-) -> *const CassTableMeta {
+) -> CassBorrowedSharedPtr<CassTableMeta, CConst> {
     if table.is_null() {
-        return std::ptr::null();
+        return RefFFI::null();
     }
 
-    let keyspace_meta = RefFFI::as_ref(keyspace_meta);
+    let keyspace_meta = RefFFI::as_ref(keyspace_meta).unwrap();
     let table_name = ptr_to_cstr_n(table, table_length).unwrap();
 
     let table_meta = keyspace_meta.tables.get(table_name);
 
     match table_meta {
         Some(meta) => RefFFI::as_ptr(meta),
-        None => std::ptr::null(),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_name(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) {
-    let table_meta = RefFFI::as_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
     write_str_to_c(table_meta.name.as_str(), name, name_length)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_table_meta_column_count(table_meta: *const CassTableMeta) -> size_t {
-    let table_meta = RefFFI::as_ref(table_meta);
+pub unsafe extern "C" fn cass_table_meta_column_count(
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
+) -> size_t {
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
     table_meta.columns_metadata.len() as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_column(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     index: size_t,
-) -> *const CassColumnMeta {
+) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
     // The order of columns in cpp-driver (and in DESCRIBE TABLE in cqlsh):
     // 1. partition keys sorted by position <- this is guaranteed by rust-driver.
     //    Table::partition_keys is a Vector of pk names, sorted by position.
@@ -248,7 +252,7 @@ pub unsafe extern "C" fn cass_table_meta_column(
     // Then cks by position: h, i
     // Then remaining columns alphabetically: b, c, f, g
 
-    let table_meta = RefFFI::as_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
     let index = index as usize;
 
     // Check if the index lands in partition keys. If so, simply return the corresponding column.
@@ -272,7 +276,7 @@ pub unsafe extern "C" fn cass_table_meta_column(
     table_meta
         .non_key_sorted_columns
         .get(index)
-        .map_or(std::ptr::null(), |column_name| {
+        .map_or(RefFFI::null(), |column_name| {
             // unwrap: We guarantee that column_name exists in columns_metadata. See `create_table_metadata`.
             RefFFI::as_ptr(table_meta.columns_metadata.get(column_name).unwrap())
         })
@@ -280,246 +284,244 @@ pub unsafe extern "C" fn cass_table_meta_column(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_partition_key(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     index: size_t,
-) -> *const CassColumnMeta {
-    let table_meta = RefFFI::as_ref(table_meta);
+) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
 
     match table_meta.partition_keys.get(index as usize) {
         Some(column_name) => match table_meta.columns_metadata.get(column_name) {
-            Some(column_meta) => column_meta as *const CassColumnMeta,
-            None => std::ptr::null(),
+            Some(column_meta) => RefFFI::as_ptr(column_meta),
+            None => RefFFI::null(),
         },
-        None => std::ptr::null(),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_partition_key_count(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
 ) -> size_t {
-    let table_meta = RefFFI::as_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
     table_meta.partition_keys.len() as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_clustering_key(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     index: size_t,
-) -> *const CassColumnMeta {
-    let table_meta = RefFFI::as_ref(table_meta);
+) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
 
     match table_meta.clustering_keys.get(index as usize) {
         Some(column_name) => match table_meta.columns_metadata.get(column_name) {
-            Some(column_meta) => column_meta as *const CassColumnMeta,
-            None => std::ptr::null(),
+            Some(column_meta) => RefFFI::as_ptr(column_meta),
+            None => RefFFI::null(),
         },
-        None => std::ptr::null(),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_clustering_key_count(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
 ) -> size_t {
-    let table_meta = RefFFI::as_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
     table_meta.clustering_keys.len() as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_column_by_name(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     column: *const c_char,
-) -> *const CassColumnMeta {
+) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
     cass_table_meta_column_by_name_n(table_meta, column, strlen(column))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_column_by_name_n(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     column: *const c_char,
     column_length: size_t,
-) -> *const CassColumnMeta {
+) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
     if column.is_null() {
-        return std::ptr::null();
+        return RefFFI::null();
     }
 
-    let table_meta = RefFFI::as_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
     let column_name = ptr_to_cstr_n(column, column_length).unwrap();
 
     match table_meta.columns_metadata.get(column_name) {
-        Some(column_meta) => column_meta as *const CassColumnMeta,
-        None => std::ptr::null(),
+        Some(column_meta) => RefFFI::as_ptr(column_meta),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_column_meta_name(
-    column_meta: *const CassColumnMeta,
+    column_meta: CassBorrowedSharedPtr<CassColumnMeta, CConst>,
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) {
-    let column_meta = RefFFI::as_ref(column_meta);
+    let column_meta = RefFFI::as_ref(column_meta).unwrap();
     write_str_to_c(column_meta.name.as_str(), name, name_length)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_column_meta_data_type(
-    column_meta: *const CassColumnMeta,
-) -> *const CassDataType {
-    let column_meta = RefFFI::as_ref(column_meta);
+    column_meta: CassBorrowedSharedPtr<CassColumnMeta, CConst>,
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+    let column_meta = RefFFI::as_ref(column_meta).unwrap();
     ArcFFI::as_ptr(&column_meta.column_type)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_column_meta_type(
-    column_meta: *const CassColumnMeta,
+    column_meta: CassBorrowedSharedPtr<CassColumnMeta, CConst>,
 ) -> CassColumnType {
-    let column_meta = RefFFI::as_ref(column_meta);
+    let column_meta = RefFFI::as_ref(column_meta).unwrap();
     column_meta.column_kind
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name(
-    keyspace_meta: *const CassKeyspaceMeta,
+    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     view: *const c_char,
-) -> *const CassMaterializedViewMeta {
+) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
     cass_keyspace_meta_materialized_view_by_name_n(keyspace_meta, view, strlen(view))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name_n(
-    keyspace_meta: *const CassKeyspaceMeta,
+    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     view: *const c_char,
     view_length: size_t,
-) -> *const CassMaterializedViewMeta {
+) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
     if view.is_null() {
-        return std::ptr::null();
+        return RefFFI::null();
     }
 
-    let keyspace_meta = RefFFI::as_ref(keyspace_meta);
+    let keyspace_meta = RefFFI::as_ref(keyspace_meta).unwrap();
     let view_name = ptr_to_cstr_n(view, view_length).unwrap();
 
     match keyspace_meta.views.get(view_name) {
         Some(view_meta) => RefFFI::as_ptr(view_meta.as_ref()),
-        None => std::ptr::null(),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     view: *const c_char,
-) -> *const CassMaterializedViewMeta {
+) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
     cass_table_meta_materialized_view_by_name_n(table_meta, view, strlen(view))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name_n(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     view: *const c_char,
     view_length: size_t,
-) -> *const CassMaterializedViewMeta {
+) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
     if view.is_null() {
-        return std::ptr::null();
+        return RefFFI::null();
     }
 
-    let table_meta = RefFFI::as_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
     let view_name = ptr_to_cstr_n(view, view_length).unwrap();
 
     match table_meta.views.get(view_name) {
         Some(view_meta) => RefFFI::as_ptr(view_meta.as_ref()),
-        None => std::ptr::null(),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_materialized_view_count(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
 ) -> size_t {
-    let table_meta = RefFFI::as_ref(table_meta);
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
     table_meta.views.len() as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_table_meta_materialized_view(
-    table_meta: *const CassTableMeta,
+    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     index: size_t,
-) -> *const CassMaterializedViewMeta {
-    let table_meta = RefFFI::as_ref(table_meta);
+) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
+    let table_meta = RefFFI::as_ref(table_meta).unwrap();
 
     match table_meta.views.iter().nth(index as usize) {
         Some(view_meta) => RefFFI::as_ptr(view_meta.1.as_ref()),
-        None => std::ptr::null(),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name(
-    view_meta: *const CassMaterializedViewMeta,
+    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     column: *const c_char,
-) -> *const CassColumnMeta {
+) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
     cass_materialized_view_meta_column_by_name_n(view_meta, column, strlen(column))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name_n(
-    view_meta: *const CassMaterializedViewMeta,
+    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     column: *const c_char,
     column_length: size_t,
-) -> *const CassColumnMeta {
+) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
     if column.is_null() {
-        return std::ptr::null();
+        return RefFFI::null();
     }
 
-    let view_meta = RefFFI::as_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta).unwrap();
     let column_name = ptr_to_cstr_n(column, column_length).unwrap();
 
     match view_meta.view_metadata.columns_metadata.get(column_name) {
-        Some(column_meta) => column_meta as *const CassColumnMeta,
-        None => std::ptr::null(),
+        Some(column_meta) => RefFFI::as_ptr(column_meta),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_materialized_view_meta_name(
-    view_meta: *const CassMaterializedViewMeta,
+    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) {
-    let view_meta = RefFFI::as_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta).unwrap();
     write_str_to_c(view_meta.name.as_str(), name, name_length)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_materialized_view_meta_base_table(
-    view_meta: *const CassMaterializedViewMeta,
-) -> *const CassTableMeta {
-    let view_meta = RefFFI::as_ref(view_meta);
+    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
+) -> CassBorrowedSharedPtr<CassTableMeta, CConst> {
+    let view_meta = RefFFI::as_ref(view_meta).unwrap();
 
-    match view_meta.base_table.upgrade() {
-        Some(arc) => RefFFI::as_ptr(&arc),
-        None => {
-            tracing::error!("Failed to upgrade a weak reference to table metadata from materialized view metadata! This is a driver bug!");
-            std::ptr::null()
-        }
+    let ptr = RefFFI::weak_as_ptr(&view_meta.base_table);
+    if RefFFI::is_null(&ptr) {
+        tracing::error!("Failed to upgrade a weak reference to table metadata from materialized view metadata! This is a driver bug!");
     }
+    ptr
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_materialized_view_meta_column_count(
-    view_meta: *const CassMaterializedViewMeta,
+    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
 ) -> size_t {
-    let view_meta = RefFFI::as_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta).unwrap();
     view_meta.view_metadata.columns_metadata.len() as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_materialized_view_meta_column(
-    view_meta: *const CassMaterializedViewMeta,
+    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     index: size_t,
-) -> *const CassColumnMeta {
-    let view_meta = RefFFI::as_ref(view_meta);
+) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
+    let view_meta = RefFFI::as_ref(view_meta).unwrap();
 
     match view_meta
         .view_metadata
@@ -527,53 +529,53 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column(
         .iter()
         .nth(index as usize)
     {
-        Some(column_entry) => column_entry.1 as *const CassColumnMeta,
-        None => std::ptr::null(),
+        Some(column_entry) => RefFFI::as_ptr(column_entry.1),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_materialized_view_meta_partition_key_count(
-    view_meta: *const CassMaterializedViewMeta,
+    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
 ) -> size_t {
-    let view_meta = RefFFI::as_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta).unwrap();
     view_meta.view_metadata.partition_keys.len() as size_t
 }
 
 pub unsafe extern "C" fn cass_materialized_view_meta_partition_key(
-    view_meta: *const CassMaterializedViewMeta,
+    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     index: size_t,
-) -> *const CassColumnMeta {
-    let view_meta = RefFFI::as_ref(view_meta);
+) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
+    let view_meta = RefFFI::as_ref(view_meta).unwrap();
 
     match view_meta.view_metadata.partition_keys.get(index as usize) {
         Some(column_name) => match view_meta.view_metadata.columns_metadata.get(column_name) {
-            Some(column_meta) => column_meta as *const CassColumnMeta,
-            None => std::ptr::null(),
+            Some(column_meta) => RefFFI::as_ptr(column_meta),
+            None => RefFFI::null(),
         },
-        None => std::ptr::null(),
+        None => RefFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_materialized_view_meta_clustering_key_count(
-    view_meta: *const CassMaterializedViewMeta,
+    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
 ) -> size_t {
-    let view_meta = RefFFI::as_ref(view_meta);
+    let view_meta = RefFFI::as_ref(view_meta).unwrap();
     view_meta.view_metadata.clustering_keys.len() as size_t
 }
 
 pub unsafe extern "C" fn cass_materialized_view_meta_clustering_key(
-    view_meta: *const CassMaterializedViewMeta,
+    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     index: size_t,
-) -> *const CassColumnMeta {
-    let view_meta = RefFFI::as_ref(view_meta);
+) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
+    let view_meta = RefFFI::as_ref(view_meta).unwrap();
 
     match view_meta.view_metadata.clustering_keys.get(index as usize) {
         Some(column_name) => match view_meta.view_metadata.columns_metadata.get(column_name) {
-            Some(column_meta) => column_meta as *const CassColumnMeta,
-            None => std::ptr::null(),
+            Some(column_meta) => RefFFI::as_ptr(column_meta),
+            None => RefFFI::null(),
         },
-        None => std::ptr::null(),
+        None => RefFFI::null(),
     }
 }

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -13,7 +13,9 @@ pub struct CassSchemaMeta {
     pub keyspaces: HashMap<String, CassKeyspaceMeta>,
 }
 
-impl BoxFFI for CassSchemaMeta {}
+impl FFI for CassSchemaMeta {
+    type Origin = FromBox;
+}
 
 pub struct CassKeyspaceMeta {
     pub name: String,
@@ -25,7 +27,9 @@ pub struct CassKeyspaceMeta {
 }
 
 // Owned by CassSchemaMeta
-impl RefFFI for CassKeyspaceMeta {}
+impl FFI for CassKeyspaceMeta {
+    type Origin = FromRef;
+}
 
 pub struct CassTableMeta {
     pub name: String,
@@ -40,7 +44,9 @@ pub struct CassTableMeta {
 // Either:
 // - owned by CassMaterializedViewMeta - won't be given to user
 // - Owned by CassKeyspaceMeta (in Arc), referenced (Weak) by CassMaterializedViewMeta
-impl RefFFI for CassTableMeta {}
+impl FFI for CassTableMeta {
+    type Origin = FromRef;
+}
 
 pub struct CassMaterializedViewMeta {
     pub name: String,
@@ -49,7 +55,9 @@ pub struct CassMaterializedViewMeta {
 }
 
 // Shared ownership by CassKeyspaceMeta and CassTableMeta
-impl RefFFI for CassMaterializedViewMeta {}
+impl FFI for CassMaterializedViewMeta {
+    type Origin = FromRef;
+}
 
 pub struct CassColumnMeta {
     pub name: String,
@@ -58,7 +66,9 @@ pub struct CassColumnMeta {
 }
 
 // Owned by CassTableMeta
-impl RefFFI for CassColumnMeta {}
+impl FFI for CassColumnMeta {
+    type Origin = FromRef;
+}
 
 pub fn create_table_metadata(table_name: &str, table_metadata: &Table) -> CassTableMeta {
     let mut columns_metadata = HashMap::new();

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -73,7 +73,9 @@ impl CassPrepared {
     }
 }
 
-impl ArcFFI for CassPrepared {}
+impl FFI for CassPrepared {
+    type Origin = FromArc;
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_prepared_free(

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -76,15 +76,17 @@ impl CassPrepared {
 impl ArcFFI for CassPrepared {}
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_prepared_free(prepared_raw: *const CassPrepared) {
+pub unsafe extern "C" fn cass_prepared_free(
+    prepared_raw: CassOwnedSharedPtr<CassPrepared, CConst>,
+) {
     ArcFFI::free(prepared_raw);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_prepared_bind(
-    prepared_raw: *const CassPrepared,
-) -> *mut CassStatement {
-    let prepared: Arc<_> = ArcFFI::cloned_from_ptr(prepared_raw);
+    prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
+) -> CassOwnedExclusivePtr<CassStatement, CMut> {
+    let prepared: Arc<_> = ArcFFI::cloned_from_ptr(prepared_raw).unwrap();
     let bound_values_size = prepared.statement.get_variable_col_specs().len();
 
     // cloning prepared statement's arc, because creating CassStatement should not invalidate
@@ -107,12 +109,12 @@ pub unsafe extern "C" fn cass_prepared_bind(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_prepared_parameter_name(
-    prepared_raw: *const CassPrepared,
+    prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
     index: size_t,
     name: *mut *const c_char,
     name_length: *mut size_t,
 ) -> CassError {
-    let prepared = ArcFFI::as_ref(prepared_raw);
+    let prepared = ArcFFI::as_ref(prepared_raw).unwrap();
 
     match prepared
         .statement
@@ -129,38 +131,38 @@ pub unsafe extern "C" fn cass_prepared_parameter_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_prepared_parameter_data_type(
-    prepared_raw: *const CassPrepared,
+    prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
     index: size_t,
-) -> *const CassDataType {
-    let prepared = ArcFFI::as_ref(prepared_raw);
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+    let prepared = ArcFFI::as_ref(prepared_raw).unwrap();
 
     match prepared.variable_col_data_types.get(index as usize) {
         Some(dt) => ArcFFI::as_ptr(dt),
-        None => std::ptr::null(),
+        None => ArcFFI::null(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name(
-    prepared_raw: *const CassPrepared,
+    prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
     name: *const c_char,
-) -> *const CassDataType {
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
     cass_prepared_parameter_data_type_by_name_n(prepared_raw, name, strlen(name))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name_n(
-    prepared_raw: *const CassPrepared,
+    prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
     name: *const c_char,
     name_length: size_t,
-) -> *const CassDataType {
-    let prepared = ArcFFI::as_ref(prepared_raw);
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+    let prepared = ArcFFI::as_ref(prepared_raw).unwrap();
     let parameter_name =
         ptr_to_cstr_n(name, name_length).expect("Prepared parameter name is not UTF-8");
 
     let data_type = prepared.get_variable_data_type_by_name(parameter_name);
     match data_type {
         Some(dt) => ArcFFI::as_ptr(dt),
-        None => std::ptr::null(),
+        None => ArcFFI::null(),
     }
 }

--- a/scylla-rust-wrapper/src/query_error.rs
+++ b/scylla-rust-wrapper/src/query_error.rs
@@ -56,21 +56,25 @@ impl From<&WriteType> for CassWriteType {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_error_result_free(error_result: *const CassErrorResult) {
+pub unsafe extern "C" fn cass_error_result_free(
+    error_result: CassOwnedSharedPtr<CassErrorResult, CConst>,
+) {
     ArcFFI::free(error_result);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_error_result_code(error_result: *const CassErrorResult) -> CassError {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+pub unsafe extern "C" fn cass_error_result_code(
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
+) -> CassError {
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     error_result.to_cass_error()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_consistency(
-    error_result: *const CassErrorResult,
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> CassConsistency {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(
             RequestAttemptError::DbError(DbError::Unavailable { consistency, .. }, _)
@@ -85,9 +89,9 @@ pub unsafe extern "C" fn cass_error_result_consistency(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_responses_received(
-    error_result: *const CassErrorResult,
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_int32_t {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(attempt_error)) => {
             match attempt_error {
@@ -109,9 +113,9 @@ pub unsafe extern "C" fn cass_error_result_responses_received(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_responses_required(
-    error_result: *const CassErrorResult,
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_int32_t {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(attempt_error)) => {
             match attempt_error {
@@ -133,9 +137,9 @@ pub unsafe extern "C" fn cass_error_result_responses_required(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_num_failures(
-    error_result: *const CassErrorResult,
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_int32_t {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(RequestAttemptError::DbError(
             DbError::ReadFailure { numfailures, .. },
@@ -151,9 +155,9 @@ pub unsafe extern "C" fn cass_error_result_num_failures(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_data_present(
-    error_result: *const CassErrorResult,
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_bool_t {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(RequestAttemptError::DbError(
             DbError::ReadTimeout { data_present, .. },
@@ -181,9 +185,9 @@ pub unsafe extern "C" fn cass_error_result_data_present(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_write_type(
-    error_result: *const CassErrorResult,
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> CassWriteType {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(RequestAttemptError::DbError(
             DbError::WriteTimeout { write_type, .. },
@@ -199,11 +203,11 @@ pub unsafe extern "C" fn cass_error_result_write_type(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_keyspace(
-    error_result: *const CassErrorResult,
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
     c_keyspace: *mut *const ::std::os::raw::c_char,
     c_keyspace_len: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(RequestAttemptError::DbError(
             DbError::AlreadyExists { keyspace, .. },
@@ -225,11 +229,11 @@ pub unsafe extern "C" fn cass_error_result_keyspace(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_table(
-    error_result: *const CassErrorResult,
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
     c_table: *mut *const ::std::os::raw::c_char,
     c_table_len: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(RequestAttemptError::DbError(
             DbError::AlreadyExists { table, .. },
@@ -244,11 +248,11 @@ pub unsafe extern "C" fn cass_error_result_table(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_function(
-    error_result: *const CassErrorResult,
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
     c_function: *mut *const ::std::os::raw::c_char,
     c_function_len: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(RequestAttemptError::DbError(
             DbError::FunctionFailure { function, .. },
@@ -262,8 +266,10 @@ pub unsafe extern "C" fn cass_error_result_function(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_error_num_arg_types(error_result: *const CassErrorResult) -> size_t {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+pub unsafe extern "C" fn cass_error_num_arg_types(
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
+) -> size_t {
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(RequestAttemptError::DbError(
             DbError::FunctionFailure { arg_types, .. },
@@ -275,12 +281,12 @@ pub unsafe extern "C" fn cass_error_num_arg_types(error_result: *const CassError
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_error_result_arg_type(
-    error_result: *const CassErrorResult,
+    error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
     index: size_t,
     arg_type: *mut *const ::std::os::raw::c_char,
     arg_type_length: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result);
+    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
     match error_result {
         CassErrorResult::Query(ExecutionError::LastAttemptError(RequestAttemptError::DbError(
             DbError::FunctionFailure { arg_types, .. },

--- a/scylla-rust-wrapper/src/query_error.rs
+++ b/scylla-rust-wrapper/src/query_error.rs
@@ -19,7 +19,9 @@ pub enum CassErrorResult {
     Deserialization(#[from] DeserializationError),
 }
 
-impl ArcFFI for CassErrorResult {}
+impl FFI for CassErrorResult {
+    type Origin = FromArc;
+}
 
 impl From<Consistency> for CassConsistency {
     fn from(c: Consistency) -> CassConsistency {

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -92,7 +92,9 @@ impl CassResult {
     }
 }
 
-impl ArcFFI for CassResult {}
+impl FFI for CassResult {
+    type Origin = FromArc;
+}
 
 #[derive(Debug)]
 pub struct CassResultMetadata {
@@ -122,7 +124,9 @@ pub struct CassRow {
     pub result_metadata: Arc<CassResultMetadata>,
 }
 
-impl RefFFI for CassRow {}
+impl FFI for CassRow {
+    type Origin = FromRef;
+}
 
 pub fn create_cass_rows_from_rows(
     rows: Vec<Row>,
@@ -158,7 +162,9 @@ pub struct CassValue {
     pub value_type: Arc<CassDataType>,
 }
 
-impl RefFFI for CassValue {}
+impl FFI for CassValue {
+    type Origin = FromRef;
+}
 
 fn create_cass_row_columns(row: Row, metadata: &Arc<CassResultMetadata>) -> Vec<CassValue> {
     row.columns

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -3,7 +3,7 @@ use scylla::policies::retry::{
 };
 use std::sync::Arc;
 
-use crate::argconv::ArcFFI;
+use crate::argconv::{ArcFFI, CMut, CassOwnedSharedPtr};
 
 pub enum RetryPolicy {
     DefaultRetryPolicy(Arc<DefaultRetryPolicy>),
@@ -16,27 +16,30 @@ pub type CassRetryPolicy = RetryPolicy;
 impl ArcFFI for CassRetryPolicy {}
 
 #[no_mangle]
-pub extern "C" fn cass_retry_policy_default_new() -> *mut CassRetryPolicy {
+pub extern "C" fn cass_retry_policy_default_new() -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
     ArcFFI::into_ptr(Arc::new(RetryPolicy::DefaultRetryPolicy(Arc::new(
         DefaultRetryPolicy,
-    )))) as *mut _
+    ))))
 }
 
 #[no_mangle]
-pub extern "C" fn cass_retry_policy_downgrading_consistency_new() -> *mut CassRetryPolicy {
+pub extern "C" fn cass_retry_policy_downgrading_consistency_new(
+) -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
     ArcFFI::into_ptr(Arc::new(RetryPolicy::DowngradingConsistencyRetryPolicy(
         Arc::new(DowngradingConsistencyRetryPolicy),
-    ))) as *mut _
+    )))
 }
 
 #[no_mangle]
-pub extern "C" fn cass_retry_policy_fallthrough_new() -> *mut CassRetryPolicy {
+pub extern "C" fn cass_retry_policy_fallthrough_new() -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
     ArcFFI::into_ptr(Arc::new(RetryPolicy::FallthroughRetryPolicy(Arc::new(
         FallthroughRetryPolicy,
-    )))) as *mut _
+    ))))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_retry_policy_free(retry_policy: *mut CassRetryPolicy) {
+pub unsafe extern "C" fn cass_retry_policy_free(
+    retry_policy: CassOwnedSharedPtr<CassRetryPolicy, CMut>,
+) {
     ArcFFI::free(retry_policy);
 }

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -3,7 +3,7 @@ use scylla::policies::retry::{
 };
 use std::sync::Arc;
 
-use crate::argconv::{ArcFFI, CMut, CassOwnedSharedPtr};
+use crate::argconv::{ArcFFI, CMut, CassOwnedSharedPtr, FromArc, FFI};
 
 pub enum RetryPolicy {
     DefaultRetryPolicy(Arc<DefaultRetryPolicy>),
@@ -13,7 +13,9 @@ pub enum RetryPolicy {
 
 pub type CassRetryPolicy = RetryPolicy;
 
-impl ArcFFI for CassRetryPolicy {}
+impl FFI for CassRetryPolicy {
+    type Origin = FromArc;
+}
 
 #[no_mangle]
 pub extern "C" fn cass_retry_policy_default_new() -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -73,7 +73,7 @@ impl CassSessionInner {
         session_opt: Arc<RwLock<Option<CassSessionInner>>>,
         cluster: &CassCluster,
         keyspace: Option<String>,
-    ) -> *mut CassFuture {
+    ) -> CassOwnedSharedPtr<CassFuture, CMut> {
         let session_builder = build_session_builder(cluster);
         let exec_profile_map = cluster.execution_profile_map().clone();
 
@@ -140,52 +140,52 @@ pub type CassSession = RwLock<Option<CassSessionInner>>;
 impl ArcFFI for CassSession {}
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_session_new() -> *mut CassSession {
+pub unsafe extern "C" fn cass_session_new() -> CassOwnedSharedPtr<CassSession, CMut> {
     let session = Arc::new(RwLock::new(None::<CassSessionInner>));
-    ArcFFI::into_ptr(session) as *mut CassSession
+    ArcFFI::into_ptr(session)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_connect(
-    session_raw: *mut CassSession,
-    cluster_raw: *const CassCluster,
-) -> *mut CassFuture {
-    let session_opt = ArcFFI::cloned_from_ptr(session_raw);
-    let cluster: &CassCluster = BoxFFI::as_ref(cluster_raw);
+    session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
+    cluster_raw: CassBorrowedSharedPtr<CassCluster, CConst>,
+) -> CassOwnedSharedPtr<CassFuture, CMut> {
+    let session_opt = ArcFFI::cloned_from_ptr(session_raw).unwrap();
+    let cluster: &CassCluster = BoxFFI::as_ref(cluster_raw).unwrap();
 
     CassSessionInner::connect(session_opt, cluster, None)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_connect_keyspace(
-    session_raw: *mut CassSession,
-    cluster_raw: *const CassCluster,
+    session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
+    cluster_raw: CassBorrowedSharedPtr<CassCluster, CConst>,
     keyspace: *const c_char,
-) -> *mut CassFuture {
-    cass_session_connect_keyspace_n(session_raw, cluster_raw, keyspace, strlen(keyspace)) as *mut _
+) -> CassOwnedSharedPtr<CassFuture, CMut> {
+    cass_session_connect_keyspace_n(session_raw, cluster_raw, keyspace, strlen(keyspace))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_connect_keyspace_n(
-    session_raw: *mut CassSession,
-    cluster_raw: *const CassCluster,
+    session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
+    cluster_raw: CassBorrowedSharedPtr<CassCluster, CConst>,
     keyspace: *const c_char,
     keyspace_length: size_t,
-) -> *mut CassFuture {
-    let session_opt = ArcFFI::cloned_from_ptr(session_raw);
-    let cluster: &CassCluster = BoxFFI::as_ref(cluster_raw);
+) -> CassOwnedSharedPtr<CassFuture, CMut> {
+    let session_opt = ArcFFI::cloned_from_ptr(session_raw).unwrap();
+    let cluster: &CassCluster = BoxFFI::as_ref(cluster_raw).unwrap();
     let keyspace = ptr_to_cstr_n(keyspace, keyspace_length).map(ToOwned::to_owned);
 
-    CassSessionInner::connect(session_opt, cluster, keyspace) as *mut _
+    CassSessionInner::connect(session_opt, cluster, keyspace)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_execute_batch(
-    session_raw: *mut CassSession,
-    batch_raw: *const CassBatch,
-) -> *mut CassFuture {
-    let session_opt = ArcFFI::cloned_from_ptr(session_raw);
-    let batch_from_raw = BoxFFI::as_ref(batch_raw);
+    session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
+    batch_raw: CassBorrowedSharedPtr<CassBatch, CConst>,
+) -> CassOwnedSharedPtr<CassFuture, CMut> {
+    let session_opt = ArcFFI::cloned_from_ptr(session_raw).unwrap();
+    let batch_from_raw = BoxFFI::as_ref(batch_raw).unwrap();
     let mut state = batch_from_raw.state.clone();
     let request_timeout_ms = batch_from_raw.batch_request_timeout_ms;
 
@@ -247,13 +247,13 @@ async fn request_with_timeout(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_execute(
-    session_raw: *mut CassSession,
-    statement_raw: *const CassStatement,
-) -> *mut CassFuture {
-    let session_opt = ArcFFI::cloned_from_ptr(session_raw);
+    session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
+    statement_raw: CassBorrowedSharedPtr<CassStatement, CConst>,
+) -> CassOwnedSharedPtr<CassFuture, CMut> {
+    let session_opt = ArcFFI::cloned_from_ptr(session_raw).unwrap();
 
     // DO NOT refer to `statement_opt` inside the async block, as I've done just to face a segfault.
-    let statement_opt = BoxFFI::as_ref(statement_raw);
+    let statement_opt = BoxFFI::as_ref(statement_raw).unwrap();
     let paging_state = statement_opt.paging_state.clone();
     let paging_enabled = statement_opt.paging_enabled;
     let request_timeout_ms = statement_opt.request_timeout_ms;
@@ -382,11 +382,11 @@ pub unsafe extern "C" fn cass_session_execute(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_prepare_from_existing(
-    cass_session: *mut CassSession,
-    statement: *const CassStatement,
-) -> *mut CassFuture {
-    let session = ArcFFI::cloned_from_ptr(cass_session);
-    let cass_statement = BoxFFI::as_ref(statement);
+    cass_session: CassBorrowedSharedPtr<CassSession, CMut>,
+    statement: CassBorrowedSharedPtr<CassStatement, CMut>,
+) -> CassOwnedSharedPtr<CassFuture, CMut> {
+    let session = ArcFFI::cloned_from_ptr(cass_session).unwrap();
+    let cass_statement = BoxFFI::as_ref(statement).unwrap();
     let statement = cass_statement.statement.clone();
 
     CassFuture::make_raw(async move {
@@ -418,18 +418,18 @@ pub unsafe extern "C" fn cass_session_prepare_from_existing(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_prepare(
-    session: *mut CassSession,
+    session: CassBorrowedSharedPtr<CassSession, CMut>,
     query: *const c_char,
-) -> *mut CassFuture {
+) -> CassOwnedSharedPtr<CassFuture, CMut> {
     cass_session_prepare_n(session, query, strlen(query))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_prepare_n(
-    cass_session_raw: *mut CassSession,
+    cass_session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
     query: *const c_char,
     query_length: size_t,
-) -> *mut CassFuture {
+) -> CassOwnedSharedPtr<CassFuture, CMut> {
     let query_str = ptr_to_cstr_n(query, query_length)
         // Apparently nullptr denotes an empty statement string.
         // It seems to be intended (for some weird reason, why not save a round-trip???)
@@ -437,7 +437,7 @@ pub unsafe extern "C" fn cass_session_prepare_n(
         // There is a test for this: `NullStringApiArgsTest.Integration_Cassandra_PrepareNullQuery`.
         .unwrap_or_default();
     let query = Statement::new(query_str.to_string());
-    let cass_session = ArcFFI::cloned_from_ptr(cass_session_raw);
+    let cass_session = ArcFFI::cloned_from_ptr(cass_session_raw).unwrap();
 
     CassFuture::make_raw(async move {
         let session_guard = cass_session.read().await;
@@ -464,13 +464,15 @@ pub unsafe extern "C" fn cass_session_prepare_n(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_session_free(session_raw: *mut CassSession) {
+pub unsafe extern "C" fn cass_session_free(session_raw: CassOwnedSharedPtr<CassSession, CMut>) {
     ArcFFI::free(session_raw);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_session_close(session: *mut CassSession) -> *mut CassFuture {
-    let session_opt = ArcFFI::cloned_from_ptr(session);
+pub unsafe extern "C" fn cass_session_close(
+    session: CassBorrowedSharedPtr<CassSession, CMut>,
+) -> CassOwnedSharedPtr<CassFuture, CMut> {
+    let session_opt = ArcFFI::cloned_from_ptr(session).unwrap();
 
     CassFuture::make_raw(async move {
         let mut session_guard = session_opt.write().await;
@@ -488,8 +490,10 @@ pub unsafe extern "C" fn cass_session_close(session: *mut CassSession) -> *mut C
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_session_get_client_id(session: *const CassSession) -> CassUuid {
-    let cass_session = ArcFFI::as_ref(session);
+pub unsafe extern "C" fn cass_session_get_client_id(
+    session: CassBorrowedSharedPtr<CassSession, CMut>,
+) -> CassUuid {
+    let cass_session = ArcFFI::as_ref(session).unwrap();
 
     let client_id: uuid::Uuid = cass_session.blocking_read().as_ref().unwrap().client_id;
     client_id.into()
@@ -497,9 +501,9 @@ pub unsafe extern "C" fn cass_session_get_client_id(session: *const CassSession)
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_get_schema_meta(
-    session: *const CassSession,
-) -> *const CassSchemaMeta {
-    let cass_session = ArcFFI::as_ref(session);
+    session: CassBorrowedSharedPtr<CassSession, CConst>,
+) -> CassOwnedExclusivePtr<CassSchemaMeta, CConst> {
+    let cass_session = ArcFFI::as_ref(session).unwrap();
     let mut keyspaces: HashMap<String, CassKeyspaceMeta> = HashMap::new();
 
     for (keyspace_name, keyspace) in cass_session
@@ -597,7 +601,9 @@ mod tests {
         future::{
             cass_future_error_code, cass_future_error_message, cass_future_free, cass_future_wait,
         },
-        retry_policy::{cass_retry_policy_default_new, cass_retry_policy_fallthrough_new},
+        retry_policy::{
+            cass_retry_policy_default_new, cass_retry_policy_fallthrough_new, CassRetryPolicy,
+        },
         statement::{cass_statement_free, cass_statement_new, cass_statement_set_retry_policy},
         testing::assert_cass_error_eq,
         types::cass_bool_t,
@@ -618,15 +624,15 @@ mod tests {
             .try_init();
     }
 
-    unsafe fn cass_future_wait_check_and_free(fut: *mut CassFuture) {
-        cass_future_wait(fut);
-        if cass_future_error_code(fut) != CassError::CASS_OK {
+    unsafe fn cass_future_wait_check_and_free(fut: CassOwnedSharedPtr<CassFuture, CMut>) {
+        cass_future_wait(fut.borrow());
+        if cass_future_error_code(fut.borrow()) != CassError::CASS_OK {
             let mut message: *const c_char = std::ptr::null();
             let mut message_len: size_t = 0;
-            cass_future_error_message(fut, &mut message, &mut message_len);
+            cass_future_error_message(fut.borrow(), &mut message, &mut message_len);
             eprintln!("{:?}", ptr_to_cstr_n(message, message_len));
         }
-        assert_cass_error_eq!(cass_future_error_code(fut), CassError::CASS_OK);
+        assert_cass_error_eq!(cass_future_error_code(fut.borrow()), CassError::CASS_OK);
         cass_future_free(fut);
     }
 
@@ -704,41 +710,54 @@ mod tests {
         proxy: RunningProxy,
     ) -> RunningProxy {
         unsafe {
-            let cluster_raw = cass_cluster_new();
+            let mut cluster_raw = cass_cluster_new();
             let ip = node_addr.ip().to_string();
             let (c_ip, c_ip_len) = str_to_c_str_n(ip.as_str());
 
             assert_cass_error_eq!(
-                cass_cluster_set_contact_points_n(cluster_raw, c_ip, c_ip_len),
+                cass_cluster_set_contact_points_n(cluster_raw.borrow_mut(), c_ip, c_ip_len),
                 CassError::CASS_OK
             );
             let session_raw = cass_session_new();
-            let profile_raw = cass_execution_profile_new();
+            let mut profile_raw = cass_execution_profile_new();
             {
-                cass_future_wait_check_and_free(cass_session_connect(session_raw, cluster_raw));
+                cass_future_wait_check_and_free(cass_session_connect(
+                    session_raw.borrow(),
+                    cluster_raw.borrow().into_c_const(),
+                ));
                 // Initially, the profile map is empty.
 
-                assert!(ArcFFI::as_ref(session_raw)
+                assert!(ArcFFI::as_ref(session_raw.borrow())
+                    .unwrap()
                     .blocking_read()
                     .as_ref()
                     .unwrap()
                     .exec_profile_map
                     .is_empty());
 
-                cass_cluster_set_execution_profile(cluster_raw, make_c_str!("prof"), profile_raw);
+                cass_cluster_set_execution_profile(
+                    cluster_raw.borrow_mut(),
+                    make_c_str!("prof"),
+                    profile_raw.borrow_mut(),
+                );
                 // Mutations in cluster do not affect the session that was connected before.
-                assert!(ArcFFI::as_ref(session_raw)
+                assert!(ArcFFI::as_ref(session_raw.borrow())
+                    .unwrap()
                     .blocking_read()
                     .as_ref()
                     .unwrap()
                     .exec_profile_map
                     .is_empty());
 
-                cass_future_wait_check_and_free(cass_session_close(session_raw));
+                cass_future_wait_check_and_free(cass_session_close(session_raw.borrow()));
 
                 // Mutations in cluster are now propagated to the session.
-                cass_future_wait_check_and_free(cass_session_connect(session_raw, cluster_raw));
-                let profile_map_keys = ArcFFI::as_ref(session_raw)
+                cass_future_wait_check_and_free(cass_session_connect(
+                    session_raw.borrow(),
+                    cluster_raw.borrow().into_c_const(),
+                ));
+                let profile_map_keys = ArcFFI::as_ref(session_raw.borrow())
+                    .unwrap()
                     .blocking_read()
                     .as_ref()
                     .unwrap()
@@ -751,7 +770,7 @@ mod tests {
                     std::iter::once(ExecProfileName::try_from("prof".to_owned()).unwrap())
                         .collect::<HashSet<_>>()
                 );
-                cass_future_wait_check_and_free(cass_session_close(session_raw));
+                cass_future_wait_check_and_free(cass_session_close(session_raw.borrow()));
             }
             cass_execution_profile_free(profile_raw);
             cass_session_free(session_raw);
@@ -788,18 +807,18 @@ mod tests {
         proxy: RunningProxy,
     ) -> RunningProxy {
         unsafe {
-            let cluster_raw = cass_cluster_new();
+            let mut cluster_raw = cass_cluster_new();
             let ip = node_addr.ip().to_string();
             let (c_ip, c_ip_len) = str_to_c_str_n(ip.as_str());
 
             assert_cass_error_eq!(
-                cass_cluster_set_contact_points_n(cluster_raw, c_ip, c_ip_len),
+                cass_cluster_set_contact_points_n(cluster_raw.borrow_mut(), c_ip, c_ip_len),
                 CassError::CASS_OK
             );
 
             let session_raw = cass_session_new();
 
-            let profile_raw = cass_execution_profile_new();
+            let mut profile_raw = cass_execution_profile_new();
             // A name of a profile that will have been registered in the Cluster.
             let valid_name = "profile";
             let valid_name_c_str = make_c_str!("profile");
@@ -809,36 +828,49 @@ mod tests {
 
             // Inserting into virtual system tables is prohibited and results in WriteFailure error.
             let invalid_query = make_c_str!("INSERT INTO system.runtime_info (group, item, value) VALUES ('bindings_test', 'bindings_test', 'bindings_test')");
-            let statement_raw = cass_statement_new(invalid_query, 0);
-            let batch_raw = cass_batch_new(CassBatchType::CASS_BATCH_TYPE_LOGGED);
+            let mut statement_raw = cass_statement_new(invalid_query, 0);
+            let mut batch_raw = cass_batch_new(CassBatchType::CASS_BATCH_TYPE_LOGGED);
             assert_cass_error_eq!(
-                cass_batch_add_statement(batch_raw, statement_raw),
+                cass_batch_add_statement(batch_raw.borrow_mut(), statement_raw.borrow()),
                 CassError::CASS_OK
             );
 
             assert_cass_error_eq!(
-                cass_cluster_set_execution_profile(cluster_raw, valid_name_c_str, profile_raw,),
+                cass_cluster_set_execution_profile(
+                    cluster_raw.borrow_mut(),
+                    valid_name_c_str,
+                    profile_raw.borrow_mut(),
+                ),
                 CassError::CASS_OK
             );
 
-            cass_future_wait_check_and_free(cass_session_connect(session_raw, cluster_raw));
+            cass_future_wait_check_and_free(cass_session_connect(
+                session_raw.borrow(),
+                cluster_raw.borrow().into_c_const(),
+            ));
             {
                 /* Test valid configurations */
-                let statement = BoxFFI::as_ref(statement_raw);
-                let batch = BoxFFI::as_ref(batch_raw);
                 {
+                    let statement = BoxFFI::as_ref(statement_raw.borrow()).unwrap();
+                    let batch = BoxFFI::as_ref(batch_raw.borrow()).unwrap();
                     assert!(statement.exec_profile.is_none());
                     assert!(batch.exec_profile.is_none());
 
                     // Set exec profile - it is not yet resolved.
                     assert_cass_error_eq!(
-                        cass_statement_set_execution_profile(statement_raw, valid_name_c_str,),
+                        cass_statement_set_execution_profile(
+                            statement_raw.borrow_mut(),
+                            valid_name_c_str,
+                        ),
                         CassError::CASS_OK
                     );
                     assert_cass_error_eq!(
-                        cass_batch_set_execution_profile(batch_raw, valid_name_c_str,),
+                        cass_batch_set_execution_profile(batch_raw.borrow_mut(), valid_name_c_str,),
                         CassError::CASS_OK
                     );
+
+                    let statement = BoxFFI::as_ref(statement_raw.borrow()).unwrap();
+                    let batch = BoxFFI::as_ref(batch_raw.borrow()).unwrap();
                     assert_eq!(
                         statement
                             .exec_profile
@@ -866,7 +898,13 @@ mod tests {
 
                     // Make a query - this should resolve the profile.
                     assert_cass_error_eq!(
-                        cass_future_error_code(cass_session_execute(session_raw, statement_raw)),
+                        cass_future_error_code(
+                            cass_session_execute(
+                                session_raw.borrow(),
+                                statement_raw.borrow().into_c_const()
+                            )
+                            .borrow()
+                        ),
                         CassError::CASS_ERROR_SERVER_WRITE_FAILURE
                     );
                     assert!(statement
@@ -879,7 +917,13 @@ mod tests {
                         .as_handle()
                         .is_some());
                     assert_cass_error_eq!(
-                        cass_future_error_code(cass_session_execute_batch(session_raw, batch_raw,)),
+                        cass_future_error_code(
+                            cass_session_execute_batch(
+                                session_raw.borrow(),
+                                batch_raw.borrow().into_c_const(),
+                            )
+                            .borrow()
+                        ),
                         CassError::CASS_ERROR_SERVER_WRITE_FAILURE
                     );
                     assert!(batch
@@ -894,20 +938,29 @@ mod tests {
 
                     // NULL name sets exec profile to None
                     assert_cass_error_eq!(
-                        cass_statement_set_execution_profile(statement_raw, std::ptr::null::<i8>()),
+                        cass_statement_set_execution_profile(
+                            statement_raw.borrow_mut(),
+                            std::ptr::null::<i8>()
+                        ),
                         CassError::CASS_OK
                     );
                     assert_cass_error_eq!(
-                        cass_batch_set_execution_profile(batch_raw, std::ptr::null::<i8>()),
+                        cass_batch_set_execution_profile(
+                            batch_raw.borrow_mut(),
+                            std::ptr::null::<i8>()
+                        ),
                         CassError::CASS_OK
                     );
+
+                    let statement = BoxFFI::as_ref(statement_raw.borrow()).unwrap();
+                    let batch = BoxFFI::as_ref(batch_raw.borrow()).unwrap();
                     assert!(statement.exec_profile.is_none());
                     assert!(batch.exec_profile.is_none());
 
                     // valid name again, but of nonexisting profile!
                     assert_cass_error_eq!(
                         cass_statement_set_execution_profile_n(
-                            statement_raw,
+                            statement_raw.borrow_mut(),
                             nonexisting_name_c_str,
                             nonexisting_name_len,
                         ),
@@ -915,12 +968,15 @@ mod tests {
                     );
                     assert_cass_error_eq!(
                         cass_batch_set_execution_profile_n(
-                            batch_raw,
+                            batch_raw.borrow_mut(),
                             nonexisting_name_c_str,
                             nonexisting_name_len,
                         ),
                         CassError::CASS_OK
                     );
+
+                    let statement = BoxFFI::as_ref(statement_raw.borrow()).unwrap();
+                    let batch = BoxFFI::as_ref(batch_raw.borrow()).unwrap();
                     assert_eq!(
                         statement
                             .exec_profile
@@ -948,7 +1004,13 @@ mod tests {
 
                     // So when we now issue a query, it should end with error and leave exec_profile_handle uninitialised.
                     assert_cass_error_eq!(
-                        cass_future_error_code(cass_session_execute(session_raw, statement_raw)),
+                        cass_future_error_code(
+                            cass_session_execute(
+                                session_raw.borrow(),
+                                statement_raw.borrow().into_c_const()
+                            )
+                            .borrow()
+                        ),
                         CassError::CASS_ERROR_LIB_EXECUTION_PROFILE_INVALID
                     );
                     assert_eq!(
@@ -964,7 +1026,13 @@ mod tests {
                         &nonexisting_name.to_owned().try_into().unwrap()
                     );
                     assert_cass_error_eq!(
-                        cass_future_error_code(cass_session_execute_batch(session_raw, batch_raw)),
+                        cass_future_error_code(
+                            cass_session_execute_batch(
+                                session_raw.borrow(),
+                                batch_raw.borrow().into_c_const()
+                            )
+                            .borrow()
+                        ),
                         CassError::CASS_ERROR_LIB_EXECUTION_PROFILE_INVALID
                     );
                     assert_eq!(
@@ -982,7 +1050,7 @@ mod tests {
                 }
             }
 
-            cass_future_wait_check_and_free(cass_session_close(session_raw));
+            cass_future_wait_check_and_free(cass_session_close(session_raw.borrow()));
             cass_execution_profile_free(profile_raw);
             cass_statement_free(statement_raw);
             cass_batch_free(batch_raw);
@@ -1052,49 +1120,71 @@ mod tests {
         mut proxy: RunningProxy,
     ) -> RunningProxy {
         unsafe {
-            let cluster_raw = cass_cluster_new();
+            let mut cluster_raw = cass_cluster_new();
             let ip = node_addr.ip().to_string();
             let (c_ip, c_ip_len) = str_to_c_str_n(ip.as_str());
 
             assert_cass_error_eq!(
-                cass_cluster_set_contact_points_n(cluster_raw, c_ip, c_ip_len,),
+                cass_cluster_set_contact_points_n(cluster_raw.borrow_mut(), c_ip, c_ip_len,),
                 CassError::CASS_OK
             );
 
             let fallthrough_policy = cass_retry_policy_fallthrough_new();
             let default_policy = cass_retry_policy_default_new();
-            cass_cluster_set_retry_policy(cluster_raw, fallthrough_policy);
+            cass_cluster_set_retry_policy(cluster_raw.borrow_mut(), fallthrough_policy.borrow());
 
             let session_raw = cass_session_new();
 
-            let profile_raw = cass_execution_profile_new();
+            let mut profile_raw = cass_execution_profile_new();
             // A name of a profile that will have been registered in the Cluster.
             let profile_name_c_str = make_c_str!("profile");
 
             assert_cass_error_eq!(
-                cass_execution_profile_set_retry_policy(profile_raw, default_policy),
+                cass_execution_profile_set_retry_policy(
+                    profile_raw.borrow_mut(),
+                    default_policy.borrow()
+                ),
                 CassError::CASS_OK
             );
 
             let query = make_c_str!("SELECT host_id FROM system.local WHERE key='local'");
-            let statement_raw = cass_statement_new(query, 0);
-            let batch_raw = cass_batch_new(CassBatchType::CASS_BATCH_TYPE_LOGGED);
+            let mut statement_raw = cass_statement_new(query, 0);
+            let mut batch_raw = cass_batch_new(CassBatchType::CASS_BATCH_TYPE_LOGGED);
             assert_cass_error_eq!(
-                cass_batch_add_statement(batch_raw, statement_raw),
+                cass_batch_add_statement(batch_raw.borrow_mut(), statement_raw.borrow()),
                 CassError::CASS_OK
             );
 
             assert_cass_error_eq!(
-                cass_cluster_set_execution_profile(cluster_raw, profile_name_c_str, profile_raw,),
+                cass_cluster_set_execution_profile(
+                    cluster_raw.borrow_mut(),
+                    profile_name_c_str,
+                    profile_raw.borrow_mut(),
+                ),
                 CassError::CASS_OK
             );
 
-            cass_future_wait_check_and_free(cass_session_connect(session_raw, cluster_raw));
+            cass_future_wait_check_and_free(cass_session_connect(
+                session_raw.borrow(),
+                cluster_raw.borrow().into_c_const(),
+            ));
             {
-                let execute_query =
-                    || cass_future_error_code(cass_session_execute(session_raw, statement_raw));
-                let execute_batch =
-                    || cass_future_error_code(cass_session_execute_batch(session_raw, batch_raw));
+                unsafe fn execute_query(
+                    session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
+                    statement_raw: CassBorrowedSharedPtr<CassStatement, CConst>,
+                ) -> CassError {
+                    cass_future_error_code(
+                        cass_session_execute(session_raw, statement_raw).borrow(),
+                    )
+                }
+                unsafe fn execute_batch(
+                    session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
+                    batch_raw: CassBorrowedSharedPtr<CassBatch, CConst>,
+                ) -> CassError {
+                    cass_future_error_code(
+                        cass_session_execute_batch(session_raw, batch_raw).borrow(),
+                    )
+                }
 
                 fn reset_proxy_rules(proxy: &mut RunningProxy) {
                     proxy.running_nodes[0].change_request_rules(Some(
@@ -1104,33 +1194,47 @@ mod tests {
                     ))
                 }
 
-                let assert_query_with_fallthrough_policy = |proxy: &mut RunningProxy| {
+                unsafe fn assert_query_with_fallthrough_policy(
+                    proxy: &mut RunningProxy,
+                    session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
+                    statement_raw: CassBorrowedSharedPtr<CassStatement, CConst>,
+                    batch_raw: CassBorrowedSharedPtr<CassBatch, CConst>,
+                ) {
                     reset_proxy_rules(&mut *proxy);
                     assert_cass_error_eq!(
-                        execute_query(),
+                        execute_query(session_raw.borrow(), statement_raw),
                         CassError::CASS_ERROR_SERVER_READ_TIMEOUT,
                     );
                     reset_proxy_rules(&mut *proxy);
                     assert_cass_error_eq!(
-                        execute_batch(),
+                        execute_batch(session_raw, batch_raw),
                         CassError::CASS_ERROR_SERVER_READ_TIMEOUT,
                     );
-                };
+                }
 
-                let assert_query_with_default_policy = |proxy: &mut RunningProxy| {
+                unsafe fn assert_query_with_default_policy(
+                    proxy: &mut RunningProxy,
+                    session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
+                    statement_raw: CassBorrowedSharedPtr<CassStatement, CConst>,
+                    batch_raw: CassBorrowedSharedPtr<CassBatch, CConst>,
+                ) {
                     reset_proxy_rules(&mut *proxy);
                     assert_cass_error_eq!(
-                        execute_query(),
+                        execute_query(session_raw.borrow(), statement_raw),
                         CassError::CASS_ERROR_SERVER_READ_FAILURE
                     );
                     reset_proxy_rules(&mut *proxy);
                     assert_cass_error_eq!(
-                        execute_batch(),
+                        execute_batch(session_raw, batch_raw),
                         CassError::CASS_ERROR_SERVER_READ_FAILURE
                     );
-                };
+                }
 
-                let set_provided_exec_profile = |name| {
+                unsafe fn set_provided_exec_profile(
+                    name: *const i8,
+                    statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
+                    batch_raw: CassBorrowedExclusivePtr<CassBatch, CMut>,
+                ) {
                     // Set statement/batch exec profile.
                     assert_cass_error_eq!(
                         cass_statement_set_execution_profile(statement_raw, name,),
@@ -1140,26 +1244,40 @@ mod tests {
                         cass_batch_set_execution_profile(batch_raw, name,),
                         CassError::CASS_OK
                     );
-                };
-                let set_exec_profile = || {
-                    set_provided_exec_profile(profile_name_c_str);
-                };
-                let unset_exec_profile = || {
-                    set_provided_exec_profile(std::ptr::null::<i8>());
-                };
-                let set_retry_policy_on_stmt = |policy| {
+                }
+                unsafe fn set_exec_profile(
+                    profile_name_c_str: *const c_char,
+                    statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
+                    batch_raw: CassBorrowedExclusivePtr<CassBatch, CMut>,
+                ) {
+                    set_provided_exec_profile(profile_name_c_str, statement_raw, batch_raw);
+                }
+                unsafe fn unset_exec_profile(
+                    statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
+                    batch_raw: CassBorrowedExclusivePtr<CassBatch, CMut>,
+                ) {
+                    set_provided_exec_profile(std::ptr::null::<i8>(), statement_raw, batch_raw);
+                }
+                unsafe fn set_retry_policy_on_stmt(
+                    policy: CassBorrowedSharedPtr<CassRetryPolicy, CMut>,
+                    statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
+                    batch_raw: CassBorrowedExclusivePtr<CassBatch, CMut>,
+                ) {
                     assert_cass_error_eq!(
-                        cass_statement_set_retry_policy(statement_raw, policy,),
+                        cass_statement_set_retry_policy(statement_raw, policy.borrow(),),
                         CassError::CASS_OK
                     );
                     assert_cass_error_eq!(
                         cass_batch_set_retry_policy(batch_raw, policy,),
                         CassError::CASS_OK
                     );
-                };
-                let unset_retry_policy_on_stmt = || {
-                    set_retry_policy_on_stmt(std::ptr::null());
-                };
+                }
+                unsafe fn unset_retry_policy_on_stmt(
+                    statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
+                    batch_raw: CassBorrowedExclusivePtr<CassBatch, CMut>,
+                ) {
+                    set_retry_policy_on_stmt(ArcFFI::null(), statement_raw, batch_raw);
+                }
 
                 // ### START TESTING
 
@@ -1167,62 +1285,164 @@ mod tests {
                 // the default cluster-wide retry policy should be used: in this case, fallthrough.
 
                 // F - -
-                assert_query_with_fallthrough_policy(&mut proxy);
+                assert_query_with_fallthrough_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F D -
-                set_exec_profile();
-                assert_query_with_default_policy(&mut proxy);
+                set_exec_profile(
+                    profile_name_c_str,
+                    statement_raw.borrow_mut(),
+                    batch_raw.borrow_mut(),
+                );
+                assert_query_with_default_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F - -
-                unset_exec_profile();
-                assert_query_with_fallthrough_policy(&mut proxy);
+                unset_exec_profile(statement_raw.borrow_mut(), batch_raw.borrow_mut());
+                assert_query_with_fallthrough_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F - F
-                set_retry_policy_on_stmt(fallthrough_policy);
-                assert_query_with_fallthrough_policy(&mut proxy);
+                set_retry_policy_on_stmt(
+                    fallthrough_policy.borrow(),
+                    statement_raw.borrow_mut(),
+                    batch_raw.borrow_mut(),
+                );
+                assert_query_with_fallthrough_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F D F
-                set_exec_profile();
-                assert_query_with_fallthrough_policy(&mut proxy);
+                set_exec_profile(
+                    profile_name_c_str,
+                    statement_raw.borrow_mut(),
+                    batch_raw.borrow_mut(),
+                );
+                assert_query_with_fallthrough_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F D -
-                unset_retry_policy_on_stmt();
-                assert_query_with_default_policy(&mut proxy);
+                unset_retry_policy_on_stmt(statement_raw.borrow_mut(), batch_raw.borrow_mut());
+                assert_query_with_default_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F D F
-                set_retry_policy_on_stmt(fallthrough_policy);
-                assert_query_with_fallthrough_policy(&mut proxy);
+                set_retry_policy_on_stmt(
+                    fallthrough_policy.borrow(),
+                    statement_raw.borrow_mut(),
+                    batch_raw.borrow_mut(),
+                );
+                assert_query_with_fallthrough_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F D D
-                set_retry_policy_on_stmt(default_policy);
-                assert_query_with_default_policy(&mut proxy);
+                set_retry_policy_on_stmt(
+                    default_policy.borrow(),
+                    statement_raw.borrow_mut(),
+                    batch_raw.borrow_mut(),
+                );
+                assert_query_with_default_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F D F
-                set_retry_policy_on_stmt(fallthrough_policy);
-                assert_query_with_fallthrough_policy(&mut proxy);
+                set_retry_policy_on_stmt(
+                    fallthrough_policy.borrow(),
+                    statement_raw.borrow_mut(),
+                    batch_raw.borrow_mut(),
+                );
+                assert_query_with_fallthrough_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F - F
-                unset_exec_profile();
-                assert_query_with_fallthrough_policy(&mut proxy);
+                unset_exec_profile(statement_raw.borrow_mut(), batch_raw.borrow_mut());
+                assert_query_with_fallthrough_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F - -
-                unset_retry_policy_on_stmt();
-                assert_query_with_fallthrough_policy(&mut proxy);
+                unset_retry_policy_on_stmt(statement_raw.borrow_mut(), batch_raw.borrow_mut());
+                assert_query_with_fallthrough_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F - D
-                set_retry_policy_on_stmt(default_policy);
-                assert_query_with_default_policy(&mut proxy);
+                set_retry_policy_on_stmt(
+                    default_policy.borrow(),
+                    statement_raw.borrow_mut(),
+                    batch_raw.borrow_mut(),
+                );
+                assert_query_with_default_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F D D
-                set_exec_profile();
-                assert_query_with_default_policy(&mut proxy);
+                set_exec_profile(
+                    profile_name_c_str,
+                    statement_raw.borrow_mut(),
+                    batch_raw.borrow_mut(),
+                );
+                assert_query_with_default_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
 
                 // F D -
-                unset_retry_policy_on_stmt();
-                assert_query_with_default_policy(&mut proxy);
+                unset_retry_policy_on_stmt(statement_raw.borrow_mut(), batch_raw.borrow_mut());
+                assert_query_with_default_policy(
+                    &mut proxy,
+                    session_raw.borrow(),
+                    statement_raw.borrow().into_c_const(),
+                    batch_raw.borrow().into_c_const(),
+                );
             }
 
-            cass_future_wait_check_and_free(cass_session_close(session_raw));
+            cass_future_wait_check_and_free(cass_session_close(session_raw.borrow()));
             cass_execution_profile_free(profile_raw);
             cass_statement_free(statement_raw);
             cass_batch_free(batch_raw);
@@ -1236,28 +1456,36 @@ mod tests {
     #[ntest::timeout(5000)]
     fn session_with_latency_aware_load_balancing_does_not_panic() {
         unsafe {
-            let cluster_raw = cass_cluster_new();
+            let mut cluster_raw = cass_cluster_new();
 
             // An IP with very little chance of having a Scylla node listening
             let ip = "127.0.1.231";
             let (c_ip, c_ip_len) = str_to_c_str_n(ip);
 
             assert_cass_error_eq!(
-                cass_cluster_set_contact_points_n(cluster_raw, c_ip, c_ip_len),
+                cass_cluster_set_contact_points_n(cluster_raw.borrow_mut(), c_ip, c_ip_len),
                 CassError::CASS_OK
             );
-            cass_cluster_set_latency_aware_routing(cluster_raw, true as cass_bool_t);
+            cass_cluster_set_latency_aware_routing(cluster_raw.borrow_mut(), true as cass_bool_t);
             let session_raw = cass_session_new();
-            let profile_raw = cass_execution_profile_new();
+            let mut profile_raw = cass_execution_profile_new();
             assert_cass_error_eq!(
-                cass_execution_profile_set_latency_aware_routing(profile_raw, true as cass_bool_t),
+                cass_execution_profile_set_latency_aware_routing(
+                    profile_raw.borrow_mut(),
+                    true as cass_bool_t
+                ),
                 CassError::CASS_OK
             );
             let profile_name = make_c_str!("latency_aware");
-            cass_cluster_set_execution_profile(cluster_raw, profile_name, profile_raw);
+            cass_cluster_set_execution_profile(
+                cluster_raw.borrow_mut(),
+                profile_name,
+                profile_raw.borrow_mut(),
+            );
             {
-                let cass_future = cass_session_connect(session_raw, cluster_raw);
-                cass_future_wait(cass_future);
+                let cass_future =
+                    cass_session_connect(session_raw.borrow(), cluster_raw.borrow().into_c_const());
+                cass_future_wait(cass_future.borrow());
                 // The exact outcome is not important, we only test that we don't panic.
             }
             cass_execution_profile_free(profile_raw);
@@ -1276,27 +1504,27 @@ mod tests {
             let profile_name = make_c_str!("latency_aware");
 
             unsafe {
-                let cluster_raw = cass_cluster_new();
+                let mut cluster_raw = cass_cluster_new();
 
                 assert_cass_error_eq!(
-                    cass_cluster_set_contact_points_n(cluster_raw, c_ip, c_ip_len),
+                    cass_cluster_set_contact_points_n(cluster_raw.borrow_mut(), c_ip, c_ip_len),
                     CassError::CASS_OK
                 );
-                cass_cluster_set_latency_aware_routing(cluster_raw, true as cass_bool_t);
+                cass_cluster_set_latency_aware_routing(cluster_raw.borrow_mut(), true as cass_bool_t);
                 let session_raw = cass_session_new();
-                let profile_raw = cass_execution_profile_new();
+                let mut profile_raw = cass_execution_profile_new();
                 assert_cass_error_eq!(
-                    cass_execution_profile_set_latency_aware_routing(profile_raw, true as cass_bool_t),
+                    cass_execution_profile_set_latency_aware_routing(profile_raw.borrow_mut(), true as cass_bool_t),
                     CassError::CASS_OK
                 );
-                cass_cluster_set_execution_profile(cluster_raw, profile_name, profile_raw);
+                cass_cluster_set_execution_profile(cluster_raw.borrow_mut(), profile_name, profile_raw.borrow_mut());
                 {
-                    let cass_future = cass_session_connect(session_raw, cluster_raw);
+                    let cass_future = cass_session_connect(session_raw.borrow(), cluster_raw.borrow().into_c_const());
 
                     // This checks that we don't use-after-free the cluster inside the future.
                     cass_cluster_free(cluster_raw);
 
-                    cass_future_wait(cass_future);
+                    cass_future_wait(cass_future.borrow());
                     // The exact outcome is not important, we only test that we don't segfault.
                 }
                 cass_execution_profile_free(profile_raw);

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -137,7 +137,9 @@ impl CassSessionInner {
 
 pub type CassSession = RwLock<Option<CassSessionInner>>;
 
-impl ArcFFI for CassSession {}
+impl FFI for CassSession {
+    type Origin = FromArc;
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_session_new() -> CassOwnedSharedPtr<CassSession, CMut> {

--- a/scylla-rust-wrapper/src/ssl.rs
+++ b/scylla-rust-wrapper/src/ssl.rs
@@ -1,4 +1,6 @@
-use crate::argconv::ArcFFI;
+use crate::argconv::CassBorrowedSharedPtr;
+use crate::argconv::CassOwnedSharedPtr;
+use crate::argconv::{ArcFFI, CMut};
 use crate::cass_error::CassError;
 use crate::types::size_t;
 use libc::{c_int, strlen};
@@ -27,13 +29,13 @@ pub const CASS_SSL_VERIFY_PEER_IDENTITY: i32 = 0x02;
 pub const CASS_SSL_VERIFY_PEER_IDENTITY_DNS: i32 = 0x04;
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_ssl_new() -> *mut CassSsl {
+pub unsafe extern "C" fn cass_ssl_new() -> CassOwnedSharedPtr<CassSsl, CMut> {
     openssl_sys::init();
     cass_ssl_new_no_lib_init()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_ssl_new_no_lib_init() -> *mut CassSsl {
+pub unsafe extern "C" fn cass_ssl_new_no_lib_init() -> CassOwnedSharedPtr<CassSsl, CMut> {
     let ssl_context: *mut SSL_CTX = SSL_CTX_new(TLS_method());
     let trusted_store: *mut X509_STORE = X509_STORE_new();
 
@@ -45,7 +47,7 @@ pub unsafe extern "C" fn cass_ssl_new_no_lib_init() -> *mut CassSsl {
         trusted_store,
     };
 
-    ArcFFI::into_ptr(Arc::new(ssl)) as *mut _
+    ArcFFI::into_ptr(Arc::new(ssl))
 }
 
 // This is required for the type system to impl Send + Sync for Arc<CassSsl>.
@@ -64,7 +66,7 @@ impl Drop for CassSsl {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_ssl_free(ssl: *mut CassSsl) {
+pub unsafe extern "C" fn cass_ssl_free(ssl: CassOwnedSharedPtr<CassSsl, CMut>) {
     ArcFFI::free(ssl);
 }
 
@@ -96,7 +98,7 @@ unsafe extern "C" fn pem_password_callback(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_ssl_add_trusted_cert(
-    ssl: *mut CassSsl,
+    ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
     cert: *const c_char,
 ) -> CassError {
     if cert.is_null() {
@@ -108,11 +110,11 @@ pub unsafe extern "C" fn cass_ssl_add_trusted_cert(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_ssl_add_trusted_cert_n(
-    ssl: *mut CassSsl,
+    ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
     cert: *const c_char,
     cert_length: size_t,
 ) -> CassError {
-    let ssl = ArcFFI::cloned_from_ptr(ssl);
+    let ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
     let bio = BIO_new_mem_buf(cert as *const c_void, cert_length.try_into().unwrap());
 
     if bio.is_null() {
@@ -139,8 +141,11 @@ pub unsafe extern "C" fn cass_ssl_add_trusted_cert_n(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_ssl_set_verify_flags(ssl: *mut CassSsl, flags: i32) {
-    let ssl = ArcFFI::cloned_from_ptr(ssl);
+pub unsafe extern "C" fn cass_ssl_set_verify_flags(
+    ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
+    flags: i32,
+) {
+    let ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
 
     match flags {
         CASS_SSL_VERIFY_NONE => {
@@ -164,7 +169,10 @@ pub unsafe extern "C" fn cass_ssl_set_verify_flags(ssl: *mut CassSsl, flags: i32
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_ssl_set_cert(ssl: *mut CassSsl, cert: *const c_char) -> CassError {
+pub unsafe extern "C" fn cass_ssl_set_cert(
+    ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
+    cert: *const c_char,
+) -> CassError {
     if cert.is_null() {
         return CassError::CASS_ERROR_SSL_INVALID_CERT;
     }
@@ -174,11 +182,11 @@ pub unsafe extern "C" fn cass_ssl_set_cert(ssl: *mut CassSsl, cert: *const c_cha
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_ssl_set_cert_n(
-    ssl: *mut CassSsl,
+    ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
     cert: *const c_char,
     cert_length: size_t,
 ) -> CassError {
-    let ssl = ArcFFI::cloned_from_ptr(ssl);
+    let ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
     let bio = BIO_new_mem_buf(cert as *const c_void, cert_length.try_into().unwrap());
 
     if bio.is_null() {
@@ -246,7 +254,7 @@ unsafe extern "C" fn SSL_CTX_use_certificate_chain_bio(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_ssl_set_private_key(
-    ssl: *mut CassSsl,
+    ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
     key: *const c_char,
     password: *mut c_char,
 ) -> CassError {
@@ -265,13 +273,13 @@ pub unsafe extern "C" fn cass_ssl_set_private_key(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_ssl_set_private_key_n(
-    ssl: *mut CassSsl,
+    ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
     key: *const c_char,
     key_length: size_t,
     password: *mut c_char,
     _password_length: size_t,
 ) -> CassError {
-    let ssl = ArcFFI::cloned_from_ptr(ssl);
+    let ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
     let bio = BIO_new_mem_buf(key as *const c_void, key_length.try_into().unwrap());
 
     if bio.is_null() {

--- a/scylla-rust-wrapper/src/ssl.rs
+++ b/scylla-rust-wrapper/src/ssl.rs
@@ -1,6 +1,4 @@
-use crate::argconv::CassBorrowedSharedPtr;
-use crate::argconv::CassOwnedSharedPtr;
-use crate::argconv::{ArcFFI, CMut};
+use crate::argconv::{ArcFFI, CMut, CassBorrowedSharedPtr, CassOwnedSharedPtr, FromArc, FFI};
 use crate::cass_error::CassError;
 use crate::types::size_t;
 use libc::{c_int, strlen};
@@ -21,7 +19,9 @@ pub struct CassSsl {
     pub(crate) trusted_store: *mut X509_STORE,
 }
 
-impl ArcFFI for CassSsl {}
+impl FFI for CassSsl {
+    type Origin = FromArc;
+}
 
 pub const CASS_SSL_VERIFY_NONE: i32 = 0x00;
 pub const CASS_SSL_VERIFY_PEER_CERT: i32 = 0x01;

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -216,7 +216,9 @@ pub struct CassStatement {
     pub(crate) exec_profile: Option<PerStatementExecProfile>,
 }
 
-impl BoxFFI for CassStatement {}
+impl FFI for CassStatement {
+    type Origin = FromBox;
+}
 
 impl CassStatement {
     fn bind_cql_value(&mut self, index: usize, value: Option<CassCqlValue>) -> CassError {

--- a/scylla-rust-wrapper/src/testing.rs
+++ b/scylla-rust-wrapper/src/testing.rs
@@ -21,7 +21,7 @@ macro_rules! assert_cass_future_error_message_eq {
 
         let mut ___message: *const c_char = ::std::ptr::null();
         let mut ___msg_len: size_t = 0;
-        cass_future_error_message($cass_fut, &mut ___message, &mut ___msg_len);
+        cass_future_error_message($cass_fut.borrow(), &mut ___message, &mut ___msg_len);
         assert_eq!(ptr_to_cstr_n(___message, ___msg_len), $error_msg_opt);
     };
 }

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -63,7 +63,9 @@ impl From<&CassTuple> for CassCqlValue {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_tuple_new(item_count: size_t) -> *mut CassTuple {
+pub unsafe extern "C" fn cass_tuple_new(
+    item_count: size_t,
+) -> CassOwnedExclusivePtr<CassTuple, CMut> {
     BoxFFI::into_ptr(Box::new(CassTuple {
         data_type: None,
         items: vec![None; item_count as usize],
@@ -72,12 +74,12 @@ pub unsafe extern "C" fn cass_tuple_new(item_count: size_t) -> *mut CassTuple {
 
 #[no_mangle]
 unsafe extern "C" fn cass_tuple_new_from_data_type(
-    data_type: *const CassDataType,
-) -> *mut CassTuple {
-    let data_type = ArcFFI::cloned_from_ptr(data_type);
+    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
+) -> CassOwnedExclusivePtr<CassTuple, CMut> {
+    let data_type = ArcFFI::cloned_from_ptr(data_type).unwrap();
     let item_count = match data_type.get_unchecked() {
         CassDataTypeInner::Tuple(v) => v.len(),
-        _ => return std::ptr::null_mut(),
+        _ => return BoxFFI::null_mut(),
     };
     BoxFFI::into_ptr(Box::new(CassTuple {
         data_type: Some(data_type),
@@ -86,13 +88,15 @@ unsafe extern "C" fn cass_tuple_new_from_data_type(
 }
 
 #[no_mangle]
-unsafe extern "C" fn cass_tuple_free(tuple: *mut CassTuple) {
+unsafe extern "C" fn cass_tuple_free(tuple: CassOwnedExclusivePtr<CassTuple, CMut>) {
     BoxFFI::free(tuple);
 }
 
 #[no_mangle]
-unsafe extern "C" fn cass_tuple_data_type(tuple: *const CassTuple) -> *const CassDataType {
-    match &BoxFFI::as_ref(tuple).data_type {
+unsafe extern "C" fn cass_tuple_data_type(
+    tuple: CassBorrowedSharedPtr<CassTuple, CConst>,
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+    match &BoxFFI::as_ref(tuple).unwrap().data_type {
         Some(t) => ArcFFI::as_ptr(t),
         None => ArcFFI::as_ptr(&UNTYPED_TUPLE_TYPE),
     }
@@ -136,12 +140,12 @@ mod tests {
             let empty_tuple = cass_tuple_new(2);
 
             // This would previously return a non Arc-based pointer.
-            let empty_tuple_dt = cass_tuple_data_type(empty_tuple);
+            let empty_tuple_dt = cass_tuple_data_type(empty_tuple.borrow().into_c_const());
 
             let empty_set_dt = cass_data_type_new(CassValueType::CASS_VALUE_TYPE_SET);
             // This will try to increment the reference count of `empty_tuple_dt`.
             // Previously, this would fail, because `empty_tuple_dt` did not originate from an Arc allocation.
-            cass_data_type_add_sub_type(empty_set_dt, empty_tuple_dt);
+            cass_data_type_add_sub_type(empty_set_dt.borrow(), empty_tuple_dt);
 
             cass_data_type_free(empty_set_dt)
         }

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -17,7 +17,9 @@ pub struct CassTuple {
     pub items: Vec<Option<CassCqlValue>>,
 }
 
-impl BoxFFI for CassTuple {}
+impl FFI for CassTuple {
+    type Origin = FromBox;
+}
 
 impl CassTuple {
     fn get_types(&self) -> Option<&Vec<Arc<CassDataType>>> {

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -83,9 +83,9 @@ impl From<&CassUserType> for CassCqlValue {
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_user_type_new_from_data_type(
-    data_type_raw: *const CassDataType,
-) -> *mut CassUserType {
-    let data_type = ArcFFI::cloned_from_ptr(data_type_raw);
+    data_type_raw: CassBorrowedSharedPtr<CassDataType, CConst>,
+) -> CassOwnedExclusivePtr<CassUserType, CMut> {
+    let data_type = ArcFFI::cloned_from_ptr(data_type_raw).unwrap();
 
     match data_type.get_unchecked() {
         CassDataTypeInner::UDT(udt_data_type) => {
@@ -95,19 +95,19 @@ pub unsafe extern "C" fn cass_user_type_new_from_data_type(
                 field_values,
             }))
         }
-        _ => std::ptr::null_mut(),
+        _ => BoxFFI::null_mut(),
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_user_type_free(user_type: *mut CassUserType) {
+pub unsafe extern "C" fn cass_user_type_free(user_type: CassOwnedExclusivePtr<CassUserType, CMut>) {
     BoxFFI::free(user_type);
 }
 #[no_mangle]
 pub unsafe extern "C" fn cass_user_type_data_type(
-    user_type: *const CassUserType,
-) -> *const CassDataType {
-    ArcFFI::as_ptr(&BoxFFI::as_ref(user_type).data_type)
+    user_type: CassBorrowedSharedPtr<CassUserType, CConst>,
+) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+    ArcFFI::as_ptr(&BoxFFI::as_ref(user_type).unwrap().data_type)
 }
 
 prepare_binders_macro!(@index_and_name CassUserType,

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -14,7 +14,9 @@ pub struct CassUserType {
     pub field_values: Vec<Option<CassCqlValue>>,
 }
 
-impl BoxFFI for CassUserType {}
+impl FFI for CassUserType {
+    type Origin = FromBox;
+}
 
 impl CassUserType {
     fn set_field_by_index(&mut self, index: usize, value: Option<CassCqlValue>) -> CassError {

--- a/scylla-rust-wrapper/src/uuid.rs
+++ b/scylla-rust-wrapper/src/uuid.rs
@@ -17,7 +17,9 @@ pub struct CassUuidGen {
     pub last_timestamp: AtomicU64,
 }
 
-impl BoxFFI for CassUuidGen {}
+impl FFI for CassUuidGen {
+    type Origin = FromBox;
+}
 
 // Implementation directly ported from Cpp Driver implementation:
 

--- a/scylla-rust-wrapper/src/uuid.rs
+++ b/scylla-rust-wrapper/src/uuid.rs
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn cass_uuid_max_from_time(timestamp: cass_uint64_t, outpu
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_uuid_gen_new() -> *mut CassUuidGen {
+pub unsafe extern "C" fn cass_uuid_gen_new() -> CassOwnedExclusivePtr<CassUuidGen, CMut> {
     // Inspired by C++ driver implementation in its intent.
     // The original driver tries to generate a number that
     // uniquely identifies this machine and the current process.
@@ -122,7 +122,9 @@ pub unsafe extern "C" fn cass_uuid_gen_new() -> *mut CassUuidGen {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_uuid_gen_new_with_node(node: cass_uint64_t) -> *mut CassUuidGen {
+pub unsafe extern "C" fn cass_uuid_gen_new_with_node(
+    node: cass_uint64_t,
+) -> CassOwnedExclusivePtr<CassUuidGen, CMut> {
     BoxFFI::into_ptr(Box::new(CassUuidGen {
         clock_seq_and_node: rand_clock_seq_and_node(node & 0x0000FFFFFFFFFFFF),
         last_timestamp: AtomicU64::new(0),
@@ -130,8 +132,11 @@ pub unsafe extern "C" fn cass_uuid_gen_new_with_node(node: cass_uint64_t) -> *mu
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_uuid_gen_time(uuid_gen: *mut CassUuidGen, output: *mut CassUuid) {
-    let uuid_gen = BoxFFI::as_mut_ref(uuid_gen);
+pub unsafe extern "C" fn cass_uuid_gen_time(
+    uuid_gen: CassBorrowedExclusivePtr<CassUuidGen, CMut>,
+    output: *mut CassUuid,
+) {
+    let uuid_gen = BoxFFI::as_mut_ref(uuid_gen).unwrap();
 
     let uuid = CassUuid {
         time_and_version: set_version(monotonic_timestamp(&mut uuid_gen.last_timestamp), 1),
@@ -157,11 +162,11 @@ pub unsafe extern "C" fn cass_uuid_gen_random(_uuid_gen: *mut CassUuidGen, outpu
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_uuid_gen_from_time(
-    uuid_gen: *mut CassUuidGen,
+    uuid_gen: CassBorrowedExclusivePtr<CassUuidGen, CMut>,
     timestamp: cass_uint64_t,
     output: *mut CassUuid,
 ) {
-    let uuid_gen = BoxFFI::as_mut_ref(uuid_gen);
+    let uuid_gen = BoxFFI::as_mut_ref(uuid_gen).unwrap();
 
     let uuid = CassUuid {
         time_and_version: set_version(from_unix_timestamp(timestamp), 1),
@@ -250,6 +255,6 @@ pub unsafe extern "C" fn cass_uuid_from_string_n(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_uuid_gen_free(uuid_gen: *mut CassUuidGen) {
+pub unsafe extern "C" fn cass_uuid_gen_free(uuid_gen: CassOwnedExclusivePtr<CassUuidGen, CMut>) {
     BoxFFI::free(uuid_gen);
 }


### PR DESCRIPTION
This is a follow-up to: https://github.com/scylladb/cpp-rust-driver/pull/207.

It defines a `CassPtr` type, wrapper over `Option<NonNull<T>>`. The pointer is parameterized by:
## Lifetime
Thanks to that, we can distinguish between owned (should be freed) and borrowed pointers.

## Properties
There are currently two properties:
1. `Ownership` - it tells whether the pointer is mutable from Rust perspective. In other words, `Exclusive` = mutable pointer, `Shared` = immutable pointer.
2. `CMutability` - the semantics of this one are very simple. It just tells whether the pointer is `T*` or `const T*` in C API definition. It's introduced so we can distinguish **shared**, **logically mutable** types (`Mutability::Const` and `CMutability::CMut`) from **shared**, **logically immutable** types (`Mutability::Const` and `CMutability::CConst`). This property will help to write safe unit tests where we play a role of C API user.

During review, please pay attention to that if some pointer was originally `const T*` (or `*const T` in Rust), then it is `CConst` after this PR. Analogously, if it was `T*` (or `*mut T` in Rust), then it should be `CMut`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~