### PR TITLE
cargo: enable unsafe-op-in-unsafe-fn compiler lint

### DIFF
--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -54,3 +54,6 @@ opt-level = 3
 codegen-units = 1
 debug = 2
 strip = "none"
+
+[lints.rust]
+unsafe-op-in-unsafe-fn = "warn"

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -7,20 +7,20 @@ use std::ptr::NonNull;
 use std::sync::{Arc, Weak};
 
 pub unsafe fn ptr_to_cstr(ptr: *const c_char) -> Option<&'static str> {
-    CStr::from_ptr(ptr).to_str().ok()
+    unsafe { CStr::from_ptr(ptr) }.to_str().ok()
 }
 
 pub unsafe fn ptr_to_cstr_n(ptr: *const c_char, size: size_t) -> Option<&'static str> {
     if ptr.is_null() {
         return None;
     }
-    std::str::from_utf8(std::slice::from_raw_parts(ptr as *const u8, size as usize)).ok()
+    std::str::from_utf8(unsafe { std::slice::from_raw_parts(ptr as *const u8, size as usize) }).ok()
 }
 
 pub unsafe fn arr_to_cstr<const N: usize>(arr: &[c_char]) -> Option<&'static str> {
     let null_char = '\0' as c_char;
     let end_index = arr[..N].iter().position(|c| c == &null_char).unwrap_or(N);
