### PR TITLE
iterator: don't erase the lifetime by using 'static

### DIFF
--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -86,7 +86,7 @@ impl CassFuture {
             state: Mutex::new(Default::default()),
             wait_for_value: Condvar::new(),
         });
-        let cass_fut_clone = cass_fut.clone();
+        let cass_fut_clone = Arc::clone(&cass_fut);
         let join_handle = RUNTIME.spawn(async move {
             let r = fut.await;
             let maybe_cb = {
@@ -360,7 +360,7 @@ pub unsafe extern "C" fn cass_future_get_result(
     ArcFFI::as_ref(future_raw)
         .with_waited_result(|r: &mut CassFutureResult| -> Option<Arc<CassResult>> {
             match r.as_ref().ok()? {
-                CassResultValue::QueryResult(qr) => Some(qr.clone()),
+                CassResultValue::QueryResult(qr) => Some(Arc::clone(qr)),
                 _ => None,
             }
         })
@@ -374,7 +374,7 @@ pub unsafe extern "C" fn cass_future_get_error_result(
     ArcFFI::as_ref(future_raw)
         .with_waited_result(|r: &mut CassFutureResult| -> Option<Arc<CassErrorResult>> {
             match r.as_ref().ok()? {
-                CassResultValue::QueryError(qr) => Some(qr.clone()),
+                CassResultValue::QueryError(qr) => Some(Arc::clone(qr)),
                 _ => None,
             }
         })
@@ -388,7 +388,7 @@ pub unsafe extern "C" fn cass_future_get_prepared(
     ArcFFI::as_ref(future_raw)
         .with_waited_result(|r: &mut CassFutureResult| -> Option<Arc<CassPrepared>> {
             match r.as_ref().ok()? {
-                CassResultValue::Prepared(p) => Some(p.clone()),
+                CassResultValue::Prepared(p) => Some(Arc::clone(p)),
                 _ => None,
             }
         })

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -278,7 +278,7 @@ fn get_column_value(column: CqlValue, column_type: &Arc<CassDataType>) -> Value 
 }
 
 pub struct CassResultIterator {
-    result: Arc<CassResult>,
+    result: &'static CassResult,
     position: Option<usize>,
 }
 
@@ -824,7 +824,7 @@ pub unsafe extern "C" fn cass_iterator_get_materialized_view_meta(
 
 #[no_mangle]
 pub unsafe extern "C" fn cass_iterator_from_result(result: *const CassResult) -> *mut CassIterator {
-    let result_from_raw = ArcFFI::cloned_from_ptr(result);
+    let result_from_raw = ArcFFI::as_ref(result);
 
     let iterator = CassResultIterator {
         result: result_from_raw,


### PR DESCRIPTION
The iterators are borrowing from different types which are owners of the data. Let's emphasize it and introduce lifetime parameters to iterator types.

As a bonus, I replaced all `.clone()` with `Arc::clone()` in `future.rs`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~