### PR TITLE
cmake: bump minimum version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 project(cppdriverv2 C CXX)
 
 set(CASS_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,7 +1,7 @@
 #
 # Format and verify formatting using clang-format
 #
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 include(FindPackageHandleStandardArgs)
 

--- a/cmake/ExternalProject-OpenSSL.cmake
+++ b/cmake/ExternalProject-OpenSSL.cmake
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(ExternalProject)
 include(Windows-Environment)
 if(NOT MSVC_ENVIRONMENT_SCRIPT)

--- a/cmake/ExternalProject-libssh2.cmake
+++ b/cmake/ExternalProject-libssh2.cmake
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(ExternalProject)
 include(Windows-Environment)
 

--- a/cmake/ExternalProject-libuv.cmake
+++ b/cmake/ExternalProject-libuv.cmake
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(ExternalProject)
 include(Windows-Environment)
 

--- a/cmake/ExternalProject-zlib.cmake
+++ b/cmake/ExternalProject-zlib.cmake
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(ExternalProject)
 include(Windows-Environment)
 

--- a/examples/async/CMakeLists.txt
+++ b/examples/async/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME async)

--- a/examples/auth/CMakeLists.txt
+++ b/examples/auth/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME auth)

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME basic)

--- a/examples/batch/CMakeLists.txt
+++ b/examples/batch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME batch)

--- a/examples/bind_by_name/CMakeLists.txt
+++ b/examples/bind_by_name/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME bind_by_name)

--- a/examples/callbacks/CMakeLists.txt
+++ b/examples/callbacks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME callbacks)

--- a/examples/cloud/CMakeLists.txt
+++ b/examples/cloud/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME cloud)

--- a/examples/collections/CMakeLists.txt
+++ b/examples/collections/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME collections)

--- a/examples/concurrent_executions/CMakeLists.txt
+++ b/examples/concurrent_executions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME concurrent_executions)

--- a/examples/date_time/CMakeLists.txt
+++ b/examples/date_time/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME date_time)

--- a/examples/dse/date_range/CMakeLists.txt
+++ b/examples/dse/date_range/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME date_range)

--- a/examples/dse/geotypes/CMakeLists.txt
+++ b/examples/dse/geotypes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME geotypes)

--- a/examples/dse/gssapi/CMakeLists.txt
+++ b/examples/dse/gssapi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 

--- a/examples/dse/plaintext/CMakeLists.txt
+++ b/examples/dse/plaintext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 

--- a/examples/dse/proxy_execution/CMakeLists.txt
+++ b/examples/dse/proxy_execution/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME proxy_execution)

--- a/examples/duration/CMakeLists.txt
+++ b/examples/duration/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME duration)

--- a/examples/execution_profiles/CMakeLists.txt
+++ b/examples/execution_profiles/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME execution_profiles)

--- a/examples/host_listener/CMakeLists.txt
+++ b/examples/host_listener/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME host_listener)

--- a/examples/logging/CMakeLists.txt
+++ b/examples/logging/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME logging)

--- a/examples/maps/CMakeLists.txt
+++ b/examples/maps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME maps)

--- a/examples/named_parameters/CMakeLists.txt
+++ b/examples/named_parameters/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME named_parameters)

--- a/examples/paging/CMakeLists.txt
+++ b/examples/paging/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME paging)

--- a/examples/perf/CMakeLists.txt
+++ b/examples/perf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME perf)

--- a/examples/prepared/CMakeLists.txt
+++ b/examples/prepared/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME prepared)

--- a/examples/schema_meta/CMakeLists.txt
+++ b/examples/schema_meta/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME schema_meta)

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME simple)

--- a/examples/ssl/CMakeLists.txt
+++ b/examples/ssl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME ssl)

--- a/examples/tracing/CMakeLists.txt
+++ b/examples/tracing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME tracing)

--- a/examples/tuple/CMakeLists.txt
+++ b/examples/tuple/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME tuple)

--- a/examples/udt/CMakeLists.txt
+++ b/examples/udt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME udt)

--- a/examples/uuids/CMakeLists.txt
+++ b/examples/uuids/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME uuids)

--- a/src/third_party/sparsehash/CMakeLists.txt
+++ b/src/third_party/sparsehash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.15)
 
 include(CheckCXXSourceCompiles)
 include(CheckFunctionExists)


### PR DESCRIPTION
According to https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features, starting from release 4.0, the compatibility with CMake < 3.15 is no longer supported.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~