### PR TITLE
Release v0.4.0

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-cpp-driver-rust"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "assert_matches",
  "bindgen",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cpp-driver-rust"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"
 repository = "https://github.com/scylladb/scylla-rust-driver"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB CPP Rust Driver 0.4.0, an API-compatible rewrite of https://github.com/scylladb/cpp-driver as a wrapper for the Rust driver. It will fully replace the CPP driver, which is already reaching its End of Life.

We are also happy to announce, that starting from this release, the driver version can be considered **Beta**:
1. Safety refactor hardened FFI API and detected some critical bugs - this increased our confidence in the quality of the driver.
2. Key features are already implemented and tested.
3. The underlying rust-driver version is stable and breaking changes are not expected anytime soon.

Some minor features still need to be included. See [_Limitations_ section in README.md](https://github.com/scylladb/cpp-rust-driver/?tab=readme-ov-file#limitations).

The underlying Rust driver used version: [1.1.0](https://github.com/scylladb/scylla-rust-driver/releases/tag/v1.1.0).

## Changes

**Implemented API functions:**
- **Schema metadata:**
    - `cass_table_meta_column` ([#228](https://github.com/scylladb/cpp-rust-driver/pull/228))
- **CassIterator:**
    - `cass_iterator_type` ([#230](https://github.com/scylladb/cpp-rust-driver/pull/230))
- **CassValue:**
    - `cass_value_get_bytes` - extended the support for remaining CQL types. ([#236](https://github.com/scylladb/cpp-rust-driver/pull/236))

**New features / enhancements**
- Bumped underlying rust-driver version to `1.1.0`. ([#237](https://github.com/scylladb/cpp-rust-driver/pull/237))
- Safety refactor - implemented an API which ensures safe pointer manipulation. This enforces the safety on the type level - most critical bugs should now be discovered at compile time. ([#207](https://github.com/scylladb/cpp-rust-driver/pull/207), [#225](https://github.com/scylladb/cpp-rust-driver/pull/225), [#226](https://github.com/scylladb/cpp-rust-driver/pull/226), [#208](https://github.com/scylladb/cpp-rust-driver/pull/208))
- Lazy deserialization refactor - rows and values are now lazily deserialized to the specific type - only when requested. This allowed us to reduce the number of allocations on a hot path and properly implement `cass_value_get_bytes` method. ([#213](https://github.com/scylladb/cpp-rust-driver/pull/213), [#236](https://github.com/scylladb/cpp-rust-driver/pull/236))
- Enabled caching result metadata optimization for prepared statements on rust-driver side by default. ([#210](https://github.com/scylladb/cpp-rust-driver/pull/210))

**Bug fixes:**
- Fixed by-name parameter binding, so the logic is consistent with cpp-driver. ([#187](https://github.com/scylladb/cpp-rust-driver/pull/187))
- Thanks to new FFI API, we found and fixed few bug fixes related to raw pointer manipulation. ([#229](https://github.com/scylladb/cpp-rust-driver/pull/229))

**CI / developer tool improvements:**
- Enabled `NamedParametersTests` suite and introduced new test cases to the suite. ([#187](https://github.com/scylladb/cpp-rust-driver/pull/187))
- Addressed clippy lints ([#211](https://github.com/scylladb/cpp-rust-driver/pull/211), [#218](https://github.com/scylladb/cpp-rust-driver/pull/218))
- Added `lib` to crate-type list in `Cargo.toml`. This is to enable the `doctests` during CI. ([#227](https://github.com/scylladb/cpp-rust-driver/pull/227))
- Enabled `unsafe-op-in-unsafe-fn` compiler lint. ([#232](https://github.com/scylladb/cpp-rust-driver/pull/232))
- Bumped minimum cmake version to `3.15` ([#233](https://github.com/scylladb/cpp-rust-driver/pull/233))
- Started building packages for Fedora 41. ([#247](https://github.com/scylladb/cpp-rust-driver/pull/247))
- Started installing valgrind using `apt` instead of `snap`. ([#248](https://github.com/scylladb/cpp-rust-driver/pull/248))
- Updated `Cargo.lock` file to build the library with latest dependencies. (#[250](https://github.com/scylladb/cpp-rust-driver/pull/250))
- Bumped Rust edition to 2024. (#[251](https://github.com/scylladb/cpp-rust-driver/pull/251))

**Documentation:**
- Bumped `sphinx-scylladb-theme` version multiple times (current version is `1.8.6`). ([#217](https://github.com/scylladb/cpp-rust-driver/pull/217), [#219](https://github.com/scylladb/cpp-rust-driver/pull/219), [#234](https://github.com/scylladb/cpp-rust-driver/pull/234))

**Others:**
- Replaced [`lazy_static`](https://docs.rs/lazy_static/latest/lazy_static/) usages with [`LazyLock`](https://doc.rust-lang.org/beta/std/sync/struct.LazyLock.html), which was stabilized in Rust 1.80. Removed `lazy_static` dependency altogether. ([#212](https://github.com/scylladb/cpp-rust-driver/pull/212))
- Added `WHERE key='local'` clause to all queries to `system.local` table. ([#221](https://github.com/scylladb/cpp-rust-driver/pull/221))
- Updated `README.md`. ([#246](https://github.com/scylladb/cpp-rust-driver/pull/246))

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/cpp-rust-driver/](https://github.com/scylladb/cpp-rust-driver/)
Contributions are most welcome!

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:
| commits | author              |
|---------|---------------------|
| 90      | Mikołaj Uzarski     |
| 4       | Karol Baryła        |
| 3       | dependabot[bot]     |
| 1       | Dmitry Kropachev    |
| 1       | Wojciech Przytuła   |
