### PR TITLE
Release 0.3.0

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-cpp-driver-rust"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_matches",
  "bindgen",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cpp-driver-rust"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"
 repository = "https://github.com/scylladb/scylla-rust-driver"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB CPP Rust Driver 0.3.0, an API-compatible rewrite of https://github.com/scylladb/cpp-driver as a wrapper for the Rust driver. It will fully replace the CPP driver, which is already reaching its End of Life.
**The current driver version should be considered Alpha**. 

Some minor features still need to be included. See [_Limitations_ section in README.md](README.md#Limitations).

The underlying Rust driver used version: [0.15.0](https://github.com/scylladb/scylla-rust-driver/releases/tag/v0.15.0).

Currently, the cpp-rust-driver does not fully utilize lazy deserialization mechanism introduced in rust-driver 0.15.0. The support for lazy deserialization, and all features
that depend on it are going to be introduced in some future release.

## Changes

Starting from this release, features that are not part of original `cpp-driver`, but are implemented in `cpp-rust-driver` as an extension to original API, will be labeled as 🚀 **[Extension]**.

**Implemented API functions:**
- **CassPrepared:** ([#185](https://github.com/scylladb/cpp-rust-driver/pull/185))
    - `cass_prepared_parameter_name`
    - `cass_prepared_parameter_data_type`
    - `cass_prepared_parameter_data_type_by_name[_n]`
- **CassResult:** ([#136](https://github.com/scylladb/cpp-rust-driver/pull/136))
    - `cass_result_column_type`
    - `cass_result_column_data_type`
- **Heartbeat/Keepalive:** ([#194](https://github.com/scylladb/cpp-rust-driver/pull/194))
    - `cass_cluster_set_connection_heartbeat_interval`
    - `cass_cluster_set_connection_idle_timeout`
- **Schema agreement:** ([#198](https://github.com/scylladb/cpp-rust-driver/pull/198))
    - `cass_cluster_set_max_schema_wait_time`
    - `cass_cluster_set_schema_agreement_interval` 🚀 **[Extension]**
- **Rack awareness:** ([#195](https://github.com/scylladb/cpp-rust-driver/pull/195))
    - `cass_cluster_set_load_balance_rack_aware[_n]`
    - `cass_execution_profile_set_load_balance_rack_aware[_n]`

**New features / enhancements**
- Prepared statements now cache result metadata provided by the server. The metadata is **NOT** updated when table schema is altered. ([#136](https://github.com/scylladb/cpp-rust-driver/pull/136), [#205](https://github.com/scylladb/cpp-rust-driver/pull/205))

**Bug fixes:**
- Fixed `cass_result_first_row` implementation. Previously, it would panic for `RESULT:Rows` response with empty rows. ([#136](https://github.com/scylladb/cpp-rust-driver/pull/136))
- Original cpp-driver tries to prepare an empty statement when null pointer is provided
to `cass_session_prepare`. We decided to inherit this behaviour for compatibility reasons. ([#194](https://github.com/scylladb/cpp-rust-driver/pull/194))
- Adjusted some cluster config defaults, according to the defaults specified by `cassandra.h`. ([#193](https://github.com/scylladb/cpp-rust-driver/pull/193))
- Fixed the bug where the driver would fallthrough to default round-robin LBP for execution profiles whose LBP was not set by the user. Now, if the LBP for the execution profile is not set, the driver chooses the global LBP defined on the cluster object. ([#197](https://github.com/scylladb/cpp-rust-driver/pull/197))
- Fixed the bug where result metadata would be inconsistent for prepared statements when table schema was altered. ([#205](https://github.com/scylladb/cpp-rust-driver/pull/205))

**CI / developer tool improvements:**
- Adjusted to rust-driver logic, and enabled the `SerialConsistencyTests` suite. ([#186](https://github.com/scylladb/cpp-rust-driver/pull/186))
- Fixed the runner's image ubuntu version to 22.04 during CI. ([#191](https://github.com/scylladb/cpp-rust-driver/pull/191))
- Enabled `NullStringApiArgsTest` suite. ([#194](https://github.com/scylladb/cpp-rust-driver/pull/194))
- Added an explicit step to update apt cache during CI jobs. ([#190](https://github.com/scylladb/cpp-rust-driver/pull/190))
- Adjusted, and enabled 2 out of 3 tests from `HeartbeatTests` suite. ([#202](https://github.com/scylladb/cpp-rust-driver/pull/202))
- Enabled `AlterDoesntUpdateColumnCount` test in favor of `AlterProperlyUpdatesColumnCount`. It is related to the bug fix regarding prepared statement's result metadata. ([#205](https://github.com/scylladb/cpp-rust-driver/pull/205))

**Documentation:**
- Created a `docs` directory with a sample docs site. Work on the documentation will continue in the near future. ([#134](https://github.com/scylladb/cpp-rust-driver/pull/134))

**Others:**
- Adjusted `build.rs`, so bindgen generates definitions for numeric types automatically. Created modules for each source file generated by `bindgen`. ([#188](https://github.com/scylladb/cpp-rust-driver/pull/188))
- Got rid of redundant `cassandra.h` file in `scylla-rust-wrapper`. ([#196](https://github.com/scylladb/cpp-rust-driver/pull/196))

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/cpp-rust-driver/](https://github.com/scylladb/cpp-rust-driver/)
Contributions are most welcome!

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:
| commits | author              |
|---------|---------------------|
| 76      | Mikołaj Uzarski     |
| 3       | David Garcia        |
| 2       | Karol Baryła        |
| 1       | Dmitry Kropachev    |