-    ptr_to_cstr_n(arr.as_ptr(), end_index as size_t)
+    unsafe { ptr_to_cstr_n(arr.as_ptr(), end_index as size_t) }
 }
 
 pub fn str_to_arr<const N: usize>(s: &str) -> [c_char; N] {
@@ -41,15 +41,17 @@ pub fn str_to_arr<const N: usize>(s: &str) -> [c_char; N] {
 }
 
 pub unsafe fn write_str_to_c(s: &str, c_str: *mut *const c_char, c_strlen: *mut size_t) {
-    *c_str = s.as_ptr() as *const c_char;
-    *c_strlen = s.len() as u64;
+    unsafe {
+        *c_str = s.as_ptr() as *const c_char;
+        *c_strlen = s.len() as u64;
+    }
 }
 
 pub unsafe fn strlen(ptr: *const c_char) -> size_t {
     if ptr.is_null() {
         return 0;
     }
-    libc::strlen(ptr) as size_t
+    unsafe { libc::strlen(ptr) as size_t }
 }
 
 #[cfg(test)]

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -80,7 +80,7 @@ macro_rules! make_name_binder {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
             use crate::value::CassCqlValue::*;
-            let name = ptr_to_cstr(name).unwrap();
+            let name = unsafe { ptr_to_cstr(name) }.unwrap();
             match ($e)($($arg), *) {
                 Ok(v) => $consume_v(BoxFFI::as_mut_ref(this).unwrap(), name, v),
                 Err(e) => e,
@@ -102,7 +102,7 @@ macro_rules! make_name_n_binder {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
             use crate::value::CassCqlValue::*;
-            let name = ptr_to_cstr_n(name, name_length).unwrap();
+            let name = unsafe { ptr_to_cstr_n(name, name_length) }.unwrap();
             match ($e)($($arg), *) {
                 Ok(v) => $consume_v(BoxFFI::as_mut_ref(this).unwrap(), name, v),
                 Err(e) => e,
@@ -217,7 +217,7 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |v| Ok(Some(Text(ptr_to_cstr(v).unwrap().to_string()))),
+            |v| Ok(Some(Text(unsafe { ptr_to_cstr(v) }.unwrap().to_string()))),
             [v @ *const std::os::raw::c_char]
         );
     };
@@ -226,7 +226,7 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |v, n| Ok(Some(Text(ptr_to_cstr_n(v, n).unwrap().to_string()))),
+            |v, n| Ok(Some(Text(unsafe { ptr_to_cstr_n(v, n) }.unwrap().to_string()))),
             [v @ *const std::os::raw::c_char, n @ size_t]
         );
     };
@@ -236,7 +236,7 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $consume_v,
             $fn,
             |v, v_size| {
-                let v_vec = std::slice::from_raw_parts(v, v_size as usize).to_vec();
+                let v_vec = unsafe { std::slice::from_raw_parts(v, v_size as usize) }.to_vec();
                 Ok(Some(Blob(v_vec)))
             },
             [v @ *const cass_byte_t, v_size @ size_t]
@@ -291,7 +291,7 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $fn,
             |v, v_size, scale| {
                 use scylla::value::CqlDecimal;
-                let varint = std::slice::from_raw_parts(v, v_size as usize);
+                let varint = unsafe { std::slice::from_raw_parts(v, v_size as usize) };
                 Ok(Some(Decimal(CqlDecimal::from_signed_be_bytes_slice_and_exponent(varint, scale))))
             },
             [v @ *const cass_byte_t, v_size @ size_t, scale @ cass_int32_t]

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -249,12 +249,12 @@ unsafe impl Sync for CassDataType {}
 
 impl CassDataType {
     pub unsafe fn get_unchecked(&self) -> &CassDataTypeInner {
-        &*self.0.get()
+        unsafe { &*self.0.get() }
     }
 
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn get_mut_unchecked(&self) -> &mut CassDataTypeInner {
-        &mut *self.0.get()
+        unsafe { &mut *self.0.get() }
     }
 
     pub const fn new(inner: CassDataTypeInner) -> CassDataType {
@@ -479,7 +479,9 @@ pub unsafe extern "C" fn cass_data_type_new_from_existing(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassOwnedSharedPtr<CassDataType, CMut> {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    ArcFFI::into_ptr(CassDataType::new_arced(data_type.get_unchecked().clone()))
+    ArcFFI::into_ptr(CassDataType::new_arced(
+        unsafe { data_type.get_unchecked() }.clone(),
+    ))
 }
 
 #[no_mangle]
@@ -510,7 +512,7 @@ pub unsafe extern "C" fn cass_data_type_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassValueType {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    data_type.get_unchecked().get_value_type()
+    unsafe { data_type.get_unchecked() }.get_value_type()
 }
 
 #[no_mangle]
@@ -518,7 +520,7 @@ pub unsafe extern "C" fn cass_data_type_is_frozen(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> cass_bool_t {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    let is_frozen = match data_type.get_unchecked() {
+    let is_frozen = match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(udt) => udt.frozen,
         CassDataTypeInner::List { frozen, .. } => *frozen,
         CassDataTypeInner::Set { frozen, .. } => *frozen,
@@ -536,9 +538,9 @@ pub unsafe extern "C" fn cass_data_type_type_name(
     type_name_length: *mut size_t,
 ) -> CassError {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    match data_type.get_unchecked() {
+    match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(UDTDataType { name, .. }) => {
-            write_str_to_c(name, type_name, type_name_length);
+            unsafe { write_str_to_c(name, type_name, type_name_length) };
             CassError::CASS_OK
         }
         _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -550,7 +552,7 @@ pub unsafe extern "C" fn cass_data_type_set_type_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     type_name: *const c_char,
 ) -> CassError {
-    cass_data_type_set_type_name_n(data_type, type_name, strlen(type_name))
+    unsafe { cass_data_type_set_type_name_n(data_type, type_name, strlen(type_name)) }
 }
 
 #[no_mangle]
@@ -560,11 +562,11 @@ pub unsafe extern "C" fn cass_data_type_set_type_name_n(
     type_name_length: size_t,
 ) -> CassError {
     let data_type = ArcFFI::as_ref(data_type_raw).unwrap();
-    let type_name_string = ptr_to_cstr_n(type_name, type_name_length)
+    let type_name_string = unsafe { ptr_to_cstr_n(type_name, type_name_length) }
         .unwrap()
         .to_string();
 
-    match data_type.get_mut_unchecked() {
+    match unsafe { data_type.get_mut_unchecked() } {
         CassDataTypeInner::UDT(udt_data_type) => {
             udt_data_type.name = type_name_string;
             CassError::CASS_OK
@@ -580,9 +582,9 @@ pub unsafe extern "C" fn cass_data_type_keyspace(
     keyspace_length: *mut size_t,
 ) -> CassError {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    match data_type.get_unchecked() {
+    match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(UDTDataType { name, .. }) => {
-            write_str_to_c(name, keyspace, keyspace_length);
+            unsafe { write_str_to_c(name, keyspace, keyspace_length) };
             CassError::CASS_OK
         }
         _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -594,7 +596,7 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     keyspace: *const c_char,
 ) -> CassError {
-    cass_data_type_set_keyspace_n(data_type, keyspace, strlen(keyspace))
+    unsafe { cass_data_type_set_keyspace_n(data_type, keyspace, strlen(keyspace)) }
 }
 
 #[no_mangle]
@@ -604,11 +606,11 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
     keyspace_length: size_t,
 ) -> CassError {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    let keyspace_string = ptr_to_cstr_n(keyspace, keyspace_length)
+    let keyspace_string = unsafe { ptr_to_cstr_n(keyspace, keyspace_length) }
         .unwrap()
         .to_string();
 
-    match data_type.get_mut_unchecked() {
+    match unsafe { data_type.get_mut_unchecked() } {
         CassDataTypeInner::UDT(udt_data_type) => {
             udt_data_type.keyspace = keyspace_string;
             CassError::CASS_OK
@@ -624,9 +626,9 @@ pub unsafe extern "C" fn cass_data_type_class_name(
     class_name_length: *mut size_t,
 ) -> CassError {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    match data_type.get_unchecked() {
+    match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::Custom(name) => {
-            write_str_to_c(name, class_name, class_name_length);
+            unsafe { write_str_to_c(name, class_name, class_name_length) };
             CassError::CASS_OK
         }
         _ => CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
@@ -638,7 +640,7 @@ pub unsafe extern "C" fn cass_data_type_set_class_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     class_name: *const ::std::os::raw::c_char,
 ) -> CassError {
-    cass_data_type_set_class_name_n(data_type, class_name, strlen(class_name))
+    unsafe { cass_data_type_set_class_name_n(data_type, class_name, strlen(class_name)) }
 }
 
 #[no_mangle]
@@ -648,10 +650,10 @@ pub unsafe extern "C" fn cass_data_type_set_class_name_n(
     class_name_length: size_t,
 ) -> CassError {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    let class_string = ptr_to_cstr_n(class_name, class_name_length)
+    let class_string = unsafe { ptr_to_cstr_n(class_name, class_name_length) }
         .unwrap()
         .to_string();
-    match data_type.get_mut_unchecked() {
+    match unsafe { data_type.get_mut_unchecked() } {
         CassDataTypeInner::Custom(name) => {
             *name = class_string;
             CassError::CASS_OK
@@ -665,7 +667,7 @@ pub unsafe extern "C" fn cass_data_type_sub_type_count(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> size_t {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    match data_type.get_unchecked() {
+    match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::Value(..) => 0,
         CassDataTypeInner::UDT(udt_data_type) => udt_data_type.field_types.len() as size_t,
         CassDataTypeInner::List { typ, .. } | CassDataTypeInner::Set { typ, .. } => {
@@ -685,7 +687,7 @@ pub unsafe extern "C" fn cass_data_type_sub_type_count(
 pub unsafe extern "C" fn cass_data_sub_type_count(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> size_t {
-    cass_data_type_sub_type_count(data_type)
+    unsafe { cass_data_type_sub_type_count(data_type) }
 }
 
 #[no_mangle]
@@ -695,7 +697,7 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type(
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
     let sub_type: Option<&Arc<CassDataType>> =
-        data_type.get_unchecked().get_sub_data_type(index as usize);
+        unsafe { data_type.get_unchecked() }.get_sub_data_type(index as usize);
 
     match sub_type {
         None => ArcFFI::null(),
@@ -709,7 +711,7 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     name: *const ::std::os::raw::c_char,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
-    cass_data_type_sub_data_type_by_name_n(data_type, name, strlen(name))
+    unsafe { cass_data_type_sub_data_type_by_name_n(data_type, name, strlen(name)) }
 }
 
 #[no_mangle]
@@ -719,8 +721,8 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n(
     name_length: size_t,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    let name_str = ptr_to_cstr_n(name, name_length).unwrap();
-    match data_type.get_unchecked() {
+    let name_str = unsafe { ptr_to_cstr_n(name, name_length) }.unwrap();
+    match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(udt) => match udt.get_field_by_name(name_str) {
             None => ArcFFI::null(),
             Some(t) => ArcFFI::as_ptr(t),
@@ -737,11 +739,11 @@ pub unsafe extern "C" fn cass_data_type_sub_type_name(
     name_length: *mut size_t,
 ) -> CassError {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    match data_type.get_unchecked() {
+    match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(udt) => match udt.field_types.get(index as usize) {
             None => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
             Some((field_name, _)) => {
-                write_str_to_c(field_name, name, name_length);
+                unsafe { write_str_to_c(field_name, name, name_length) };
                 CassError::CASS_OK
             }
         },
@@ -755,8 +757,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type(
     sub_data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassError {
     let data_type = ArcFFI::as_ref(data_type).unwrap();
-    match data_type
-        .get_mut_unchecked()
+    match unsafe { data_type.get_mut_unchecked() }
         .add_sub_data_type(ArcFFI::cloned_from_ptr(sub_data_type).unwrap())
     {
         Ok(()) => CassError::CASS_OK,
@@ -770,7 +771,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
     name: *const c_char,
     sub_data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassError {
-    cass_data_type_add_sub_type_by_name_n(data_type, name, strlen(name), sub_data_type)
+    unsafe { cass_data_type_add_sub_type_by_name_n(data_type, name, strlen(name), sub_data_type) }
 }
 
 #[no_mangle]
@@ -780,11 +781,13 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
     name_length: size_t,
     sub_data_type_raw: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassError {
-    let name_string = ptr_to_cstr_n(name, name_length).unwrap().to_string();
+    let name_string = unsafe { ptr_to_cstr_n(name, name_length) }
+        .unwrap()
+        .to_string();
     let sub_data_type = ArcFFI::cloned_from_ptr(sub_data_type_raw).unwrap();
 
     let data_type = ArcFFI::as_ref(data_type_raw).unwrap();
-    match data_type.get_mut_unchecked() {
+    match unsafe { data_type.get_mut_unchecked() } {
         CassDataTypeInner::UDT(udt_data_type) => {
             // The Cpp Driver does not check whether field_types size
             // exceeded field_count.
@@ -801,7 +804,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type(
     sub_value_type: CassValueType,
 ) -> CassError {
     let sub_data_type = CassDataType::new_arced(CassDataTypeInner::Value(sub_value_type));
-    cass_data_type_add_sub_type(data_type, ArcFFI::as_ptr(&sub_data_type))
+    unsafe { cass_data_type_add_sub_type(data_type, ArcFFI::as_ptr(&sub_data_type)) }
 }
 
 #[no_mangle]
@@ -811,7 +814,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
     sub_value_type: CassValueType,
 ) -> CassError {
     let sub_data_type = CassDataType::new_arced(CassDataTypeInner::Value(sub_value_type));
-    cass_data_type_add_sub_type_by_name(data_type, name, ArcFFI::as_ptr(&sub_data_type))
+    unsafe { cass_data_type_add_sub_type_by_name(data_type, name, ArcFFI::as_ptr(&sub_data_type)) }
 }
 
 #[no_mangle]
@@ -822,12 +825,14 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
     sub_value_type: CassValueType,
 ) -> CassError {
     let sub_data_type = CassDataType::new_arced(CassDataTypeInner::Value(sub_value_type));
-    cass_data_type_add_sub_type_by_name_n(
-        data_type,
-        name,
-        name_length,
-        ArcFFI::as_ptr(&sub_data_type),
-    )
+    unsafe {
+        cass_data_type_add_sub_type_by_name_n(
+            data_type,
+            name,
+            name_length,
+            ArcFFI::as_ptr(&sub_data_type),
+        )
+    }
 }
 
 impl TryFrom<CassConsistency> for Consistency {

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn cass_cluster_set_contact_points(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     contact_points: *const c_char,
 ) -> CassError {
-    cass_cluster_set_contact_points_n(cluster, contact_points, strlen(contact_points))
+    unsafe { cass_cluster_set_contact_points_n(cluster, contact_points, strlen(contact_points)) }
 }
 
 #[no_mangle]
@@ -256,7 +256,7 @@ pub unsafe extern "C" fn cass_cluster_set_contact_points_n(
     contact_points: *const c_char,
     contact_points_length: size_t,
 ) -> CassError {
-    match cluster_set_contact_points(cluster, contact_points, contact_points_length) {
+    match unsafe { cluster_set_contact_points(cluster, contact_points, contact_points_length) } {
         Ok(()) => CassError::CASS_OK,
         Err(err) => err,
     }
@@ -268,7 +268,7 @@ unsafe fn cluster_set_contact_points(
     contact_points_length: size_t,
 ) -> Result<(), CassError> {
     let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
-    let mut contact_points = ptr_to_cstr_n(contact_points_raw, contact_points_length)
+    let mut contact_points = unsafe { ptr_to_cstr_n(contact_points_raw, contact_points_length) }
         .ok_or(CassError::CASS_ERROR_LIB_BAD_PARAMS)?
         .split(',')
         .filter(|s| !s.is_empty()) // Extra commas should be ignored.
@@ -306,7 +306,7 @@ pub unsafe extern "C" fn cass_cluster_set_application_name(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     app_name: *const c_char,
 ) {
-    cass_cluster_set_application_name_n(cluster_raw, app_name, strlen(app_name))
+    unsafe { cass_cluster_set_application_name_n(cluster_raw, app_name, strlen(app_name)) }
 }
 
 #[no_mangle]
@@ -316,7 +316,9 @@ pub unsafe extern "C" fn cass_cluster_set_application_name_n(
     app_name_len: size_t,
 ) {
     let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
-    let app_name = ptr_to_cstr_n(app_name, app_name_len).unwrap().to_string();
+    let app_name = unsafe { ptr_to_cstr_n(app_name, app_name_len) }
+        .unwrap()
+        .to_string();
 
     cluster
         .session_builder
@@ -330,7 +332,7 @@ pub unsafe extern "C" fn cass_cluster_set_application_version(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     app_version: *const c_char,
 ) {
-    cass_cluster_set_application_version_n(cluster_raw, app_version, strlen(app_version))
+    unsafe { cass_cluster_set_application_version_n(cluster_raw, app_version, strlen(app_version)) }
 }
 
 #[no_mangle]
@@ -340,7 +342,7 @@ pub unsafe extern "C" fn cass_cluster_set_application_version_n(
     app_version_len: size_t,
 ) {
     let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
-    let app_version = ptr_to_cstr_n(app_version, app_version_len)
+    let app_version = unsafe { ptr_to_cstr_n(app_version, app_version_len) }
         .unwrap()
         .to_string();
 
@@ -486,13 +488,15 @@ pub unsafe extern "C" fn cass_cluster_set_credentials(
     username: *const c_char,
     password: *const c_char,
 ) {
-    cass_cluster_set_credentials_n(
-        cluster,
-        username,
-        strlen(username),
-        password,
-        strlen(password),
-    )
+    unsafe {
+        cass_cluster_set_credentials_n(
+            cluster,
+            username,
+            strlen(username),
+            password,
+            strlen(password),
+        )
+    }
 }
 
 #[no_mangle]
@@ -504,8 +508,8 @@ pub unsafe extern "C" fn cass_cluster_set_credentials_n(
     password_length: size_t,
 ) {
     // TODO: string error handling
-    let username = ptr_to_cstr_n(username_raw, username_length).unwrap();
-    let password = ptr_to_cstr_n(password_raw, password_length).unwrap();
+    let username = unsafe { ptr_to_cstr_n(username_raw, username_length) }.unwrap();
+    let password = unsafe { ptr_to_cstr_n(password_raw, password_length) }.unwrap();
 
     let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     cluster.auth_username = Some(username.to_string());
@@ -527,13 +531,15 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware(
     used_hosts_per_remote_dc: c_uint,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
-    cass_cluster_set_load_balance_dc_aware_n(
-        cluster,
-        local_dc,
-        strlen(local_dc),
-        used_hosts_per_remote_dc,
-        allow_remote_dcs_for_local_cl,
-    )
+    unsafe {
+        cass_cluster_set_load_balance_dc_aware_n(
+            cluster,
+            local_dc,
+            strlen(local_dc),
+            used_hosts_per_remote_dc,
+            allow_remote_dcs_for_local_cl,
+        )
+    }
 }
 
 pub(crate) unsafe fn set_load_balance_dc_aware_n(
@@ -552,7 +558,7 @@ pub(crate) unsafe fn set_load_balance_dc_aware_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
 
-    let local_dc = ptr_to_cstr_n(local_dc_raw, local_dc_length)
+    let local_dc = unsafe { ptr_to_cstr_n(local_dc_raw, local_dc_length) }
         .unwrap()
         .to_string();
 
@@ -571,13 +577,15 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
 ) -> CassError {
     let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
-    set_load_balance_dc_aware_n(
-        &mut cluster.load_balancing_config,
-        local_dc_raw,
-        local_dc_length,
-        used_hosts_per_remote_dc,
-        allow_remote_dcs_for_local_cl,
-    )
+    unsafe {
+        set_load_balance_dc_aware_n(
+            &mut cluster.load_balancing_config,
+            local_dc_raw,
+            local_dc_length,
+            used_hosts_per_remote_dc,
+            allow_remote_dcs_for_local_cl,
+        )
+    }
 }
 
 #[no_mangle]
@@ -586,13 +594,15 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware(
     local_dc_raw: *const c_char,
     local_rack_raw: *const c_char,
 ) -> CassError {
-    cass_cluster_set_load_balance_rack_aware_n(
-        cluster_raw,
-        local_dc_raw,
-        strlen(local_dc_raw),
-        local_rack_raw,
-        strlen(local_rack_raw),
-    )
+    unsafe {
+        cass_cluster_set_load_balance_rack_aware_n(
+            cluster_raw,
+            local_dc_raw,
+            strlen(local_dc_raw),
+            local_rack_raw,
+            strlen(local_rack_raw),
+        )
+    }
 }
 
 #[no_mangle]
@@ -605,13 +615,15 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware_n(
 ) -> CassError {
     let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
-    set_load_balance_rack_aware_n(
-        &mut cluster.load_balancing_config,
-        local_dc_raw,
-        local_dc_length,
-        local_rack_raw,
-        local_rack_length,
-    )
+    unsafe {
+        set_load_balance_rack_aware_n(
+            &mut cluster.load_balancing_config,
+            local_dc_raw,
+            local_dc_length,
+            local_rack_raw,
+            local_rack_length,
+        )
+    }
 }
 
 pub(crate) unsafe fn set_load_balance_rack_aware_n(
@@ -622,8 +634,8 @@ pub(crate) unsafe fn set_load_balance_rack_aware_n(
     local_rack_length: size_t,
 ) -> CassError {
     let (local_dc, local_rack) = match (
-        ptr_to_cstr_n(local_dc_raw, local_dc_length),
-        ptr_to_cstr_n(local_rack_raw, local_rack_length),
+        unsafe { ptr_to_cstr_n(local_dc_raw, local_dc_length) },
+        unsafe { ptr_to_cstr_n(local_rack_raw, local_rack_length) },
     ) {
         (Some(local_dc_str), Some(local_rack_str))
             if local_dc_length > 0 && local_rack_length > 0 =>
@@ -649,7 +661,7 @@ pub unsafe extern "C" fn cass_cluster_set_cloud_secure_connection_bundle_n(
     path_length: size_t,
 ) -> CassError {
     // FIXME: Should unzip file associated with the path
-    let zip_file = ptr_to_cstr_n(path, path_length).unwrap();
+    let zip_file = unsafe { ptr_to_cstr_n(path, path_length) }.unwrap();
 
     if zip_file == "invalid_filename" {
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
@@ -831,9 +843,9 @@ pub unsafe extern "C" fn cass_cluster_set_ssl(
     let cluster_from_raw = BoxFFI::as_mut_ref(cluster).unwrap();
     let cass_ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
 
-    let ssl_context_builder = SslContextBuilder::from_ptr(cass_ssl.ssl_context);
+    let ssl_context_builder = unsafe { SslContextBuilder::from_ptr(cass_ssl.ssl_context) };
     // Reference count is increased as tokio_openssl will try to free `ssl_context` when calling `SSL_free`.
-    SSL_CTX_up_ref(cass_ssl.ssl_context);
+    unsafe { SSL_CTX_up_ref(cass_ssl.ssl_context) };
 
     cluster_from_raw.session_builder.config.tls_context = Some(ssl_context_builder.build().into());
 }
@@ -922,7 +934,7 @@ pub unsafe extern "C" fn cass_cluster_set_execution_profile(
     name: *const c_char,
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
 ) -> CassError {
-    cass_cluster_set_execution_profile_n(cluster, name, strlen(name), profile)
+    unsafe { cass_cluster_set_execution_profile_n(cluster, name, strlen(name), profile) }
 }
 
 #[no_mangle]
@@ -934,7 +946,7 @@ pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
 ) -> CassError {
     let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
     let name = if let Some(name) =
-        ptr_to_cstr_n(name, name_length).and_then(|name| name.to_owned().try_into().ok())
+        unsafe { ptr_to_cstr_n(name, name_length) }.and_then(|name| name.to_owned().try_into().ok())
     {
         name
     } else {

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -161,7 +161,7 @@ unsafe extern "C" fn cass_collection_new_from_data_type(
     item_count: size_t,
 ) -> CassOwnedExclusivePtr<CassCollection, CMut> {
     let data_type = ArcFFI::cloned_from_ptr(data_type).unwrap();
-    let (capacity, collection_type) = match data_type.get_unchecked() {
+    let (capacity, collection_type) = match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::List { .. } => {
             (item_count, CassCollectionType::CASS_COLLECTION_TYPE_LIST)
         }

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn cass_statement_set_execution_profile(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
     name: *const c_char,
 ) -> CassError {
-    cass_statement_set_execution_profile_n(statement, name, strlen(name))
+    unsafe { cass_statement_set_execution_profile_n(statement, name, strlen(name)) }
 }
 
 #[no_mangle]
@@ -205,8 +205,8 @@ pub unsafe extern "C" fn cass_statement_set_execution_profile_n(
     name_length: size_t,
 ) -> CassError {
     let statement = BoxFFI::as_mut_ref(statement).unwrap();
-    let name: Option<ExecProfileName> =
-        ptr_to_cstr_n(name, name_length).and_then(|name| name.to_owned().try_into().ok());
+    let name: Option<ExecProfileName> = unsafe { ptr_to_cstr_n(name, name_length) }
+        .and_then(|name| name.to_owned().try_into().ok());
     statement.exec_profile = name.map(PerStatementExecProfile::new_unresolved);
 
     CassError::CASS_OK
@@ -217,7 +217,7 @@ pub unsafe extern "C" fn cass_batch_set_execution_profile(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     name: *const c_char,
 ) -> CassError {
-    cass_batch_set_execution_profile_n(batch, name, strlen(name))
+    unsafe { cass_batch_set_execution_profile_n(batch, name, strlen(name)) }
 }
 
 #[no_mangle]
@@ -227,8 +227,8 @@ pub unsafe extern "C" fn cass_batch_set_execution_profile_n(
     name_length: size_t,
 ) -> CassError {
     let batch = BoxFFI::as_mut_ref(batch).unwrap();
-    let name: Option<ExecProfileName> =
-        ptr_to_cstr_n(name, name_length).and_then(|name| name.to_owned().try_into().ok());
+    let name: Option<ExecProfileName> = unsafe { ptr_to_cstr_n(name, name_length) }
+        .and_then(|name| name.to_owned().try_into().ok());
     batch.exec_profile = name.map(PerStatementExecProfile::new_unresolved);
 
     CassError::CASS_OK
@@ -342,13 +342,15 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware(
     used_hosts_per_remote_dc: cass_uint32_t,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
-    cass_execution_profile_set_load_balance_dc_aware_n(
-        profile,
-        local_dc,
-        strlen(local_dc),
-        used_hosts_per_remote_dc,
-        allow_remote_dcs_for_local_cl,
-    )
+    unsafe {
+        cass_execution_profile_set_load_balance_dc_aware_n(
+            profile,
+            local_dc,
+            strlen(local_dc),
+            used_hosts_per_remote_dc,
+            allow_remote_dcs_for_local_cl,
+        )
+    }
 }
 
 #[no_mangle]
@@ -361,13 +363,15 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware_n(
 ) -> CassError {
     let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
 
-    set_load_balance_dc_aware_n(
-        &mut profile_builder.load_balancing_config,
-        local_dc,
-        local_dc_length,
-        used_hosts_per_remote_dc,
-        allow_remote_dcs_for_local_cl,
-    )
+    unsafe {
+        set_load_balance_dc_aware_n(
+            &mut profile_builder.load_balancing_config,
+            local_dc,
+            local_dc_length,
+            used_hosts_per_remote_dc,
+            allow_remote_dcs_for_local_cl,
+        )
+    }
 }
 
 #[no_mangle]
@@ -376,13 +380,15 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware(
     local_dc_raw: *const c_char,
     local_rack_raw: *const c_char,
 ) -> CassError {
-    cass_execution_profile_set_load_balance_rack_aware_n(
-        profile,
-        local_dc_raw,
-        strlen(local_dc_raw),
-        local_rack_raw,
-        strlen(local_rack_raw),
-    )
+    unsafe {
+        cass_execution_profile_set_load_balance_rack_aware_n(
+            profile,
+            local_dc_raw,
+            strlen(local_dc_raw),
+            local_rack_raw,
+            strlen(local_rack_raw),
+        )
+    }
 }
 
 #[no_mangle]
@@ -395,13 +401,15 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware_n(
 ) -> CassError {
     let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
 
-    set_load_balance_rack_aware_n(
-        &mut profile_builder.load_balancing_config,
-        local_dc_raw,
-        local_dc_length,
-        local_rack_raw,
-        local_rack_length,
-    )
+    unsafe {
+        set_load_balance_rack_aware_n(
+            &mut profile_builder.load_balancing_config,
+            local_dc_raw,
+            local_dc_length,
+            local_rack_raw,
+            local_rack_length,
+        )
+    }
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -35,18 +35,22 @@ pub unsafe extern "C" fn testing_cluster_get_contact_points(
 
     match CString::new(contact_points_string) {
         Ok(cstring) => {
-            *contact_points = cstring.into_raw();
-            *contact_points_length = length as size_t;
+            unsafe {
+                *contact_points = cstring.into_raw();
+                *contact_points_length = length as size_t
+            };
         }
         Err(_) => {
             // The contact points string contained a nul byte in the middle.
-            *contact_points = std::ptr::null_mut();
-            *contact_points_length = 0;
+            unsafe {
+                *contact_points = std::ptr::null_mut();
+                *contact_points_length = 0
+            };
         }
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn testing_free_contact_points(contact_points: *mut c_char) {
-    let _ = CString::from_raw(contact_points);
+    let _ = unsafe { CString::from_raw(contact_points) };
 }

--- a/scylla-rust-wrapper/src/iterator.rs
+++ b/scylla-rust-wrapper/src/iterator.rs
@@ -427,7 +427,7 @@ pub unsafe extern "C" fn cass_iterator_get_user_type_field_name(
         match udt_entry_opt {
             Some(udt_entry) => {
                 let field_name = &udt_entry.0;
-                write_str_to_c(field_name.as_str(), name, name_length);
+                unsafe { write_str_to_c(field_name.as_str(), name, name_length) };
             }
             None => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
         }
@@ -672,14 +672,14 @@ pub unsafe extern "C" fn cass_iterator_from_row<'result>(
 pub unsafe extern "C" fn cass_iterator_from_collection<'result>(
     value: CassBorrowedSharedPtr<'result, CassValue, CConst>,
 ) -> CassOwnedExclusivePtr<CassIterator<'result>, CMut> {
-    let is_collection = cass_value_is_collection(value.borrow()) != 0;
+    let is_collection = unsafe { cass_value_is_collection(value.borrow()) } != 0;
 
     if RefFFI::is_null(&value) || !is_collection {
         return BoxFFI::null_mut();
     }
 
-    let item_count = cass_value_item_count(value.borrow());
-    let item_count = match cass_value_type(value.borrow()) {
+    let item_count = unsafe { cass_value_item_count(value.borrow()) };
+    let item_count = match unsafe { cass_value_type(value.borrow()) } {
         CassValueType::CASS_VALUE_TYPE_MAP => item_count * 2,
         _ => item_count,
     };

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -82,10 +82,10 @@ pub unsafe extern "C" fn stderr_log_callback(
     eprintln!(
         "{} [{}] ({}:{}) {}",
         message.time_ms,
-        ptr_to_cstr(cass_log_level_string(message.severity)).unwrap(),
-        ptr_to_cstr(message.file).unwrap(),
+        unsafe { ptr_to_cstr(cass_log_level_string(message.severity)) }.unwrap(),
+        unsafe { ptr_to_cstr(message.file) }.unwrap(),
         message.line,
-        arr_to_cstr::<{ CASS_LOG_MAX_MESSAGE_SIZE }>(&message.message).unwrap(),
+        unsafe { arr_to_cstr::<{ CASS_LOG_MAX_MESSAGE_SIZE }>(&message.message) }.unwrap(),
     )
 }
 
@@ -211,8 +211,10 @@ pub unsafe extern "C" fn cass_log_get_callback_and_data(
 ) {
     let logger = LOGGER.read().unwrap();
 
-    *callback_out = logger.cb;
-    *data_out = logger.data;
+    unsafe {
+        *callback_out = logger.cb;
+        *data_out = logger.data;
+    }
 }
 
 #[no_mangle]

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -128,7 +128,9 @@ pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name(
     schema_meta: CassBorrowedSharedPtr<CassSchemaMeta, CConst>,
     keyspace_name: *const c_char,
 ) -> CassBorrowedSharedPtr<CassKeyspaceMeta, CConst> {
-    cass_schema_meta_keyspace_by_name_n(schema_meta, keyspace_name, strlen(keyspace_name))
+    unsafe {
+        cass_schema_meta_keyspace_by_name_n(schema_meta, keyspace_name, strlen(keyspace_name))
+    }
 }
 
 #[no_mangle]
@@ -142,7 +144,7 @@ pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name_n(
     }
 
     let metadata = BoxFFI::as_ref(schema_meta).unwrap();
-    let keyspace = ptr_to_cstr_n(keyspace_name, keyspace_name_length).unwrap();
+    let keyspace = unsafe { ptr_to_cstr_n(keyspace_name, keyspace_name_length) }.unwrap();
 
     let keyspace_meta = metadata.keyspaces.get(keyspace);
 
@@ -159,7 +161,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_name(
     name_length: *mut size_t,
 ) {
     let keyspace_meta = RefFFI::as_ref(keyspace_meta).unwrap();
-    write_str_to_c(keyspace_meta.name.as_str(), name, name_length)
+    unsafe { write_str_to_c(keyspace_meta.name.as_str(), name, name_length) }
 }
 
 #[no_mangle]
@@ -167,7 +169,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name(
     keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     type_: *const c_char,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
-    cass_keyspace_meta_user_type_by_name_n(keyspace_meta, type_, strlen(type_))
+    unsafe { cass_keyspace_meta_user_type_by_name_n(keyspace_meta, type_, strlen(type_)) }
 }
 
 #[no_mangle]
@@ -181,7 +183,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
     }
 
     let keyspace_meta = RefFFI::as_ref(keyspace_meta).unwrap();
-    let user_type_name = ptr_to_cstr_n(type_, type_length).unwrap();
+    let user_type_name = unsafe { ptr_to_cstr_n(type_, type_length) }.unwrap();
 
     match keyspace_meta
         .user_defined_type_data_type
@@ -197,7 +199,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_table_by_name(
     keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     table: *const c_char,
 ) -> CassBorrowedSharedPtr<CassTableMeta, CConst> {
-    cass_keyspace_meta_table_by_name_n(keyspace_meta, table, strlen(table))
+    unsafe { cass_keyspace_meta_table_by_name_n(keyspace_meta, table, strlen(table)) }
 }
 
 #[no_mangle]
@@ -211,7 +213,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_table_by_name_n(
     }
 
     let keyspace_meta = RefFFI::as_ref(keyspace_meta).unwrap();
-    let table_name = ptr_to_cstr_n(table, table_length).unwrap();
+    let table_name = unsafe { ptr_to_cstr_n(table, table_length) }.unwrap();
 
     let table_meta = keyspace_meta.tables.get(table_name);
 
@@ -228,7 +230,7 @@ pub unsafe extern "C" fn cass_table_meta_name(
     name_length: *mut size_t,
 ) {
     let table_meta = RefFFI::as_ref(table_meta).unwrap();
-    write_str_to_c(table_meta.name.as_str(), name, name_length)
+    unsafe { write_str_to_c(table_meta.name.as_str(), name, name_length) }
 }
 
 #[no_mangle]
@@ -345,7 +347,7 @@ pub unsafe extern "C" fn cass_table_meta_column_by_name(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     column: *const c_char,
 ) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
-    cass_table_meta_column_by_name_n(table_meta, column, strlen(column))
+    unsafe { cass_table_meta_column_by_name_n(table_meta, column, strlen(column)) }
 }
 
 #[no_mangle]
@@ -359,7 +361,7 @@ pub unsafe extern "C" fn cass_table_meta_column_by_name_n(
     }
 
     let table_meta = RefFFI::as_ref(table_meta).unwrap();
-    let column_name = ptr_to_cstr_n(column, column_length).unwrap();
+    let column_name = unsafe { ptr_to_cstr_n(column, column_length) }.unwrap();
 
     match table_meta.columns_metadata.get(column_name) {
         Some(column_meta) => RefFFI::as_ptr(column_meta),
@@ -374,7 +376,7 @@ pub unsafe extern "C" fn cass_column_meta_name(
     name_length: *mut size_t,
 ) {
     let column_meta = RefFFI::as_ref(column_meta).unwrap();
-    write_str_to_c(column_meta.name.as_str(), name, name_length)
+    unsafe { write_str_to_c(column_meta.name.as_str(), name, name_length) }
 }
 
 #[no_mangle]
@@ -398,7 +400,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name(
     keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     view: *const c_char,
 ) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
-    cass_keyspace_meta_materialized_view_by_name_n(keyspace_meta, view, strlen(view))
+    unsafe { cass_keyspace_meta_materialized_view_by_name_n(keyspace_meta, view, strlen(view)) }
 }
 
 #[no_mangle]
@@ -412,7 +414,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name_n(
     }
 
     let keyspace_meta = RefFFI::as_ref(keyspace_meta).unwrap();
-    let view_name = ptr_to_cstr_n(view, view_length).unwrap();
+    let view_name = unsafe { ptr_to_cstr_n(view, view_length).unwrap() };
 
     match keyspace_meta.views.get(view_name) {
         Some(view_meta) => RefFFI::as_ptr(view_meta.as_ref()),
@@ -425,7 +427,7 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     view: *const c_char,
 ) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
-    cass_table_meta_materialized_view_by_name_n(table_meta, view, strlen(view))
+    unsafe { cass_table_meta_materialized_view_by_name_n(table_meta, view, strlen(view)) }
 }
 
 #[no_mangle]
@@ -439,7 +441,7 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name_n(
     }
 
     let table_meta = RefFFI::as_ref(table_meta).unwrap();
-    let view_name = ptr_to_cstr_n(view, view_length).unwrap();
+    let view_name = unsafe { ptr_to_cstr_n(view, view_length).unwrap() };
 
     match table_meta.views.get(view_name) {
         Some(view_meta) => RefFFI::as_ptr(view_meta.as_ref()),
@@ -473,7 +475,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name(
     view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     column: *const c_char,
 ) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
-    cass_materialized_view_meta_column_by_name_n(view_meta, column, strlen(column))
+    unsafe { cass_materialized_view_meta_column_by_name_n(view_meta, column, strlen(column)) }
 }
 
 #[no_mangle]
@@ -487,7 +489,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name_n(
     }
 
     let view_meta = RefFFI::as_ref(view_meta).unwrap();
-    let column_name = ptr_to_cstr_n(column, column_length).unwrap();
+    let column_name = unsafe { ptr_to_cstr_n(column, column_length).unwrap() };
 
     match view_meta.view_metadata.columns_metadata.get(column_name) {
         Some(column_meta) => RefFFI::as_ptr(column_meta),
@@ -502,7 +504,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_name(
     name_length: *mut size_t,
 ) {
     let view_meta = RefFFI::as_ref(view_meta).unwrap();
-    write_str_to_c(view_meta.name.as_str(), name, name_length)
+    unsafe { write_str_to_c(view_meta.name.as_str(), name, name_length) }
 }
 
 #[no_mangle]
@@ -511,7 +513,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_base_table(
 ) -> CassBorrowedSharedPtr<CassTableMeta, CConst> {
     let view_meta = RefFFI::as_ref(view_meta).unwrap();
 
-    let ptr = RefFFI::weak_as_ptr(&view_meta.base_table);
+    let ptr = unsafe { RefFFI::weak_as_ptr(&view_meta.base_table) };
     if RefFFI::is_null(&ptr) {
         tracing::error!("Failed to upgrade a weak reference to table metadata from materialized view metadata! This is a driver bug!");
     }

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn cass_prepared_parameter_name(
         .get_by_index(index as usize)
     {
         Some(col_spec) => {
-            write_str_to_c(col_spec.name(), name, name_length);
+            unsafe { write_str_to_c(col_spec.name(), name, name_length) };
             CassError::CASS_OK
         }
         None => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name(
     prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
     name: *const c_char,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
-    cass_prepared_parameter_data_type_by_name_n(prepared_raw, name, strlen(name))
+    unsafe { cass_prepared_parameter_data_type_by_name_n(prepared_raw, name, strlen(name)) }
 }
 
 #[no_mangle]
@@ -160,7 +160,7 @@ pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name_n(
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
     let prepared = ArcFFI::as_ref(prepared_raw).unwrap();
     let parameter_name =
-        ptr_to_cstr_n(name, name_length).expect("Prepared parameter name is not UTF-8");
+        unsafe { ptr_to_cstr_n(name, name_length).expect("Prepared parameter name is not UTF-8") };
 
     let data_type = prepared.get_variable_data_type_by_name(parameter_name);
     match data_type {

--- a/scylla-rust-wrapper/src/query_error.rs
+++ b/scylla-rust-wrapper/src/query_error.rs
@@ -215,14 +215,14 @@ pub unsafe extern "C" fn cass_error_result_keyspace(
             DbError::AlreadyExists { keyspace, .. },
             _,
         ))) => {
-            write_str_to_c(keyspace.as_str(), c_keyspace, c_keyspace_len);
+            unsafe { write_str_to_c(keyspace.as_str(), c_keyspace, c_keyspace_len) };
             CassError::CASS_OK
         }
         CassErrorResult::Query(ExecutionError::LastAttemptError(RequestAttemptError::DbError(
             DbError::FunctionFailure { keyspace, .. },
             _,
         ))) => {
-            write_str_to_c(keyspace.as_str(), c_keyspace, c_keyspace_len);
+            unsafe { write_str_to_c(keyspace.as_str(), c_keyspace, c_keyspace_len) };
             CassError::CASS_OK
         }
         _ => CassError::CASS_ERROR_LIB_INVALID_ERROR_RESULT_TYPE,
@@ -241,7 +241,7 @@ pub unsafe extern "C" fn cass_error_result_table(
             DbError::AlreadyExists { table, .. },
             _,
         ))) => {
-            write_str_to_c(table.as_str(), c_table, c_table_len);
+            unsafe { write_str_to_c(table.as_str(), c_table, c_table_len) };
             CassError::CASS_OK
         }
         _ => CassError::CASS_ERROR_LIB_INVALID_ERROR_RESULT_TYPE,
@@ -260,7 +260,7 @@ pub unsafe extern "C" fn cass_error_result_function(
             DbError::FunctionFailure { function, .. },
             _,
         ))) => {
-            write_str_to_c(function.as_str(), c_function, c_function_len);
+            unsafe { write_str_to_c(function.as_str(), c_function, c_function_len) };
             CassError::CASS_OK
         }
         _ => CassError::CASS_ERROR_LIB_INVALID_ERROR_RESULT_TYPE,
@@ -297,11 +297,13 @@ pub unsafe extern "C" fn cass_error_result_arg_type(
             if index >= arg_types.len() as size_t {
                 return CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
             }
-            write_str_to_c(
-                arg_types[index as usize].as_str(),
-                arg_type,
-                arg_type_length,
-            );
+            unsafe {
+                write_str_to_c(
+                    arg_types[index as usize].as_str(),
+                    arg_type,
+                    arg_type_length,
+                )
+            };
             CassError::CASS_OK
         }
         _ => CassError::CASS_ERROR_LIB_INVALID_ERROR_RESULT_TYPE,

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -289,7 +289,7 @@ pub unsafe extern "C" fn cass_result_free(result_raw: CassOwnedSharedPtr<CassRes
 pub unsafe extern "C" fn cass_result_has_more_pages(
     result: CassBorrowedSharedPtr<CassResult, CConst>,
 ) -> cass_bool_t {
-    result_has_more_pages(&result)
+    unsafe { result_has_more_pages(&result) }
 }
 
 unsafe fn result_has_more_pages(result: &CassBorrowedSharedPtr<CassResult, CConst>) -> cass_bool_t {
@@ -318,10 +318,10 @@ pub unsafe extern "C" fn cass_row_get_column_by_name(
     row: CassBorrowedSharedPtr<CassRow, CConst>,
     name: *const c_char,
 ) -> CassBorrowedSharedPtr<CassValue, CConst> {
-    let name_str = ptr_to_cstr(name).unwrap();
+    let name_str = unsafe { ptr_to_cstr(name) }.unwrap();
     let name_length = name_str.len();
 
-    cass_row_get_column_by_name_n(row, name, name_length as size_t)
+    unsafe { cass_row_get_column_by_name_n(row, name, name_length as size_t) }
 }
 
 #[no_mangle]
@@ -331,7 +331,7 @@ pub unsafe extern "C" fn cass_row_get_column_by_name_n(
     name_length: size_t,
 ) -> CassBorrowedSharedPtr<CassValue, CConst> {
     let row_from_raw = RefFFI::as_ref(row).unwrap();
-    let mut name_str = ptr_to_cstr_n(name, name_length).unwrap();
+    let mut name_str = unsafe { ptr_to_cstr_n(name, name_length).unwrap() };
     let mut is_case_sensitive = false;
 
     if name_str.starts_with('\"') && name_str.ends_with('\"') {
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn cass_result_column_name(
 
     let column_name = &metadata.col_specs.get(index_usize).unwrap().name;
 
-    write_str_to_c(column_name, name, name_length);
+    unsafe { write_str_to_c(column_name, name, name_length) };
 
     CassError::CASS_OK
 }
@@ -386,11 +386,11 @@ pub unsafe extern "C" fn cass_result_column_type(
     result: CassBorrowedSharedPtr<CassResult, CConst>,
     index: size_t,
 ) -> CassValueType {
-    let data_type_ptr = cass_result_column_data_type(result, index);
+    let data_type_ptr = unsafe { cass_result_column_data_type(result, index) };
     if ArcFFI::is_null(&data_type_ptr) {
         return CassValueType::CASS_VALUE_TYPE_UNKNOWN;
     }
-    cass_data_type_type(data_type_ptr)
+    unsafe { cass_data_type_type(data_type_ptr) }
 }
 
 #[no_mangle]
@@ -419,7 +419,7 @@ pub unsafe extern "C" fn cass_value_type(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
 ) -> CassValueType {
     let value_from_raw = RefFFI::as_ref(value).unwrap();
-    cass_data_type_type(ArcFFI::as_ptr(&value_from_raw.value_type))
+    unsafe { cass_data_type_type(ArcFFI::as_ptr(&value_from_raw.value_type)) }
 }
 
 #[no_mangle]
@@ -448,7 +448,7 @@ pub unsafe extern "C" fn cass_value_get_float(
 ) -> CassError {
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Float(f))) => std::ptr::write(output, f),
+        Some(Value::RegularValue(CqlValue::Float(f))) => unsafe { std::ptr::write(output, f) },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -463,7 +463,7 @@ pub unsafe extern "C" fn cass_value_get_double(
 ) -> CassError {
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Double(d))) => std::ptr::write(output, d),
+        Some(Value::RegularValue(CqlValue::Double(d))) => unsafe { std::ptr::write(output, d) },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -478,9 +478,9 @@ pub unsafe extern "C" fn cass_value_get_bool(
 ) -> CassError {
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Boolean(b))) => {
+        Some(Value::RegularValue(CqlValue::Boolean(b))) => unsafe {
             std::ptr::write(output, b as cass_bool_t)
-        }
+        },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -495,7 +495,7 @@ pub unsafe extern "C" fn cass_value_get_int8(
 ) -> CassError {
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::TinyInt(i))) => std::ptr::write(output, i),
+        Some(Value::RegularValue(CqlValue::TinyInt(i))) => unsafe { std::ptr::write(output, i) },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -510,7 +510,7 @@ pub unsafe extern "C" fn cass_value_get_int16(
 ) -> CassError {
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::SmallInt(i))) => std::ptr::write(output, i),
+        Some(Value::RegularValue(CqlValue::SmallInt(i))) => unsafe { std::ptr::write(output, i) },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -525,7 +525,7 @@ pub unsafe extern "C" fn cass_value_get_uint32(
 ) -> CassError {
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Date(u))) => std::ptr::write(output, u.0), // FIXME: hack
+        Some(Value::RegularValue(CqlValue::Date(u))) => unsafe { std::ptr::write(output, u.0) }, // FIXME: hack
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -540,7 +540,7 @@ pub unsafe extern "C" fn cass_value_get_int32(
 ) -> CassError {
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Int(i))) => std::ptr::write(output, i),
+        Some(Value::RegularValue(CqlValue::Int(i))) => unsafe { std::ptr::write(output, i) },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -555,14 +555,14 @@ pub unsafe extern "C" fn cass_value_get_int64(
 ) -> CassError {
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::BigInt(i))) => std::ptr::write(output, i),
-        Some(Value::RegularValue(CqlValue::Counter(i))) => {
+        Some(Value::RegularValue(CqlValue::BigInt(i))) => unsafe { std::ptr::write(output, i) },
+        Some(Value::RegularValue(CqlValue::Counter(i))) => unsafe {
             std::ptr::write(output, i.0 as cass_int64_t)
-        }
-        Some(Value::RegularValue(CqlValue::Time(d))) => std::ptr::write(output, d.0),
-        Some(Value::RegularValue(CqlValue::Timestamp(d))) => {
+        },
+        Some(Value::RegularValue(CqlValue::Time(d))) => unsafe { std::ptr::write(output, d.0) },
+        Some(Value::RegularValue(CqlValue::Timestamp(d))) => unsafe {
             std::ptr::write(output, d.0 as cass_int64_t)
-        }
+        },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -577,10 +577,12 @@ pub unsafe extern "C" fn cass_value_get_uuid(
 ) -> CassError {
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Uuid(uuid))) => std::ptr::write(output, uuid.into()),
-        Some(Value::RegularValue(CqlValue::Timeuuid(uuid))) => {
+        Some(Value::RegularValue(CqlValue::Uuid(uuid))) => unsafe {
+            std::ptr::write(output, uuid.into())
+        },
+        Some(Value::RegularValue(CqlValue::Timeuuid(uuid))) => unsafe {
             std::ptr::write(output, Into::<Uuid>::into(uuid).into())
-        }
+        },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -595,7 +597,9 @@ pub unsafe extern "C" fn cass_value_get_inet(
 ) -> CassError {
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
     match val.value {
-        Some(Value::RegularValue(CqlValue::Inet(inet))) => std::ptr::write(output, inet.into()),
+        Some(Value::RegularValue(CqlValue::Inet(inet))) => unsafe {
+            std::ptr::write(output, inet.into())
+        },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     };
@@ -618,9 +622,11 @@ pub unsafe extern "C" fn cass_value_get_decimal(
     };
 
     let (varint_value, scale_value) = decimal.as_signed_be_bytes_slice_and_exponent();
-    std::ptr::write(varint_size, varint_value.len() as size_t);
-    std::ptr::write(varint, varint_value.as_ptr());
-    std::ptr::write(scale, scale_value);
+    unsafe {
+        std::ptr::write(varint_size, varint_value.len() as size_t);
+        std::ptr::write(varint, varint_value.as_ptr());
+        std::ptr::write(scale, scale_value);
+    }
 
     CassError::CASS_OK
 }
@@ -637,12 +643,12 @@ pub unsafe extern "C" fn cass_value_get_string(
         // on any type and get internal represenation. I don't see how to do it easily in
         // a compatible way in rust, so let's do something sensible - only return result
         // for string values.
-        Some(Value::RegularValue(CqlValue::Ascii(s))) => {
+        Some(Value::RegularValue(CqlValue::Ascii(s))) => unsafe {
             write_str_to_c(s.as_str(), output, output_size)
-        }
-        Some(Value::RegularValue(CqlValue::Text(s))) => {
+        },
+        Some(Value::RegularValue(CqlValue::Text(s))) => unsafe {
             write_str_to_c(s.as_str(), output, output_size)
-        }
+        },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     }
@@ -660,11 +666,11 @@ pub unsafe extern "C" fn cass_value_get_duration(
     let val: &CassValue = val_ptr_to_ref_ensure_non_null!(value);
 
     match &val.value {
-        Some(Value::RegularValue(CqlValue::Duration(duration))) => {
+        Some(Value::RegularValue(CqlValue::Duration(duration))) => unsafe {
             std::ptr::write(months, duration.months);
             std::ptr::write(days, duration.days);
             std::ptr::write(nanos, duration.nanoseconds);
-        }
+        },
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
     }
@@ -683,14 +689,16 @@ pub unsafe extern "C" fn cass_value_get_bytes(
     // FIXME: This should be implemented for all CQL types
     // Note: currently rust driver does not allow to get raw bytes of the CQL value.
     match &value_from_raw.value {
-        Some(Value::RegularValue(CqlValue::Blob(bytes))) => {
+        Some(Value::RegularValue(CqlValue::Blob(bytes))) => unsafe {
             *output = bytes.as_ptr() as *const cass_byte_t;
             *output_size = bytes.len() as u64;
-        }
+        },
         Some(Value::RegularValue(CqlValue::Varint(varint))) => {
             let bytes = varint.as_signed_bytes_be_slice();
-            std::ptr::write(output, bytes.as_ptr());
-            std::ptr::write(output_size, bytes.len() as size_t);
+            unsafe {
+                std::ptr::write(output, bytes.as_ptr());
+                std::ptr::write(output_size, bytes.len() as size_t);
+            }
         }
         Some(_) => return CassError::CASS_ERROR_LIB_INVALID_VALUE_TYPE,
         None => return CassError::CASS_ERROR_LIB_NULL_VALUE,
@@ -714,7 +722,7 @@ pub unsafe extern "C" fn cass_value_is_collection(
     let val = RefFFI::as_ref(value).unwrap();
 
     matches!(
-        val.value_type.get_unchecked().get_value_type(),
+        unsafe { val.value_type.get_unchecked() }.get_value_type(),
         CassValueType::CASS_VALUE_TYPE_LIST
             | CassValueType::CASS_VALUE_TYPE_SET
             | CassValueType::CASS_VALUE_TYPE_MAP
@@ -727,8 +735,8 @@ pub unsafe extern "C" fn cass_value_is_duration(
 ) -> cass_bool_t {
     let val = RefFFI::as_ref(value).unwrap();
 
-    (val.value_type.get_unchecked().get_value_type() == CassValueType::CASS_VALUE_TYPE_DURATION)
-        as cass_bool_t
+    (unsafe { val.value_type.get_unchecked() }.get_value_type()
+        == CassValueType::CASS_VALUE_TYPE_DURATION) as cass_bool_t
 }
 
 #[no_mangle]
@@ -755,15 +763,17 @@ pub unsafe extern "C" fn cass_value_primary_sub_type(
 ) -> CassValueType {
     let val = RefFFI::as_ref(collection).unwrap();
 
-    match val.value_type.get_unchecked() {
+    match unsafe { val.value_type.get_unchecked() } {
         CassDataTypeInner::List {
             typ: Some(list), ..
-        } => list.get_unchecked().get_value_type(),
-        CassDataTypeInner::Set { typ: Some(set), .. } => set.get_unchecked().get_value_type(),
+        } => unsafe { list.get_unchecked() }.get_value_type(),
+        CassDataTypeInner::Set { typ: Some(set), .. } => {
+            unsafe { set.get_unchecked() }.get_value_type()
+        }
         CassDataTypeInner::Map {
             typ: MapDataType::Key(key) | MapDataType::KeyAndValue(key, _),
             ..
-        } => key.get_unchecked().get_value_type(),
+        } => unsafe { key.get_unchecked() }.get_value_type(),
         _ => CassValueType::CASS_VALUE_TYPE_UNKNOWN,
     }
 }
@@ -774,11 +784,11 @@ pub unsafe extern "C" fn cass_value_secondary_sub_type(
 ) -> CassValueType {
     let val = RefFFI::as_ref(collection).unwrap();
 
-    match val.value_type.get_unchecked() {
+    match unsafe { val.value_type.get_unchecked() } {
         CassDataTypeInner::Map {
             typ: MapDataType::KeyAndValue(_, value),
             ..
-        } => value.get_unchecked().get_value_type(),
+        } => unsafe { value.get_unchecked() }.get_value_type(),
         _ => CassValueType::CASS_VALUE_TYPE_UNKNOWN,
     }
 }
@@ -828,7 +838,7 @@ pub unsafe extern "C" fn cass_result_paging_state_token(
     paging_state: *mut *const c_char,
     paging_state_size: *mut size_t,
 ) -> CassError {
-    if result_has_more_pages(&result) == cass_false {
+    if unsafe { result_has_more_pages(&result) } == cass_false {
         return CassError::CASS_ERROR_LIB_NO_PAGING_STATE;
     }
 
@@ -836,19 +846,19 @@ pub unsafe extern "C" fn cass_result_paging_state_token(
 
     match &result_from_raw.paging_state_response {
         PagingStateResponse::HasMorePages { state } => match state.as_bytes_slice() {
-            Some(result_paging_state) => {
+            Some(result_paging_state) => unsafe {
                 *paging_state_size = result_paging_state.len() as u64;
                 *paging_state = result_paging_state.as_ptr() as *const c_char;
-            }
-            None => {
+            },
+            None => unsafe {
                 *paging_state_size = 0;
                 *paging_state = std::ptr::null();
-            }
+            },
         },
-        PagingStateResponse::NoMorePages => {
+        PagingStateResponse::NoMorePages => unsafe {
             *paging_state_size = 0;
             *paging_state = std::ptr::null();
-        }
+        },
     }
 
     CassError::CASS_OK
@@ -927,14 +937,16 @@ mod tests {
     ) -> Option<&'static str> {
         let mut name_ptr: *const c_char = std::ptr::null();
         let mut name_length: size_t = 0;
-        let cass_err = cass_result_column_name(
-            result_ptr,
-            column_index,
-            addr_of_mut!(name_ptr),
-            addr_of_mut!(name_length),
-        );
+        let cass_err = unsafe {
+            cass_result_column_name(
+                result_ptr,
+                column_index,
+                addr_of_mut!(name_ptr),
+                addr_of_mut!(name_length),
+            )
+        };
         assert_eq!(CassError::CASS_OK, cass_err);
-        ptr_to_cstr_n(name_ptr, name_length)
+        unsafe { ptr_to_cstr_n(name_ptr, name_length) }
     }
 
     #[test]

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -265,7 +265,7 @@ pub unsafe extern "C" fn cass_statement_new(
     query: *const c_char,
     parameter_count: size_t,
 ) -> CassOwnedExclusivePtr<CassStatement, CMut> {
-    cass_statement_new_n(query, strlen(query), parameter_count)
+    unsafe { cass_statement_new_n(query, strlen(query), parameter_count) }
 }
 
 #[no_mangle]
@@ -274,7 +274,7 @@ pub unsafe extern "C" fn cass_statement_new_n(
     query_length: size_t,
     parameter_count: size_t,
 ) -> CassOwnedExclusivePtr<CassStatement, CMut> {
-    let query_str = match ptr_to_cstr_n(query, query_length) {
+    let query_str = match unsafe { ptr_to_cstr_n(query, query_length) } {
         Some(v) => v,
         None => return BoxFFI::null_mut(),
     };
@@ -374,7 +374,8 @@ pub unsafe extern "C" fn cass_statement_set_paging_state_token(
     }
 
     let paging_state_usize: usize = paging_state_size.try_into().unwrap();
-    let paging_state_bytes = slice::from_raw_parts(paging_state as *const u8, paging_state_usize);
+    let paging_state_bytes =
+        unsafe { slice::from_raw_parts(paging_state as *const u8, paging_state_usize) };
     statement_from_raw.paging_state = PagingState::new_from_raw_bytes(paging_state_bytes);
     CassError::CASS_OK
 }

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -79,7 +79,7 @@ unsafe extern "C" fn cass_tuple_new_from_data_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassOwnedExclusivePtr<CassTuple, CMut> {
     let data_type = ArcFFI::cloned_from_ptr(data_type).unwrap();
-    let item_count = match data_type.get_unchecked() {
+    let item_count = match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::Tuple(v) => v.len(),
         _ => return BoxFFI::null_mut(),
     };

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn cass_user_type_new_from_data_type(
 ) -> CassOwnedExclusivePtr<CassUserType, CMut> {
     let data_type = ArcFFI::cloned_from_ptr(data_type_raw).unwrap();
 
-    match data_type.get_unchecked() {
+    match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(udt_data_type) => {
             let field_values = vec![None; udt_data_type.field_types.len()];
             BoxFFI::into_ptr(Box::new(CassUserType {


### PR DESCRIPTION
It enforces the usage of unsafe block even inside unsafe functions.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~