### PR TITLE
cargo: add "lib" to crate-type list

### DIFF
--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -39,7 +39,7 @@ ntest = "0.9.3"
 rusty-fork = "0.3.0"
 [lib]
 name = "scylla_cpp_driver"
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "lib"]
 
 [profile.dev]
 panic = "abort"

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -371,13 +371,13 @@ macro_rules! invoke_binder_maker_macro_with_type {
 ///         There are also 2 helper variants, to accomodate scenarios often encountered in cppdriver (sets of 3 functions,
 ///         binding the same type by index, name and name_n):
 ///  * `make_binders!(type, fn_idx, fn_name, fn_name_n)` - is equivalent to:
-///     ```
+///     ```rust,ignore
 ///     make_binders!(@index type, fn_idx);
 ///     make_binders!(@name type, fn_name);
 ///     make_binders!(@name_n type, fn_name_n);
 ///     ```
 ///  * `make_binders!(t1, fn_idx, t2, fn_name, t3, fn_name_n)` - is equivalent to:
-///     ```
+///     ```rust,ignore
 ///     make_binders!(@index t1, fn_idx);
 ///     make_binders!(@name t2, fn_name);
 ///     make_binders!(@name_n t3, fn_name_n);


### PR DESCRIPTION
It's required to enable the doctests for the crate. They will come in handy during further safety refactor.

I also marked the code snippets from documentation in binding.rs with `rust,ignore`. They should not be run as doc tests.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~