### PR TITLE
treewide: change *const to *mut based on cassandra.h

### DIFF
--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -446,12 +446,8 @@ pub fn get_column_type(column_type: &ColumnType) -> CassDataType {
     CassDataType::new(inner)
 }
 
-// Changed return type to const ptr - ArcFFI::into_ptr is const.
-// It's probably not a good idea - but cppdriver doesn't guarantee
-// thread safety apart from CassSession and CassFuture.
-// This comment also applies to other functions that create CassDataType.
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_new(value_type: CassValueType) -> *const CassDataType {
+pub unsafe extern "C" fn cass_data_type_new(value_type: CassValueType) -> *mut CassDataType {
     let inner = match value_type {
         CassValueType::CASS_VALUE_TYPE_LIST => CassDataTypeInner::List {
             typ: None,
@@ -472,29 +468,29 @@ pub unsafe extern "C" fn cass_data_type_new(value_type: CassValueType) -> *const
         t if t < CassValueType::CASS_VALUE_TYPE_LAST_ENTRY => CassDataTypeInner::Value(t),
         _ => return ptr::null_mut(),
     };
-    ArcFFI::into_ptr(CassDataType::new_arced(inner))
+    ArcFFI::into_ptr(CassDataType::new_arced(inner)) as *mut _
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_new_from_existing(
     data_type: *const CassDataType,
-) -> *const CassDataType {
+) -> *mut CassDataType {
     let data_type = ArcFFI::as_ref(data_type);
-    ArcFFI::into_ptr(CassDataType::new_arced(data_type.get_unchecked().clone()))
+    ArcFFI::into_ptr(CassDataType::new_arced(data_type.get_unchecked().clone())) as *mut _
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_new_tuple(item_count: size_t) -> *const CassDataType {
+pub unsafe extern "C" fn cass_data_type_new_tuple(item_count: size_t) -> *mut CassDataType {
     ArcFFI::into_ptr(CassDataType::new_arced(CassDataTypeInner::Tuple(
         Vec::with_capacity(item_count as usize),
-    )))
+    ))) as *mut _
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_data_type_new_udt(field_count: size_t) -> *const CassDataType {
+pub unsafe extern "C" fn cass_data_type_new_udt(field_count: size_t) -> *mut CassDataType {
     ArcFFI::into_ptr(CassDataType::new_arced(CassDataTypeInner::UDT(
         UDTDataType::with_capacity(field_count as usize),
-    )))
+    ))) as *mut _
 }
 
 #[no_mangle]
@@ -540,7 +536,7 @@ pub unsafe extern "C" fn cass_data_type_type_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_type_name(
-    data_type: *const CassDataType,
+    data_type: *mut CassDataType,
     type_name: *const c_char,
 ) -> CassError {
     cass_data_type_set_type_name_n(data_type, type_name, strlen(type_name))
@@ -548,7 +544,7 @@ pub unsafe extern "C" fn cass_data_type_set_type_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_type_name_n(
-    data_type_raw: *const CassDataType,
+    data_type_raw: *mut CassDataType,
     type_name: *const c_char,
     type_name_length: size_t,
 ) -> CassError {
@@ -584,7 +580,7 @@ pub unsafe extern "C" fn cass_data_type_keyspace(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_keyspace(
-    data_type: *const CassDataType,
+    data_type: *mut CassDataType,
     keyspace: *const c_char,
 ) -> CassError {
     cass_data_type_set_keyspace_n(data_type, keyspace, strlen(keyspace))
@@ -592,7 +588,7 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
-    data_type: *const CassDataType,
+    data_type: *mut CassDataType,
     keyspace: *const c_char,
     keyspace_length: size_t,
 ) -> CassError {
@@ -628,7 +624,7 @@ pub unsafe extern "C" fn cass_data_type_class_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_class_name(
-    data_type: *const CassDataType,
+    data_type: *mut CassDataType,
     class_name: *const ::std::os::raw::c_char,
 ) -> CassError {
     cass_data_type_set_class_name_n(data_type, class_name, strlen(class_name))
@@ -636,7 +632,7 @@ pub unsafe extern "C" fn cass_data_type_set_class_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_set_class_name_n(
-    data_type: *const CassDataType,
+    data_type: *mut CassDataType,
     class_name: *const ::std::os::raw::c_char,
     class_name_length: size_t,
 ) -> CassError {
@@ -740,7 +736,7 @@ pub unsafe extern "C" fn cass_data_type_sub_type_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_type(
-    data_type: *const CassDataType,
+    data_type: *mut CassDataType,
     sub_data_type: *const CassDataType,
 ) -> CassError {
     let data_type = ArcFFI::as_ref(data_type);
@@ -755,7 +751,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
-    data_type: *const CassDataType,
+    data_type: *mut CassDataType,
     name: *const c_char,
     sub_data_type: *const CassDataType,
 ) -> CassError {
@@ -764,7 +760,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
-    data_type_raw: *const CassDataType,
+    data_type_raw: *mut CassDataType,
     name: *const c_char,
     name_length: size_t,
     sub_data_type_raw: *const CassDataType,
@@ -786,7 +782,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_value_type(
-    data_type: *const CassDataType,
+    data_type: *mut CassDataType,
     sub_value_type: CassValueType,
 ) -> CassError {
     let sub_data_type = CassDataType::new_arced(CassDataTypeInner::Value(sub_value_type));
@@ -795,7 +791,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
-    data_type: *const CassDataType,
+    data_type: *mut CassDataType,
     name: *const c_char,
     sub_value_type: CassValueType,
 ) -> CassError {
@@ -805,7 +801,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
-    data_type: *const CassDataType,
+    data_type: *mut CassDataType,
     name: *const c_char,
     name_length: size_t,
     sub_value_type: CassValueType,

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -16,27 +16,27 @@ pub type CassRetryPolicy = RetryPolicy;
 impl ArcFFI for CassRetryPolicy {}
 
 #[no_mangle]
-pub extern "C" fn cass_retry_policy_default_new() -> *const CassRetryPolicy {
+pub extern "C" fn cass_retry_policy_default_new() -> *mut CassRetryPolicy {
     ArcFFI::into_ptr(Arc::new(RetryPolicy::DefaultRetryPolicy(Arc::new(
         DefaultRetryPolicy,
-    ))))
+    )))) as *mut _
 }
 
 #[no_mangle]
-pub extern "C" fn cass_retry_policy_downgrading_consistency_new() -> *const CassRetryPolicy {
+pub extern "C" fn cass_retry_policy_downgrading_consistency_new() -> *mut CassRetryPolicy {
     ArcFFI::into_ptr(Arc::new(RetryPolicy::DowngradingConsistencyRetryPolicy(
         Arc::new(DowngradingConsistencyRetryPolicy),
-    )))
+    ))) as *mut _
 }
 
 #[no_mangle]
-pub extern "C" fn cass_retry_policy_fallthrough_new() -> *const CassRetryPolicy {
+pub extern "C" fn cass_retry_policy_fallthrough_new() -> *mut CassRetryPolicy {
     ArcFFI::into_ptr(Arc::new(RetryPolicy::FallthroughRetryPolicy(Arc::new(
         FallthroughRetryPolicy,
-    ))))
+    )))) as *mut _
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_retry_policy_free(retry_policy: *const CassRetryPolicy) {
+pub unsafe extern "C" fn cass_retry_policy_free(retry_policy: *mut CassRetryPolicy) {
     ArcFFI::free(retry_policy);
 }

--- a/scylla-rust-wrapper/src/ssl.rs
+++ b/scylla-rust-wrapper/src/ssl.rs
@@ -27,13 +27,13 @@ pub const CASS_SSL_VERIFY_PEER_IDENTITY: i32 = 0x02;
 pub const CASS_SSL_VERIFY_PEER_IDENTITY_DNS: i32 = 0x04;
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_ssl_new() -> *const CassSsl {
+pub unsafe extern "C" fn cass_ssl_new() -> *mut CassSsl {
     openssl_sys::init();
     cass_ssl_new_no_lib_init()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn cass_ssl_new_no_lib_init() -> *const CassSsl {
+pub unsafe extern "C" fn cass_ssl_new_no_lib_init() -> *mut CassSsl {
     let ssl_context: *mut SSL_CTX = SSL_CTX_new(TLS_method());
     let trusted_store: *mut X509_STORE = X509_STORE_new();
 
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn cass_ssl_new_no_lib_init() -> *const CassSsl {
         trusted_store,
     };
 
-    ArcFFI::into_ptr(Arc::new(ssl))
+    ArcFFI::into_ptr(Arc::new(ssl)) as *mut _
 }
 
 // This is required for the type system to impl Send + Sync for Arc<CassSsl>.


### PR DESCRIPTION
There are some types that are shared (`Arc`), but are mutable from cpp-driver perspective.

For some reason, there were some discrepancies between C API (defined in cassandra.h) and rust binding functions. On C side, the pointer would be `T*` (non-const), while on Rust side it would be `*const T`. This PR fixes those discrepancies, so we are consistent with cassandra.h

~While going over these types, I found out that for example `CassResult` unnecessarily implements `ArcFFI`. I'll address it in a separate PR (because there are other things to adjust as well).~ Nvm, I just didn't notice that `CassResult` is cloned in `cass_future_get_result` - this is because we use `.clone()` here and not `Arc::clone()`. I'll change it then, so it's easier to spot in the future.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~