### PR TITLE
cargo: bump rust edition to 2024

### DIFF
--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scylla-cpp-driver-rust"
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"
 repository = "https://github.com/scylladb/scylla-rust-driver"
 readme = "./README.md"

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -1,10 +1,10 @@
 use crate::argconv::{
     ArcFFI, BoxFFI, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr, CassOwnedExclusivePtr,
-    FromBox, FFI,
+    FFI, FromBox,
 };
 use crate::cass_error::CassError;
 use crate::cass_types::CassConsistency;
-use crate::cass_types::{make_batch_type, CassBatchType};
+use crate::cass_types::{CassBatchType, make_batch_type};
 use crate::exec_profile::PerStatementExecProfile;
 use crate::retry_policy::CassRetryPolicy;
 use crate::statement::{BoundStatement, CassStatement};
@@ -32,7 +32,7 @@ pub struct CassBatchState {
     pub bound_values: Vec<Vec<MaybeUnset<Option<CassCqlValue>>>>,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_new(
     type_: CassBatchType,
 ) -> CassOwnedExclusivePtr<CassBatch, CMut> {
@@ -50,12 +50,12 @@ pub unsafe extern "C" fn cass_batch_new(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_free(batch: CassOwnedExclusivePtr<CassBatch, CMut>) {
     BoxFFI::free(batch);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_consistency(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     consistency: CassConsistency,
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn cass_batch_set_consistency(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_serial_consistency(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     serial_consistency: CassConsistency,
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn cass_batch_set_serial_consistency(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_retry_policy(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     retry_policy: CassBorrowedSharedPtr<CassRetryPolicy, CMut>,
@@ -112,7 +112,7 @@ pub unsafe extern "C" fn cass_batch_set_retry_policy(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_timestamp(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     timestamp: cass_int64_t,
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn cass_batch_set_timestamp(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_request_timeout(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     timeout_ms: cass_uint64_t,
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn cass_batch_set_request_timeout(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_is_idempotent(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     is_idempotent: cass_bool_t,
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn cass_batch_set_is_idempotent(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_tracing(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     enabled: cass_bool_t,
@@ -163,7 +163,7 @@ pub unsafe extern "C" fn cass_batch_set_tracing(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_add_statement(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     statement: CassBorrowedSharedPtr<CassStatement, CMut>,

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -50,7 +50,7 @@
 
 macro_rules! make_index_binder {
     ($this:ty, $consume_v:expr, $fn_by_idx:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         #[allow(clippy::redundant_closure_call)]
         pub unsafe extern "C" fn $fn_by_idx(
             this: CassBorrowedExclusivePtr<$this, CMut>,
@@ -70,7 +70,7 @@ macro_rules! make_index_binder {
 
 macro_rules! make_name_binder {
     ($this:ty, $consume_v:expr, $fn_by_name:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         #[allow(clippy::redundant_closure_call)]
         pub unsafe extern "C" fn $fn_by_name(
             this: CassBorrowedExclusivePtr<$this, CMut>,
@@ -91,7 +91,7 @@ macro_rules! make_name_binder {
 
 macro_rules! make_name_n_binder {
     ($this:ty, $consume_v:expr, $fn_by_name_n:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         #[allow(clippy::redundant_closure_call)]
         pub unsafe extern "C" fn $fn_by_name_n(
             this: CassBorrowedExclusivePtr<$this, CMut>,
@@ -113,7 +113,7 @@ macro_rules! make_name_n_binder {
 
 macro_rules! make_appender {
     ($this:ty, $consume_v:expr, $fn_append:ident, $e:expr, [$($arg:ident @ $t:ty), *]) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         #[allow(clippy::redundant_closure_call)]
         pub unsafe extern "C" fn $fn_append(
             this: CassBorrowedExclusivePtr<$this, CMut>,

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -302,11 +302,7 @@ impl CassDataTypeInner {
                 udt_data_type.field_types.get(index).map(|(_, b)| b)
             }
             CassDataTypeInner::List { typ, .. } | CassDataTypeInner::Set { typ, .. } => {
-                if index > 0 {
-                    None
-                } else {
-                    typ.as_ref()
-                }
+                if index > 0 { None } else { typ.as_ref() }
             }
             CassDataTypeInner::Map {
                 typ: MapDataType::Untyped,
@@ -447,7 +443,7 @@ pub fn get_column_type(column_type: &ColumnType) -> CassDataType {
     CassDataType::new(inner)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_new(
     value_type: CassValueType,
 ) -> CassOwnedSharedPtr<CassDataType, CMut> {
@@ -474,7 +470,7 @@ pub unsafe extern "C" fn cass_data_type_new(
     ArcFFI::into_ptr(CassDataType::new_arced(inner))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_new_from_existing(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassOwnedSharedPtr<CassDataType, CMut> {
@@ -484,7 +480,7 @@ pub unsafe extern "C" fn cass_data_type_new_from_existing(
     ))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_new_tuple(
     item_count: size_t,
 ) -> CassOwnedSharedPtr<CassDataType, CMut> {
@@ -493,7 +489,7 @@ pub unsafe extern "C" fn cass_data_type_new_tuple(
     )))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_new_udt(
     field_count: size_t,
 ) -> CassOwnedSharedPtr<CassDataType, CMut> {
@@ -502,12 +498,12 @@ pub unsafe extern "C" fn cass_data_type_new_udt(
     )))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_free(data_type: CassOwnedSharedPtr<CassDataType, CMut>) {
     ArcFFI::free(data_type);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassValueType {
@@ -515,7 +511,7 @@ pub unsafe extern "C" fn cass_data_type_type(
     unsafe { data_type.get_unchecked() }.get_value_type()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_is_frozen(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> cass_bool_t {
@@ -531,7 +527,7 @@ pub unsafe extern "C" fn cass_data_type_is_frozen(
     is_frozen as cass_bool_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_type_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     type_name: *mut *const c_char,
@@ -547,7 +543,7 @@ pub unsafe extern "C" fn cass_data_type_type_name(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_type_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     type_name: *const c_char,
@@ -555,7 +551,7 @@ pub unsafe extern "C" fn cass_data_type_set_type_name(
     unsafe { cass_data_type_set_type_name_n(data_type, type_name, strlen(type_name)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_type_name_n(
     data_type_raw: CassBorrowedSharedPtr<CassDataType, CMut>,
     type_name: *const c_char,
@@ -575,7 +571,7 @@ pub unsafe extern "C" fn cass_data_type_set_type_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_keyspace(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     keyspace: *mut *const c_char,
@@ -591,7 +587,7 @@ pub unsafe extern "C" fn cass_data_type_keyspace(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_keyspace(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     keyspace: *const c_char,
@@ -599,7 +595,7 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace(
     unsafe { cass_data_type_set_keyspace_n(data_type, keyspace, strlen(keyspace)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     keyspace: *const c_char,
@@ -619,7 +615,7 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_class_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     class_name: *mut *const ::std::os::raw::c_char,
@@ -635,7 +631,7 @@ pub unsafe extern "C" fn cass_data_type_class_name(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_class_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     class_name: *const ::std::os::raw::c_char,
@@ -643,7 +639,7 @@ pub unsafe extern "C" fn cass_data_type_set_class_name(
     unsafe { cass_data_type_set_class_name_n(data_type, class_name, strlen(class_name)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_class_name_n(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     class_name: *const ::std::os::raw::c_char,
@@ -662,7 +658,7 @@ pub unsafe extern "C" fn cass_data_type_set_class_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_sub_type_count(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> size_t {
@@ -683,14 +679,14 @@ pub unsafe extern "C" fn cass_data_type_sub_type_count(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_sub_type_count(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> size_t {
     unsafe { cass_data_type_sub_type_count(data_type) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_sub_data_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     index: size_t,
@@ -706,7 +702,7 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     name: *const ::std::os::raw::c_char,
@@ -714,7 +710,7 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name(
     unsafe { cass_data_type_sub_data_type_by_name_n(data_type, name, strlen(name)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     name: *const ::std::os::raw::c_char,
@@ -731,7 +727,7 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_sub_type_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     index: size_t,
@@ -751,7 +747,7 @@ pub unsafe extern "C" fn cass_data_type_sub_type_name(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_add_sub_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     sub_data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
@@ -765,7 +761,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     name: *const c_char,
@@ -774,7 +770,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
     unsafe { cass_data_type_add_sub_type_by_name_n(data_type, name, strlen(name), sub_data_type) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
     data_type_raw: CassBorrowedSharedPtr<CassDataType, CMut>,
     name: *const c_char,
@@ -798,7 +794,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_add_sub_value_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     sub_value_type: CassValueType,
@@ -807,7 +803,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type(
     unsafe { cass_data_type_add_sub_type(data_type, ArcFFI::as_ptr(&sub_data_type)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     name: *const c_char,
@@ -817,7 +813,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
     unsafe { cass_data_type_add_sub_type_by_name(data_type, name, ArcFFI::as_ptr(&sub_data_type)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     name: *const c_char,

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -1,7 +1,7 @@
 use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::cass_types::CassConsistency;
-use crate::exec_profile::{exec_profile_builder_modify, CassExecProfile, ExecProfileName};
+use crate::exec_profile::{CassExecProfile, ExecProfileName, exec_profile_builder_modify};
 use crate::future::CassFuture;
 use crate::retry_policy::CassRetryPolicy;
 use crate::retry_policy::RetryPolicy::*;
@@ -10,10 +10,10 @@ use crate::types::*;
 use crate::uuid::CassUuid;
 use openssl::ssl::SslContextBuilder;
 use openssl_sys::SSL_CTX_up_ref;
+use scylla::client::SelfIdentity;
 use scylla::client::execution_profile::ExecutionProfileBuilder;
 use scylla::client::session::SessionConfig;
 use scylla::client::session_builder::SessionBuilder;
-use scylla::client::SelfIdentity;
 use scylla::frame::Compression;
 use scylla::policies::load_balancing::{
     DefaultPolicyBuilder, LatencyAwarenessBuilder, LoadBalancingPolicy,
@@ -197,7 +197,7 @@ pub fn build_session_builder(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_new() -> CassOwnedExclusivePtr<CassCluster, CMut> {
     let default_execution_profile_builder = ExecutionProfileBuilder::default()
         .consistency(DEFAULT_CONSISTENCY)
@@ -237,12 +237,12 @@ pub unsafe extern "C" fn cass_cluster_new() -> CassOwnedExclusivePtr<CassCluster
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_free(cluster: CassOwnedExclusivePtr<CassCluster, CMut>) {
     BoxFFI::free(cluster);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_contact_points(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     contact_points: *const c_char,
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn cass_cluster_set_contact_points(
     unsafe { cass_cluster_set_contact_points_n(cluster, contact_points, strlen(contact_points)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_contact_points_n(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     contact_points: *const c_char,
@@ -291,7 +291,7 @@ unsafe fn cluster_set_contact_points(
     Ok(())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_use_randomized_contact_points(
     _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     _enabled: cass_bool_t,
@@ -301,7 +301,7 @@ pub unsafe extern "C" fn cass_cluster_set_use_randomized_contact_points(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_application_name(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     app_name: *const c_char,
@@ -309,7 +309,7 @@ pub unsafe extern "C" fn cass_cluster_set_application_name(
     unsafe { cass_cluster_set_application_name_n(cluster_raw, app_name, strlen(app_name)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_application_name_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     app_name: *const c_char,
@@ -327,7 +327,7 @@ pub unsafe extern "C" fn cass_cluster_set_application_name_n(
         .set_application_name(app_name)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_application_version(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     app_version: *const c_char,
@@ -335,7 +335,7 @@ pub unsafe extern "C" fn cass_cluster_set_application_version(
     unsafe { cass_cluster_set_application_version_n(cluster_raw, app_version, strlen(app_version)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_application_version_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     app_version: *const c_char,
@@ -353,7 +353,7 @@ pub unsafe extern "C" fn cass_cluster_set_application_version_n(
         .set_application_version(app_version);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_client_id(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     client_id: CassUuid,
@@ -371,7 +371,7 @@ pub unsafe extern "C" fn cass_cluster_set_client_id(
         .set_client_id(client_uuid_str)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_use_schema(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
@@ -380,7 +380,7 @@ pub unsafe extern "C" fn cass_cluster_set_use_schema(
     cluster.session_builder.config.fetch_schema_metadata = enabled != 0;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_tcp_nodelay(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
@@ -389,7 +389,7 @@ pub unsafe extern "C" fn cass_cluster_set_tcp_nodelay(
     cluster.session_builder.config.tcp_nodelay = enabled != 0;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_tcp_keepalive(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
@@ -402,7 +402,7 @@ pub unsafe extern "C" fn cass_cluster_set_tcp_keepalive(
     cluster.session_builder.config.tcp_keepalive_interval = tcp_keepalive_interval;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_connection_heartbeat_interval(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     interval_secs: c_uint,
@@ -413,7 +413,7 @@ pub unsafe extern "C" fn cass_cluster_set_connection_heartbeat_interval(
     cluster.session_builder.config.keepalive_interval = keepalive_interval;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_connection_idle_timeout(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     timeout_secs: c_uint,
@@ -424,7 +424,7 @@ pub unsafe extern "C" fn cass_cluster_set_connection_idle_timeout(
     cluster.session_builder.config.keepalive_timeout = keepalive_timeout;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_connect_timeout(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     timeout_ms: c_uint,
@@ -433,7 +433,7 @@ pub unsafe extern "C" fn cass_cluster_set_connect_timeout(
     cluster.session_builder.config.connect_timeout = Duration::from_millis(timeout_ms.into());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_request_timeout(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     timeout_ms: c_uint,
@@ -446,7 +446,7 @@ pub unsafe extern "C" fn cass_cluster_set_request_timeout(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_max_schema_wait_time(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     wait_time_ms: c_uint,
@@ -457,7 +457,7 @@ pub unsafe extern "C" fn cass_cluster_set_max_schema_wait_time(
         Duration::from_millis(wait_time_ms.into());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_schema_agreement_interval(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     interval_ms: c_uint,
@@ -468,7 +468,7 @@ pub unsafe extern "C" fn cass_cluster_set_schema_agreement_interval(
         Duration::from_millis(interval_ms.into());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_port(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     port: c_int,
@@ -482,7 +482,7 @@ pub unsafe extern "C" fn cass_cluster_set_port(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_credentials(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     username: *const c_char,
@@ -499,7 +499,7 @@ pub unsafe extern "C" fn cass_cluster_set_credentials(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_credentials_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     username_raw: *const c_char,
@@ -516,7 +516,7 @@ pub unsafe extern "C" fn cass_cluster_set_credentials_n(
     cluster.auth_password = Some(password.to_string());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_round_robin(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
 ) {
@@ -524,7 +524,7 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_round_robin(
     cluster.load_balancing_config.load_balancing_kind = Some(LoadBalancingKind::RoundRobin);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     local_dc: *const c_char,
@@ -567,7 +567,7 @@ pub(crate) unsafe fn set_load_balance_dc_aware_n(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     local_dc_raw: *const c_char,
@@ -588,7 +588,7 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     local_dc_raw: *const c_char,
@@ -605,7 +605,7 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     local_dc_raw: *const c_char,
@@ -654,7 +654,7 @@ pub(crate) unsafe fn set_load_balance_rack_aware_n(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_cloud_secure_connection_bundle_n(
     _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     path: *const c_char,
@@ -670,7 +670,7 @@ pub unsafe extern "C" fn cass_cluster_set_cloud_secure_connection_bundle_n(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_exponential_reconnect(
     _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     base_delay_ms: cass_uint64_t,
@@ -699,13 +699,13 @@ pub unsafe extern "C" fn cass_cluster_set_exponential_reconnect(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cass_custom_payload_new() -> *const CassCustomPayload {
     // FIXME: should create a new custom payload that must be freed
     std::ptr::null()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cass_future_custom_payload_item(
     _future: CassBorrowedExclusivePtr<CassFuture, CMut>,
     _i: size_t,
@@ -717,14 +717,14 @@ pub extern "C" fn cass_future_custom_payload_item(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cass_future_custom_payload_item_count(
     _future: CassBorrowedExclusivePtr<CassFuture, CMut>,
 ) -> size_t {
     0
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_use_beta_protocol_version(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enable: cass_bool_t,
@@ -735,7 +735,7 @@ pub unsafe extern "C" fn cass_cluster_set_use_beta_protocol_version(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_protocol_version(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     protocol_version: c_int,
@@ -750,7 +750,7 @@ pub unsafe extern "C" fn cass_cluster_set_protocol_version(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cass_cluster_set_queue_size_event(
     _cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     _queue_size: c_uint,
@@ -759,7 +759,7 @@ pub extern "C" fn cass_cluster_set_queue_size_event(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_constant_speculative_execution_policy(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     constant_delay_ms: cass_int64_t,
@@ -783,7 +783,7 @@ pub unsafe extern "C" fn cass_cluster_set_constant_speculative_execution_policy(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_no_speculative_execution_policy(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
 ) -> CassError {
@@ -796,7 +796,7 @@ pub unsafe extern "C" fn cass_cluster_set_no_speculative_execution_policy(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_token_aware_routing(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
@@ -805,7 +805,7 @@ pub unsafe extern "C" fn cass_cluster_set_token_aware_routing(
     cluster.load_balancing_config.token_awareness_enabled = enabled != 0;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_token_aware_routing_shuffle_replicas(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
@@ -817,7 +817,7 @@ pub unsafe extern "C" fn cass_cluster_set_token_aware_routing_shuffle_replicas(
         .token_aware_shuffling_replicas_enabled = enabled != 0;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_retry_policy(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     retry_policy: CassBorrowedSharedPtr<CassRetryPolicy, CMut>,
@@ -835,7 +835,7 @@ pub unsafe extern "C" fn cass_cluster_set_retry_policy(
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_ssl(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
@@ -850,7 +850,7 @@ pub unsafe extern "C" fn cass_cluster_set_ssl(
     cluster_from_raw.session_builder.config.tls_context = Some(ssl_context_builder.build().into());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_compression(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     compression_type: CassCompressionType,
@@ -865,7 +865,7 @@ pub unsafe extern "C" fn cass_cluster_set_compression(
     cluster_from_raw.session_builder.config.compression = compression;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
@@ -874,7 +874,7 @@ pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing(
     cluster.load_balancing_config.latency_awareness_enabled = enabled != 0;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing_settings(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     exclusion_threshold: cass_double_t,
@@ -892,7 +892,7 @@ pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing_settings(
         .minimum_measurements(min_measured as usize);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_consistency(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     consistency: CassConsistency,
@@ -910,7 +910,7 @@ pub unsafe extern "C" fn cass_cluster_set_consistency(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_serial_consistency(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     serial_consistency: CassConsistency,
@@ -928,7 +928,7 @@ pub unsafe extern "C" fn cass_cluster_set_serial_consistency(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_execution_profile(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     name: *const c_char,
@@ -937,7 +937,7 @@ pub unsafe extern "C" fn cass_cluster_set_execution_profile(
     unsafe { cass_cluster_set_execution_profile_n(cluster, name, strlen(name), profile) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     name: *const c_char,

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -135,7 +135,7 @@ impl TryFrom<&CassCollection> for CassCqlValue {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_collection_new(
     collection_type: CassCollectionType,
     item_count: size_t,
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn cass_collection_new(
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn cass_collection_new_from_data_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     item_count: size_t,
@@ -183,7 +183,7 @@ unsafe extern "C" fn cass_collection_new_from_data_type(
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn cass_collection_data_type(
     collection: CassBorrowedSharedPtr<CassCollection, CConst>,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
@@ -204,7 +204,7 @@ unsafe extern "C" fn cass_collection_data_type(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_collection_free(
     collection: CassOwnedExclusivePtr<CassCollection, CMut>,
 ) {
@@ -237,8 +237,8 @@ mod tests {
         argconv::ArcFFI,
         cass_error::CassError,
         cass_types::{
-            cass_data_type_add_sub_type, cass_data_type_free, cass_data_type_new, CassDataType,
-            CassDataTypeInner, CassValueType, MapDataType,
+            CassDataType, CassDataTypeInner, CassValueType, MapDataType,
+            cass_data_type_add_sub_type, cass_data_type_free, cass_data_type_new,
         },
         collection::{
             cass_collection_append_double, cass_collection_append_float, cass_collection_free,
@@ -247,9 +247,8 @@ mod tests {
     };
 
     use super::{
-        cass_bool_t, cass_collection_append_bool, cass_collection_append_int16,
+        CassCollectionType, cass_bool_t, cass_collection_append_bool, cass_collection_append_int16,
         cass_collection_data_type, cass_collection_new, cass_collection_new_from_data_type,
-        CassCollectionType,
     };
 
     #[test]

--- a/scylla-rust-wrapper/src/date_time.rs
+++ b/scylla-rust-wrapper/src/date_time.rs
@@ -9,17 +9,17 @@ const CASS_TIME_NANOSECONDS_PER_SECOND: i64 = 1_000_000_000;
 // All type conversions (between i32, u64, i64) based on original Cpp Driver implementation
 // and C++ implicit type promotion rules.
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_date_from_epoch(epoch_secs: cass_int64_t) -> cass_uint32_t {
     ((epoch_secs / NUM_SECONDS_PER_DAY) + (CASS_DATE_EPOCH as i64)) as u32
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_time_from_epoch(epoch_secs: cass_int64_t) -> cass_int64_t {
     CASS_TIME_NANOSECONDS_PER_SECOND * (epoch_secs % NUM_SECONDS_PER_DAY)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_date_time_to_epoch(
     date: cass_uint32_t,
     time: cass_int64_t,

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -14,15 +14,15 @@ use scylla::policies::speculative_execution::SimpleSpeculativeExecutionPolicy;
 use scylla::statement::Consistency;
 
 use crate::argconv::{
-    ptr_to_cstr_n, strlen, ArcFFI, BoxFFI, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr,
-    CassOwnedExclusivePtr, FromBox, FFI,
+    ArcFFI, BoxFFI, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr, CassOwnedExclusivePtr,
+    FFI, FromBox, ptr_to_cstr_n, strlen,
 };
 use crate::batch::CassBatch;
 use crate::cass_error::CassError;
 use crate::cass_types::CassConsistency;
 use crate::cluster::{
-    set_load_balance_dc_aware_n, set_load_balance_rack_aware_n, LoadBalancingConfig,
-    LoadBalancingKind,
+    LoadBalancingConfig, LoadBalancingKind, set_load_balance_dc_aware_n,
+    set_load_balance_rack_aware_n,
 };
 use crate::retry_policy::CassRetryPolicy;
 use crate::retry_policy::RetryPolicy::{
@@ -175,13 +175,13 @@ pub(crate) enum PerStatementExecProfileInner {
     Resolved(ExecutionProfileHandle),
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_new() -> CassOwnedExclusivePtr<CassExecProfile, CMut>
 {
     BoxFFI::into_ptr(Box::new(CassExecProfile::new()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_free(
     profile: CassOwnedExclusivePtr<CassExecProfile, CMut>,
 ) {
@@ -190,7 +190,7 @@ pub unsafe extern "C" fn cass_execution_profile_free(
 
 /* Exec profiles scope setters */
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_execution_profile(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
     name: *const c_char,
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn cass_statement_set_execution_profile(
     unsafe { cass_statement_set_execution_profile_n(statement, name, strlen(name)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_execution_profile_n(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
     name: *const c_char,
@@ -212,7 +212,7 @@ pub unsafe extern "C" fn cass_statement_set_execution_profile_n(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_execution_profile(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     name: *const c_char,
@@ -220,7 +220,7 @@ pub unsafe extern "C" fn cass_batch_set_execution_profile(
     unsafe { cass_batch_set_execution_profile_n(batch, name, strlen(name)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_execution_profile_n(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     name: *const c_char,
@@ -254,7 +254,7 @@ impl CassExecProfile {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_consistency(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     consistency: CassConsistency,
@@ -270,7 +270,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_consistency(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_no_speculative_execution_policy(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
 ) -> CassError {
@@ -281,7 +281,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_no_speculative_execution_pol
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_constant_speculative_execution_policy(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     constant_delay_ms: cass_int64_t,
@@ -303,7 +303,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_constant_speculative_executi
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_latency_aware_routing(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     enabled: cass_bool_t,
@@ -316,7 +316,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_latency_aware_routing(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_latency_aware_routing_settings(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     exclusion_threshold: cass_double_t,
@@ -335,7 +335,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_latency_aware_routing_settin
         .minimum_measurements(min_measured as usize);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     local_dc: *const c_char,
@@ -353,7 +353,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware_n(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     local_dc: *const c_char,
@@ -374,7 +374,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     local_dc_raw: *const c_char,
@@ -391,7 +391,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware_n(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     local_dc_raw: *const c_char,
@@ -412,7 +412,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_load_balance_round_robin(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
 ) -> CassError {
@@ -422,7 +422,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_round_robin(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_request_timeout(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     timeout_ms: cass_uint64_t,
@@ -435,7 +435,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_request_timeout(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_retry_policy(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     retry_policy: CassBorrowedSharedPtr<CassRetryPolicy, CMut>,
@@ -451,7 +451,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_retry_policy(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_serial_consistency(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     serial_consistency: CassConsistency,
@@ -472,7 +472,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_serial_consistency(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_token_aware_routing(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     enabled: cass_bool_t,
@@ -485,7 +485,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_token_aware_routing(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_token_aware_routing_shuffle_replicas(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     enabled: cass_bool_t,

--- a/scylla-rust-wrapper/src/execution_error.rs
+++ b/scylla-rust-wrapper/src/execution_error.rs
@@ -57,14 +57,14 @@ impl From<&WriteType> for CassWriteType {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_free(
     error_result: CassOwnedSharedPtr<CassErrorResult, CConst>,
 ) {
     ArcFFI::free(error_result);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_code(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> CassError {
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn cass_error_result_code(
     error_result.to_cass_error()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_consistency(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> CassConsistency {
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn cass_error_result_consistency(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_responses_received(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_int32_t {
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn cass_error_result_responses_received(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_responses_required(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_int32_t {
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn cass_error_result_responses_required(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_num_failures(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_int32_t {
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn cass_error_result_num_failures(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_data_present(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_bool_t {
@@ -181,7 +181,7 @@ pub unsafe extern "C" fn cass_error_result_data_present(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_write_type(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> CassWriteType {
@@ -197,7 +197,7 @@ pub unsafe extern "C" fn cass_error_result_write_type(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_keyspace(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
     c_keyspace: *mut *const ::std::os::raw::c_char,
@@ -221,7 +221,7 @@ pub unsafe extern "C" fn cass_error_result_keyspace(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_table(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
     c_table: *mut *const ::std::os::raw::c_char,
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn cass_error_result_table(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_function(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
     c_function: *mut *const ::std::os::raw::c_char,
@@ -257,7 +257,7 @@ pub unsafe extern "C" fn cass_error_result_function(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_num_arg_types(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> size_t {
@@ -270,7 +270,7 @@ pub unsafe extern "C" fn cass_error_num_arg_types(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_result_arg_type(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
     index: size_t,

--- a/scylla-rust-wrapper/src/external.rs
+++ b/scylla-rust-wrapper/src/external.rs
@@ -1,7 +1,7 @@
 use crate::cass_error::*;
 use std::os::raw::c_char;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_error_desc(error: CassError) -> *const c_char {
     let desc = match error {
         CassError::CASS_ERROR_LIB_BAD_PARAMS => c"Bad parameters",

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -1,3 +1,4 @@
+use crate::RUNTIME;
 use crate::argconv::*;
 use crate::cass_error::CassError;
 use crate::cass_error::CassErrorMessage;
@@ -7,7 +8,6 @@ use crate::prepared::CassPrepared;
 use crate::query_result::CassResult;
 use crate::types::*;
 use crate::uuid::CassUuid;
-use crate::RUNTIME;
 use futures::future;
 use std::future::Future;
 use std::mem;
@@ -297,7 +297,7 @@ impl CassFuture {
 trait CheckSendSync: Send + Sync {}
 impl CheckSendSync for CassFuture {}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_set_callback(
     future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
     callback: CassFutureCallback,
@@ -312,14 +312,14 @@ pub unsafe extern "C" fn cass_future_set_callback(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_wait(future_raw: CassBorrowedSharedPtr<CassFuture, CMut>) {
     ArcFFI::as_ref(future_raw)
         .unwrap()
         .with_waited_result(|_| ());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_wait_timed(
     future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
     timeout_us: cass_duration_t,
@@ -330,7 +330,7 @@ pub unsafe extern "C" fn cass_future_wait_timed(
         .is_ok() as cass_bool_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_ready(
     future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
 ) -> cass_bool_t {
@@ -341,7 +341,7 @@ pub unsafe extern "C" fn cass_future_ready(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_error_code(
     future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
 ) -> CassError {
@@ -354,7 +354,7 @@ pub unsafe extern "C" fn cass_future_error_code(
         })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_error_message(
     future: CassBorrowedSharedPtr<CassFuture, CMut>,
     message: *mut *const ::std::os::raw::c_char,
@@ -375,12 +375,12 @@ pub unsafe extern "C" fn cass_future_error_message(
         });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_free(future_raw: CassOwnedSharedPtr<CassFuture, CMut>) {
     ArcFFI::free(future_raw);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_get_result(
     future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
 ) -> CassOwnedSharedPtr<CassResult, CConst> {
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn cass_future_get_result(
         .map_or(ArcFFI::null(), ArcFFI::into_ptr)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_get_error_result(
     future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
 ) -> CassOwnedSharedPtr<CassErrorResult, CConst> {
@@ -410,7 +410,7 @@ pub unsafe extern "C" fn cass_future_get_error_result(
         .map_or(ArcFFI::null(), ArcFFI::into_ptr)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_get_prepared(
     future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
 ) -> CassOwnedSharedPtr<CassPrepared, CConst> {
@@ -425,7 +425,7 @@ pub unsafe extern "C" fn cass_future_get_prepared(
         .map_or(ArcFFI::null(), ArcFFI::into_ptr)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_future_tracing_id(
     future: CassBorrowedSharedPtr<CassFuture, CMut>,
     tracing_id: *mut CassUuid,

--- a/scylla-rust-wrapper/src/inet.rs
+++ b/scylla-rust-wrapper/src/inet.rs
@@ -51,17 +51,17 @@ unsafe fn cass_inet_init(address: *const cass_uint8_t, address_length: CassInetL
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_inet_init_v4(address: *const cass_uint8_t) -> CassInet {
     unsafe { cass_inet_init(address, CassInetLength::CASS_INET_V4) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_inet_init_v6(address: *const cass_uint8_t) -> CassInet {
     unsafe { cass_inet_init(address, CassInetLength::CASS_INET_V6) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_inet_string(inet: CassInet, output: *mut c_char) {
     let ip_addr: IpAddr = match inet.try_into() {
         Ok(v) => v,
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn cass_inet_string(inet: CassInet, output: *mut c_char) {
     unsafe { *null_byte = 0 };
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_inet_from_string(
     input: *const c_char,
     inet: *mut CassInet,
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn cass_inet_from_string(
     unsafe { cass_inet_from_string_n(input, strlen(input), inet) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_inet_from_string_n(
     input_raw: *const c_char,
     input_length: size_t,

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -1,10 +1,10 @@
-use std::ffi::{c_char, CString};
+use std::ffi::{CString, c_char};
 
 use crate::argconv::{BoxFFI, CMut, CassBorrowedExclusivePtr};
 use crate::cluster::CassCluster;
 use crate::types::{cass_int32_t, cass_uint16_t, size_t};
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn testing_cluster_get_connect_timeout(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
 ) -> cass_uint16_t {
@@ -13,7 +13,7 @@ pub unsafe extern "C" fn testing_cluster_get_connect_timeout(
     cluster.get_session_config().connect_timeout.as_millis() as cass_uint16_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn testing_cluster_get_port(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
 ) -> cass_int32_t {
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn testing_cluster_get_port(
     cluster.get_port() as cass_int32_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn testing_cluster_get_contact_points(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     contact_points: *mut *mut c_char,
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn testing_cluster_get_contact_points(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn testing_free_contact_points(contact_points: *mut c_char) {
     let _ = unsafe { CString::from_raw(contact_points) };
 }

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_safety_doc)]
 
-use crate::logging::stderr_log_callback;
 use crate::logging::Logger;
+use crate::logging::stderr_log_callback;
 use std::sync::LazyLock;
 use std::sync::RwLock;
 use tokio::runtime::Runtime;
@@ -129,21 +129,21 @@ pub static LOGGER: LazyLock<RwLock<Logger>> = LazyLock::new(|| {
 
 // To send a Rust object to C:
 
-// #[no_mangle]
+// #[unsafe(no_mangle)]
 // pub extern "C" fn create_foo() -> *mut Foo {
 //     BoxFFI::into_raw(Box::new(Foo))
 // }
 
 // To borrow (and not free) from C:
 
-// #[no_mangle]
+// #[unsafe(no_mangle)]
 // pub unsafe extern "C" fn do(foo: *mut Foo) -> *mut Foo {
 //     let foo = argconv::ptr_to_ref(foo);
 // }
 
 // To take over/destroy Rust object previously given to C:
 
-// #[no_mangle]
+// #[unsafe(no_mangle)]
 // pub unsafe extern "C" fn free_foo(foo: *mut Foo) {
 //     // Take the ownership of the value and it will be automatically dropped
 //     argconv::ptr_to_opt_box(foo);

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -1,20 +1,20 @@
+use crate::LOGGER;
 use crate::argconv::{
-    arr_to_cstr, ptr_to_cstr, str_to_arr, CConst, CassBorrowedSharedPtr, FromRef, RefFFI, FFI,
+    CConst, CassBorrowedSharedPtr, FFI, FromRef, RefFFI, arr_to_cstr, ptr_to_cstr, str_to_arr,
 };
 use crate::cass_log_types::{CassLogLevel, CassLogMessage};
 use crate::types::size_t;
-use crate::LOGGER;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::fmt::Write;
 use std::os::raw::{c_char, c_void};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::Level;
 use tracing::debug;
 use tracing::field::Field;
-use tracing::Level;
+use tracing_subscriber::Layer;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::prelude::*;
-use tracing_subscriber::Layer;
 
 impl FFI for CassLogMessage {
     type Origin = FromRef;
@@ -164,7 +164,7 @@ pub fn set_tracing_subscriber_with_level(level: Level) {
     .unwrap_or(()) // Ignore if it is set already
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_log_set_level(log_level: CassLogLevel) {
     if log_level == CassLogLevel::CASS_LOG_DISABLED {
         debug!("Logging is disabled!");
@@ -178,7 +178,7 @@ pub unsafe extern "C" fn cass_log_set_level(log_level: CassLogLevel) {
     debug!("Log level is set to {}", level);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_log_level_string(log_level: CassLogLevel) -> *const c_char {
     let log_level_str = match log_level {
         CassLogLevel::CASS_LOG_TRACE => c"TRACE",
@@ -194,7 +194,7 @@ pub unsafe extern "C" fn cass_log_level_string(log_level: CassLogLevel) -> *cons
     log_level_str.as_ptr()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_log_set_callback(callback: CassLogCallback, data: *mut c_void) {
     let logger = Logger {
         cb: Some(callback.unwrap_or(noop_log_callback)),
@@ -204,7 +204,7 @@ pub unsafe extern "C" fn cass_log_set_callback(callback: CassLogCallback, data: 
     *LOGGER.write().unwrap() = logger;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_log_get_callback_and_data(
     callback_out: *mut CassLogCallback,
     data_out: *mut *const c_void,
@@ -217,12 +217,12 @@ pub unsafe extern "C" fn cass_log_get_callback_and_data(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_log_cleanup() {
     // Deprecated
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_log_set_queue_size(_queue_size: size_t) {
     // Deprecated
 }

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -1,7 +1,7 @@
 use crate::argconv::*;
 use crate::cass_column_types::CassColumnType;
-use crate::cass_types::get_column_type;
 use crate::cass_types::CassDataType;
+use crate::cass_types::get_column_type;
 use crate::types::*;
 use scylla::cluster::metadata::{ColumnKind, Table};
 use std::collections::HashMap;
@@ -116,14 +116,14 @@ pub fn create_table_metadata(table_name: &str, table_metadata: &Table) -> CassTa
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_schema_meta_free(
     schema_meta: CassOwnedExclusivePtr<CassSchemaMeta, CConst>,
 ) {
     BoxFFI::free(schema_meta);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name(
     schema_meta: CassBorrowedSharedPtr<CassSchemaMeta, CConst>,
     keyspace_name: *const c_char,
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name_n(
     schema_meta: CassBorrowedSharedPtr<CassSchemaMeta, CConst>,
     keyspace_name: *const c_char,
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_keyspace_meta_name(
     keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     name: *mut *const c_char,
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_name(
     unsafe { write_str_to_c(keyspace_meta.name.as_str(), name, name_length) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name(
     keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     type_: *const c_char,
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name(
     unsafe { cass_keyspace_meta_user_type_by_name_n(keyspace_meta, type_, strlen(type_)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
     keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     type_: *const c_char,
@@ -194,7 +194,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_keyspace_meta_table_by_name(
     keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     table: *const c_char,
@@ -202,7 +202,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_table_by_name(
     unsafe { cass_keyspace_meta_table_by_name_n(keyspace_meta, table, strlen(table)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_keyspace_meta_table_by_name_n(
     keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     table: *const c_char,
@@ -223,7 +223,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_table_by_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_name(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     name: *mut *const c_char,
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn cass_table_meta_name(
     unsafe { write_str_to_c(table_meta.name.as_str(), name, name_length) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_column_count(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
 ) -> size_t {
@@ -241,7 +241,7 @@ pub unsafe extern "C" fn cass_table_meta_column_count(
     table_meta.columns_metadata.len() as size_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_column(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     index: size_t,
@@ -294,7 +294,7 @@ pub unsafe extern "C" fn cass_table_meta_column(
         })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_partition_key(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     index: size_t,
@@ -310,7 +310,7 @@ pub unsafe extern "C" fn cass_table_meta_partition_key(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_partition_key_count(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
 ) -> size_t {
@@ -318,7 +318,7 @@ pub unsafe extern "C" fn cass_table_meta_partition_key_count(
     table_meta.partition_keys.len() as size_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_clustering_key(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     index: size_t,
@@ -334,7 +334,7 @@ pub unsafe extern "C" fn cass_table_meta_clustering_key(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_clustering_key_count(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
 ) -> size_t {
@@ -342,7 +342,7 @@ pub unsafe extern "C" fn cass_table_meta_clustering_key_count(
     table_meta.clustering_keys.len() as size_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_column_by_name(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     column: *const c_char,
@@ -350,7 +350,7 @@ pub unsafe extern "C" fn cass_table_meta_column_by_name(
     unsafe { cass_table_meta_column_by_name_n(table_meta, column, strlen(column)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_column_by_name_n(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     column: *const c_char,
@@ -369,7 +369,7 @@ pub unsafe extern "C" fn cass_table_meta_column_by_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_column_meta_name(
     column_meta: CassBorrowedSharedPtr<CassColumnMeta, CConst>,
     name: *mut *const c_char,
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn cass_column_meta_name(
     unsafe { write_str_to_c(column_meta.name.as_str(), name, name_length) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_column_meta_data_type(
     column_meta: CassBorrowedSharedPtr<CassColumnMeta, CConst>,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
@@ -387,7 +387,7 @@ pub unsafe extern "C" fn cass_column_meta_data_type(
     ArcFFI::as_ptr(&column_meta.column_type)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_column_meta_type(
     column_meta: CassBorrowedSharedPtr<CassColumnMeta, CConst>,
 ) -> CassColumnType {
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn cass_column_meta_type(
     column_meta.column_kind
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name(
     keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     view: *const c_char,
@@ -403,7 +403,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name(
     unsafe { cass_keyspace_meta_materialized_view_by_name_n(keyspace_meta, view, strlen(view)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name_n(
     keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
     view: *const c_char,
@@ -422,7 +422,7 @@ pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     view: *const c_char,
@@ -430,7 +430,7 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name(
     unsafe { cass_table_meta_materialized_view_by_name_n(table_meta, view, strlen(view)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name_n(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     view: *const c_char,
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_materialized_view_count(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
 ) -> size_t {
@@ -457,7 +457,7 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view_count(
     table_meta.views.len() as size_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_table_meta_materialized_view(
     table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
     index: size_t,
@@ -470,7 +470,7 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name(
     view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     column: *const c_char,
@@ -478,7 +478,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name(
     unsafe { cass_materialized_view_meta_column_by_name_n(view_meta, column, strlen(column)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name_n(
     view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     column: *const c_char,
@@ -497,7 +497,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_materialized_view_meta_name(
     view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     name: *mut *const c_char,
@@ -507,7 +507,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_name(
     unsafe { write_str_to_c(view_meta.name.as_str(), name, name_length) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_materialized_view_meta_base_table(
     view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
 ) -> CassBorrowedSharedPtr<CassTableMeta, CConst> {
@@ -515,12 +515,14 @@ pub unsafe extern "C" fn cass_materialized_view_meta_base_table(
 
     let ptr = unsafe { RefFFI::weak_as_ptr(&view_meta.base_table) };
     if RefFFI::is_null(&ptr) {
-        tracing::error!("Failed to upgrade a weak reference to table metadata from materialized view metadata! This is a driver bug!");
+        tracing::error!(
+            "Failed to upgrade a weak reference to table metadata from materialized view metadata! This is a driver bug!"
+        );
     }
     ptr
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_materialized_view_meta_column_count(
     view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
 ) -> size_t {
@@ -528,7 +530,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column_count(
     view_meta.view_metadata.columns_metadata.len() as size_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_materialized_view_meta_column(
     view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
     index: size_t,
@@ -546,7 +548,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_materialized_view_meta_partition_key_count(
     view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
 ) -> size_t {
@@ -569,7 +571,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_partition_key(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_materialized_view_meta_clustering_key_count(
     view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
 ) -> size_t {

--- a/scylla-rust-wrapper/src/misc.rs
+++ b/scylla-rust-wrapper/src/misc.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, CStr};
+use std::ffi::{CStr, c_char};
 
 use crate::{cass_error_types::CassWriteType, cass_types::CassConsistency};
 
@@ -22,7 +22,7 @@ impl CassConsistency {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_consistency_string(consistency: CassConsistency) -> *const c_char {
     consistency.as_cstr().as_ptr() as *const c_char
 }
@@ -43,7 +43,7 @@ impl CassWriteType {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_write_type_string(write_type: CassWriteType) -> *const c_char {
     write_type.as_cstr().as_ptr() as *const c_char
 }

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -5,7 +5,7 @@ use std::{os::raw::c_char, sync::Arc};
 use crate::{
     argconv::*,
     cass_error::CassError,
-    cass_types::{get_column_type, CassDataType},
+    cass_types::{CassDataType, get_column_type},
     query_result::CassResultMetadata,
     statement::{BoundPreparedStatement, BoundStatement, CassStatement},
     types::size_t,
@@ -77,14 +77,14 @@ impl FFI for CassPrepared {
     type Origin = FromArc;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_prepared_free(
     prepared_raw: CassOwnedSharedPtr<CassPrepared, CConst>,
 ) {
     ArcFFI::free(prepared_raw);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_prepared_bind(
     prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
 ) -> CassOwnedExclusivePtr<CassStatement, CMut> {
@@ -109,7 +109,7 @@ pub unsafe extern "C" fn cass_prepared_bind(
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_prepared_parameter_name(
     prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
     index: size_t,
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn cass_prepared_parameter_name(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_prepared_parameter_data_type(
     prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
     index: size_t,
@@ -144,7 +144,7 @@ pub unsafe extern "C" fn cass_prepared_parameter_data_type(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name(
     prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
     name: *const c_char,
@@ -152,7 +152,7 @@ pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name(
     unsafe { cass_prepared_parameter_data_type_by_name_n(prepared_raw, name, strlen(name)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name_n(
     prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
     name: *const c_char,

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -1,8 +1,8 @@
 use crate::argconv::*;
 use crate::cass_error::{CassError, ToCassError};
 use crate::cass_types::{
-    cass_data_type_type, get_column_type, CassColumnSpec, CassDataType, CassDataTypeInner,
-    CassValueType, MapDataType,
+    CassColumnSpec, CassDataType, CassDataTypeInner, CassValueType, MapDataType,
+    cass_data_type_type, get_column_type,
 };
 use crate::execution_error::CassErrorResult;
 use crate::inet::CassInet;
@@ -17,8 +17,8 @@ use scylla::deserialize::row::{
 use scylla::deserialize::value::DeserializeValue;
 use scylla::errors::{DeserializationError, IntoRowsResultError, TypeCheckError};
 use scylla::frame::response::result::{ColumnSpec, DeserializedMetadataAndRawRows};
-use scylla::response::query_result::{ColumnSpecs, QueryResult};
 use scylla::response::PagingStateResponse;
+use scylla::response::query_result::{ColumnSpecs, QueryResult};
 use scylla::value::{
     Counter, CqlDate, CqlDecimalBorrowed, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid,
 };
@@ -290,8 +290,8 @@ mod row_with_self_borrowed_result_data {
 /// This is because `CassRawValue` maps the "empty" values to null in this implementation.
 pub(crate) mod cass_raw_value {
     use scylla::cluster::metadata::{ColumnType, NativeType};
-    use scylla::deserialize::value::DeserializeValue;
     use scylla::deserialize::FrameSlice;
+    use scylla::deserialize::value::DeserializeValue;
     use scylla::errors::{DeserializationError, TypeCheckError};
     use thiserror::Error;
 
@@ -473,12 +473,12 @@ impl ToCassError for NonNullDeserializationError {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_result_free(result_raw: CassOwnedSharedPtr<CassResult, CConst>) {
     ArcFFI::free(result_raw);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_result_has_more_pages(
     result: CassBorrowedSharedPtr<CassResult, CConst>,
 ) -> cass_bool_t {
@@ -490,7 +490,7 @@ unsafe fn result_has_more_pages(result: &CassBorrowedSharedPtr<CassResult, CCons
     (!result.paging_state_response.finished()) as cass_bool_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_row_get_column<'result>(
     row_raw: CassBorrowedSharedPtr<'result, CassRow<'result>, CConst>,
     index: size_t,
@@ -506,7 +506,7 @@ pub unsafe extern "C" fn cass_row_get_column<'result>(
     RefFFI::as_ptr(column_value)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_row_get_column_by_name<'result>(
     row: CassBorrowedSharedPtr<'result, CassRow<'result>, CConst>,
     name: *const c_char,
@@ -517,7 +517,7 @@ pub unsafe extern "C" fn cass_row_get_column_by_name<'result>(
     unsafe { cass_row_get_column_by_name_n(row, name, name_length as size_t) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_row_get_column_by_name_n<'result>(
     row: CassBorrowedSharedPtr<'result, CassRow<'result>, CConst>,
     name: *const c_char,
@@ -549,7 +549,7 @@ pub unsafe extern "C" fn cass_row_get_column_by_name_n<'result>(
         .unwrap_or(RefFFI::null())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_result_column_name(
     result: CassBorrowedSharedPtr<CassResult, CConst>,
     index: size_t,
@@ -579,7 +579,7 @@ pub unsafe extern "C" fn cass_result_column_name(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_result_column_type(
     result: CassBorrowedSharedPtr<CassResult, CConst>,
     index: size_t,
@@ -591,7 +591,7 @@ pub unsafe extern "C" fn cass_result_column_type(
     unsafe { cass_data_type_type(data_type_ptr) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_result_column_data_type(
     result: CassBorrowedSharedPtr<CassResult, CConst>,
     index: size_t,
@@ -613,7 +613,7 @@ pub unsafe extern "C" fn cass_result_column_data_type(
         .unwrap_or(ArcFFI::null())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_type(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
 ) -> CassValueType {
@@ -621,7 +621,7 @@ pub unsafe extern "C" fn cass_value_type(
     unsafe { cass_data_type_type(ArcFFI::as_ptr(value_from_raw.value_type)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_data_type<'result>(
     value: CassBorrowedSharedPtr<'result, CassValue<'result>, CConst>,
 ) -> CassBorrowedSharedPtr<'result, CassDataType, CConst> {
@@ -640,7 +640,7 @@ macro_rules! val_ptr_to_ref_ensure_non_null {
     }};
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_float(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut cass_float_t,
@@ -656,7 +656,7 @@ pub unsafe extern "C" fn cass_value_get_float(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_double(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut cass_double_t,
@@ -672,7 +672,7 @@ pub unsafe extern "C" fn cass_value_get_double(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_bool(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut cass_bool_t,
@@ -688,7 +688,7 @@ pub unsafe extern "C" fn cass_value_get_bool(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_int8(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut cass_int8_t,
@@ -704,7 +704,7 @@ pub unsafe extern "C" fn cass_value_get_int8(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_int16(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut cass_int16_t,
@@ -720,7 +720,7 @@ pub unsafe extern "C" fn cass_value_get_int16(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_uint32(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut cass_uint32_t,
@@ -736,7 +736,7 @@ pub unsafe extern "C" fn cass_value_get_uint32(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_int32(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut cass_int32_t,
@@ -752,7 +752,7 @@ pub unsafe extern "C" fn cass_value_get_int32(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_int64(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut cass_int64_t,
@@ -796,7 +796,7 @@ pub unsafe extern "C" fn cass_value_get_int64(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_uuid(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut CassUuid,
@@ -826,7 +826,7 @@ pub unsafe extern "C" fn cass_value_get_uuid(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_inet(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut CassInet,
@@ -842,7 +842,7 @@ pub unsafe extern "C" fn cass_value_get_inet(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_decimal(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     varint: *mut *const cass_byte_t,
@@ -866,7 +866,7 @@ pub unsafe extern "C" fn cass_value_get_decimal(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_string(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut *const c_char,
@@ -896,7 +896,7 @@ pub unsafe extern "C" fn cass_value_get_string(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_duration(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     months: *mut cass_int32_t,
@@ -919,7 +919,7 @@ pub unsafe extern "C" fn cass_value_get_duration(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_get_bytes(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
     output: *mut *const cass_byte_t,
@@ -940,7 +940,7 @@ pub unsafe extern "C" fn cass_value_get_bytes(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_is_null(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
 ) -> cass_bool_t {
@@ -948,7 +948,7 @@ pub unsafe extern "C" fn cass_value_is_null(
     val.value.slice().is_none() as cass_bool_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_is_collection(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
 ) -> cass_bool_t {
@@ -962,7 +962,7 @@ pub unsafe extern "C" fn cass_value_is_collection(
     ) as cass_bool_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_is_duration(
     value: CassBorrowedSharedPtr<CassValue, CConst>,
 ) -> cass_bool_t {
@@ -972,7 +972,7 @@ pub unsafe extern "C" fn cass_value_is_duration(
         == CassValueType::CASS_VALUE_TYPE_DURATION) as cass_bool_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_item_count(
     collection: CassBorrowedSharedPtr<CassValue, CConst>,
 ) -> size_t {
@@ -981,7 +981,7 @@ pub unsafe extern "C" fn cass_value_item_count(
     val.value.item_count().unwrap_or(0) as size_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_primary_sub_type(
     collection: CassBorrowedSharedPtr<CassValue, CConst>,
 ) -> CassValueType {
@@ -1002,7 +1002,7 @@ pub unsafe extern "C" fn cass_value_primary_sub_type(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_value_secondary_sub_type(
     collection: CassBorrowedSharedPtr<CassValue, CConst>,
 ) -> CassValueType {
@@ -1017,7 +1017,7 @@ pub unsafe extern "C" fn cass_value_secondary_sub_type(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_result_row_count(
     result_raw: CassBorrowedSharedPtr<CassResult, CConst>,
 ) -> size_t {
@@ -1030,7 +1030,7 @@ pub unsafe extern "C" fn cass_result_row_count(
     shared_data.raw_rows.rows_count() as size_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_result_column_count(
     result_raw: CassBorrowedSharedPtr<CassResult, CConst>,
 ) -> size_t {
@@ -1043,7 +1043,7 @@ pub unsafe extern "C" fn cass_result_column_count(
     shared_data.metadata.col_specs.len() as size_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_result_first_row(
     result_raw: CassBorrowedSharedPtr<CassResult, CConst>,
 ) -> CassBorrowedSharedPtr<CassRow, CConst> {
@@ -1060,7 +1060,7 @@ pub unsafe extern "C" fn cass_result_first_row(
         .unwrap_or(RefFFI::null())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_result_paging_state_token(
     result: CassBorrowedSharedPtr<CassResult, CConst>,
     paging_state: *mut *const c_char,
@@ -1096,10 +1096,10 @@ pub unsafe extern "C" fn cass_result_paging_state_token(
 mod tests {
     use scylla::cluster::metadata::{CollectionType, ColumnType, NativeType};
     use scylla::frame::response::result::{ColumnSpec, DeserializedMetadataAndRawRows, TableSpec};
-    use scylla::response::query_result::ColumnSpecs;
     use scylla::response::PagingStateResponse;
+    use scylla::response::query_result::ColumnSpecs;
 
-    use crate::argconv::{ptr_to_cstr_n, CConst, CassBorrowedSharedPtr};
+    use crate::argconv::{CConst, CassBorrowedSharedPtr, ptr_to_cstr_n};
     use crate::cass_types::{CassDataType, CassDataTypeInner};
     use crate::{
         argconv::{ArcFFI, RefFFI},
@@ -1113,8 +1113,8 @@ mod tests {
 
     use super::row_with_self_borrowed_result_data::RowWithSelfBorrowedResultData;
     use super::{
-        cass_result_column_count, cass_result_column_type, CassResult, CassResultKind,
-        CassResultMetadata, CassRowsResult, CassRowsResultSharedData,
+        CassResult, CassResultKind, CassResultMetadata, CassRowsResult, CassRowsResultSharedData,
+        cass_result_column_count, cass_result_column_type,
     };
 
     fn col_spec(name: &'static str, typ: ColumnType<'static>) -> ColumnSpec<'static> {

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -3,7 +3,7 @@ use scylla::policies::retry::{
 };
 use std::sync::Arc;
 
-use crate::argconv::{ArcFFI, CMut, CassOwnedSharedPtr, FromArc, FFI};
+use crate::argconv::{ArcFFI, CMut, CassOwnedSharedPtr, FFI, FromArc};
 
 pub enum RetryPolicy {
     DefaultRetryPolicy(Arc<DefaultRetryPolicy>),
@@ -17,29 +17,29 @@ impl FFI for CassRetryPolicy {
     type Origin = FromArc;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cass_retry_policy_default_new() -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
     ArcFFI::into_ptr(Arc::new(RetryPolicy::DefaultRetryPolicy(Arc::new(
         DefaultRetryPolicy,
     ))))
 }
 
-#[no_mangle]
-pub extern "C" fn cass_retry_policy_downgrading_consistency_new(
-) -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
+#[unsafe(no_mangle)]
+pub extern "C" fn cass_retry_policy_downgrading_consistency_new()
+-> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
     ArcFFI::into_ptr(Arc::new(RetryPolicy::DowngradingConsistencyRetryPolicy(
         Arc::new(DowngradingConsistencyRetryPolicy),
     )))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cass_retry_policy_fallthrough_new() -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
     ArcFFI::into_ptr(Arc::new(RetryPolicy::FallthroughRetryPolicy(Arc::new(
         FallthroughRetryPolicy,
     ))))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_retry_policy_free(
     retry_policy: CassOwnedSharedPtr<CassRetryPolicy, CMut>,
 ) {

--- a/scylla-rust-wrapper/src/ser_de_tests.rs
+++ b/scylla-rust-wrapper/src/ser_de_tests.rs
@@ -15,8 +15,8 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use scylla::cluster::metadata::{CollectionType, ColumnType, NativeType, UserDefinedType};
-use scylla::deserialize::value::DeserializeValue;
 use scylla::deserialize::FrameSlice;
+use scylla::deserialize::value::DeserializeValue;
 use scylla::serialize::value::SerializeValue;
 use scylla::serialize::writers::CellWriter;
 use scylla::value::{CqlDecimal, CqlDuration, CqlValue};
@@ -29,18 +29,18 @@ use crate::cass_error::CassError;
 use crate::cass_types::get_column_type;
 use crate::inet::CassInet;
 use crate::iterator::{
-    cass_iterator_fields_from_user_type, cass_iterator_free, cass_iterator_from_collection,
-    cass_iterator_from_map, cass_iterator_from_tuple, cass_iterator_get_map_key,
-    cass_iterator_get_map_value, cass_iterator_get_user_type_field_name,
+    CassIterator, CassIteratorType, cass_iterator_fields_from_user_type, cass_iterator_free,
+    cass_iterator_from_collection, cass_iterator_from_map, cass_iterator_from_tuple,
+    cass_iterator_get_map_key, cass_iterator_get_map_value, cass_iterator_get_user_type_field_name,
     cass_iterator_get_user_type_field_value, cass_iterator_get_value, cass_iterator_next,
-    cass_iterator_type, CassIterator, CassIteratorType,
+    cass_iterator_type,
 };
 use crate::query_result::cass_raw_value::CassRawValue;
 use crate::query_result::{
-    cass_value_get_bool, cass_value_get_bytes, cass_value_get_decimal, cass_value_get_double,
-    cass_value_get_duration, cass_value_get_float, cass_value_get_inet, cass_value_get_int16,
-    cass_value_get_int32, cass_value_get_int64, cass_value_get_int8, cass_value_get_string,
-    cass_value_get_uuid, cass_value_is_null, cass_value_item_count, CassValue,
+    CassValue, cass_value_get_bool, cass_value_get_bytes, cass_value_get_decimal,
+    cass_value_get_double, cass_value_get_duration, cass_value_get_float, cass_value_get_inet,
+    cass_value_get_int8, cass_value_get_int16, cass_value_get_int32, cass_value_get_int64,
+    cass_value_get_string, cass_value_get_uuid, cass_value_is_null, cass_value_item_count,
 };
 use crate::testing::{assert_cass_error_eq, setup_tracing};
 use crate::types::size_t;
@@ -546,11 +546,19 @@ fn test_deserialize_map_iterator() {
             ),
         };
         let to_serialize = HashMap::<String, i32>::from([
-        (String::from("forty two"), 42),
-        (String::from("four thousand two hundred forty-two"), 4242),
-        (String::from("four hundred twenty-four thousand four hundred twenty-four"), 424242),
-        (String::from("four hundred twenty-four million two hundred forty-two thousand four hundred twenty-two"), 42424242),
-    ]);
+            (String::from("forty two"), 42),
+            (String::from("four thousand two hundred forty-two"), 4242),
+            (
+                String::from("four hundred twenty-four thousand four hundred twenty-four"),
+                424242,
+            ),
+            (
+                String::from(
+                    "four hundred twenty-four million two hundred forty-two thousand four hundred twenty-two",
+                ),
+                42424242,
+            ),
+        ]);
         let bytes = Bytes::from(do_serialize(&to_serialize, &typ));
         let data_type = Arc::new(get_column_type(&typ));
         let cass_value = CassValue {

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -2,8 +2,8 @@ use crate::argconv::*;
 use crate::batch::CassBatch;
 use crate::cass_error::*;
 use crate::cass_types::get_column_type;
-use crate::cluster::build_session_builder;
 use crate::cluster::CassCluster;
+use crate::cluster::build_session_builder;
 use crate::exec_profile::{CassExecProfile, ExecProfileName, PerStatementExecProfile};
 use crate::future::{CassFuture, CassFutureResult, CassResultValue};
 use crate::metadata::create_table_metadata;
@@ -19,8 +19,8 @@ use scylla::client::session_builder::SessionBuilder;
 use scylla::cluster::metadata::ColumnType;
 use scylla::errors::ExecutionError;
 use scylla::frame::types::Consistency;
-use scylla::response::query_result::QueryResult;
 use scylla::response::PagingStateResponse;
+use scylla::response::query_result::QueryResult;
 use scylla::statement::unprepared::Statement;
 use std::collections::HashMap;
 use std::future::Future;
@@ -141,13 +141,13 @@ impl FFI for CassSession {
     type Origin = FromArc;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_new() -> CassOwnedSharedPtr<CassSession, CMut> {
     let session = Arc::new(RwLock::new(None::<CassSessionInner>));
     ArcFFI::into_ptr(session)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_connect(
     session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
     cluster_raw: CassBorrowedSharedPtr<CassCluster, CConst>,
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn cass_session_connect(
     CassSessionInner::connect(session_opt, cluster, None)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_connect_keyspace(
     session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
     cluster_raw: CassBorrowedSharedPtr<CassCluster, CConst>,
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn cass_session_connect_keyspace(
     unsafe { cass_session_connect_keyspace_n(session_raw, cluster_raw, keyspace, strlen(keyspace)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_connect_keyspace_n(
     session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
     cluster_raw: CassBorrowedSharedPtr<CassCluster, CConst>,
@@ -181,7 +181,7 @@ pub unsafe extern "C" fn cass_session_connect_keyspace_n(
     CassSessionInner::connect(session_opt, cluster, keyspace)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_execute_batch(
     session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
     batch_raw: CassBorrowedSharedPtr<CassBatch, CConst>,
@@ -247,7 +247,7 @@ async fn request_with_timeout(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_execute(
     session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
     statement_raw: CassBorrowedSharedPtr<CassStatement, CConst>,
@@ -382,7 +382,7 @@ pub unsafe extern "C" fn cass_session_execute(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_prepare_from_existing(
     cass_session: CassBorrowedSharedPtr<CassSession, CMut>,
     statement: CassBorrowedSharedPtr<CassStatement, CMut>,
@@ -418,7 +418,7 @@ pub unsafe extern "C" fn cass_session_prepare_from_existing(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_prepare(
     session: CassBorrowedSharedPtr<CassSession, CMut>,
     query: *const c_char,
@@ -426,7 +426,7 @@ pub unsafe extern "C" fn cass_session_prepare(
     unsafe { cass_session_prepare_n(session, query, strlen(query)) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_prepare_n(
     cass_session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
     query: *const c_char,
@@ -465,12 +465,12 @@ pub unsafe extern "C" fn cass_session_prepare_n(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_free(session_raw: CassOwnedSharedPtr<CassSession, CMut>) {
     ArcFFI::free(session_raw);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_close(
     session: CassBorrowedSharedPtr<CassSession, CMut>,
 ) -> CassOwnedSharedPtr<CassFuture, CMut> {
@@ -491,7 +491,7 @@ pub unsafe extern "C" fn cass_session_close(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_get_client_id(
     session: CassBorrowedSharedPtr<CassSession, CMut>,
 ) -> CassUuid {
@@ -501,7 +501,7 @@ pub unsafe extern "C" fn cass_session_get_client_id(
     client_id.into()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_get_schema_meta(
     session: CassBorrowedSharedPtr<CassSession, CConst>,
 ) -> CassOwnedExclusivePtr<CassSchemaMeta, CConst> {
@@ -594,17 +594,17 @@ mod tests {
             cass_cluster_set_retry_policy,
         },
         exec_profile::{
-            cass_batch_set_execution_profile, cass_batch_set_execution_profile_n,
+            ExecProfileName, cass_batch_set_execution_profile, cass_batch_set_execution_profile_n,
             cass_execution_profile_free, cass_execution_profile_new,
             cass_execution_profile_set_latency_aware_routing,
             cass_execution_profile_set_retry_policy, cass_statement_set_execution_profile,
-            cass_statement_set_execution_profile_n, ExecProfileName,
+            cass_statement_set_execution_profile_n,
         },
         future::{
             cass_future_error_code, cass_future_error_message, cass_future_free, cass_future_wait,
         },
         retry_policy::{
-            cass_retry_policy_default_new, cass_retry_policy_fallthrough_new, CassRetryPolicy,
+            CassRetryPolicy, cass_retry_policy_default_new, cass_retry_policy_fallthrough_new,
         },
         statement::{cass_statement_free, cass_statement_new, cass_statement_set_retry_policy},
         testing::assert_cass_error_eq,
@@ -731,13 +731,15 @@ mod tests {
                 ));
                 // Initially, the profile map is empty.
 
-                assert!(ArcFFI::as_ref(session_raw.borrow())
-                    .unwrap()
-                    .blocking_read()
-                    .as_ref()
-                    .unwrap()
-                    .exec_profile_map
-                    .is_empty());
+                assert!(
+                    ArcFFI::as_ref(session_raw.borrow())
+                        .unwrap()
+                        .blocking_read()
+                        .as_ref()
+                        .unwrap()
+                        .exec_profile_map
+                        .is_empty()
+                );
 
                 cass_cluster_set_execution_profile(
                     cluster_raw.borrow_mut(),
@@ -745,13 +747,15 @@ mod tests {
                     profile_raw.borrow_mut(),
                 );
                 // Mutations in cluster do not affect the session that was connected before.
-                assert!(ArcFFI::as_ref(session_raw.borrow())
-                    .unwrap()
-                    .blocking_read()
-                    .as_ref()
-                    .unwrap()
-                    .exec_profile_map
-                    .is_empty());
+                assert!(
+                    ArcFFI::as_ref(session_raw.borrow())
+                        .unwrap()
+                        .blocking_read()
+                        .as_ref()
+                        .unwrap()
+                        .exec_profile_map
+                        .is_empty()
+                );
 
                 cass_future_wait_check_and_free(cass_session_close(session_raw.borrow()));
 
@@ -831,7 +835,9 @@ mod tests {
             let (nonexisting_name_c_str, nonexisting_name_len) = str_to_c_str_n(nonexisting_name);
 
             // Inserting into virtual system tables is prohibited and results in WriteFailure error.
-            let invalid_query = make_c_str!("INSERT INTO system.runtime_info (group, item, value) VALUES ('bindings_test', 'bindings_test', 'bindings_test')");
+            let invalid_query = make_c_str!(
+                "INSERT INTO system.runtime_info (group, item, value) VALUES ('bindings_test', 'bindings_test', 'bindings_test')"
+            );
             let mut statement_raw = cass_statement_new(invalid_query, 0);
             let mut batch_raw = cass_batch_new(CassBatchType::CASS_BATCH_TYPE_LOGGED);
             assert_cass_error_eq!(
@@ -911,15 +917,17 @@ mod tests {
                         ),
                         CassError::CASS_ERROR_SERVER_WRITE_FAILURE
                     );
-                    assert!(statement
-                        .exec_profile
-                        .as_ref()
-                        .unwrap()
-                        .inner()
-                        .read()
-                        .unwrap()
-                        .as_handle()
-                        .is_some());
+                    assert!(
+                        statement
+                            .exec_profile
+                            .as_ref()
+                            .unwrap()
+                            .inner()
+                            .read()
+                            .unwrap()
+                            .as_handle()
+                            .is_some()
+                    );
                     assert_cass_error_eq!(
                         cass_future_error_code(
                             cass_session_execute_batch(
@@ -930,15 +938,17 @@ mod tests {
                         ),
                         CassError::CASS_ERROR_SERVER_WRITE_FAILURE
                     );
-                    assert!(batch
-                        .exec_profile
-                        .as_ref()
-                        .unwrap()
-                        .inner()
-                        .read()
-                        .unwrap()
-                        .as_handle()
-                        .is_some());
+                    assert!(
+                        batch
+                            .exec_profile
+                            .as_ref()
+                            .unwrap()
+                            .inner()
+                            .read()
+                            .unwrap()
+                            .as_handle()
+                            .is_some()
+                    );
 
                     // NULL name sets exec profile to None
                     assert_cass_error_eq!(
@@ -1076,8 +1086,8 @@ mod tests {
         .await;
     }
 
-    fn retry_policy_on_statement_and_batch_is_handled_properly_rules(
-    ) -> impl IntoIterator<Item = RequestRule> {
+    fn retry_policy_on_statement_and_batch_is_handled_properly_rules()
+    -> impl IntoIterator<Item = RequestRule> {
         handshake_rules()
             .into_iter()
             .chain(iter::once(RequestRule(

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -9,12 +9,12 @@ use crate::value::CassCqlValue;
 use crate::{argconv::*, value};
 use scylla::frame::types::Consistency;
 use scylla::response::{PagingState, PagingStateResponse};
+use scylla::serialize::SerializationError;
 use scylla::serialize::row::{RowSerializationContext, SerializeRow};
 use scylla::serialize::value::SerializeValue;
 use scylla::serialize::writers::RowWriter;
-use scylla::serialize::SerializationError;
-use scylla::statement::unprepared::Statement;
 use scylla::statement::SerialConsistency;
+use scylla::statement::unprepared::Statement;
 use scylla::value::MaybeUnset;
 use scylla::value::MaybeUnset::{Set, Unset};
 use std::collections::HashMap;
@@ -260,7 +260,7 @@ impl CassStatement {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_new(
     query: *const c_char,
     parameter_count: size_t,
@@ -268,7 +268,7 @@ pub unsafe extern "C" fn cass_statement_new(
     unsafe { cass_statement_new_n(query, strlen(query), parameter_count) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_new_n(
     query: *const c_char,
     query_length: size_t,
@@ -297,14 +297,14 @@ pub unsafe extern "C" fn cass_statement_new_n(
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_free(
     statement_raw: CassOwnedExclusivePtr<CassStatement, CMut>,
 ) {
     BoxFFI::free(statement_raw);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_consistency(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
     consistency: CassConsistency,
@@ -323,7 +323,7 @@ pub unsafe extern "C" fn cass_statement_set_consistency(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_paging_size(
     statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
     page_size: c_int,
@@ -345,7 +345,7 @@ pub unsafe extern "C" fn cass_statement_set_paging_size(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_paging_state(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
     result: CassBorrowedSharedPtr<CassResult, CConst>,
@@ -360,7 +360,7 @@ pub unsafe extern "C" fn cass_statement_set_paging_state(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_paging_state_token(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
     paging_state: *const c_char,
@@ -380,7 +380,7 @@ pub unsafe extern "C" fn cass_statement_set_paging_state_token(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_is_idempotent(
     statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
     is_idempotent: cass_bool_t,
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn cass_statement_set_is_idempotent(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_tracing(
     statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
     enabled: cass_bool_t,
@@ -410,7 +410,7 @@ pub unsafe extern "C" fn cass_statement_set_tracing(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_retry_policy(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
     retry_policy: CassBorrowedSharedPtr<CassRetryPolicy, CMut>,
@@ -434,7 +434,7 @@ pub unsafe extern "C" fn cass_statement_set_retry_policy(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_serial_consistency(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
     serial_consistency: CassConsistency,
@@ -480,7 +480,7 @@ fn get_consistency_from_cass_consistency(consistency: CassConsistency) -> Option
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_timestamp(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
     timestamp: cass_int64_t,
@@ -495,7 +495,7 @@ pub unsafe extern "C" fn cass_statement_set_timestamp(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_request_timeout(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
     timeout_ms: cass_uint64_t,
@@ -514,7 +514,7 @@ pub unsafe extern "C" fn cass_statement_set_request_timeout(
     CassError::CASS_OK
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_reset_parameters(
     statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
     count: size_t,

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -64,7 +64,7 @@ impl From<&CassTuple> for CassCqlValue {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_tuple_new(
     item_count: size_t,
 ) -> CassOwnedExclusivePtr<CassTuple, CMut> {
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn cass_tuple_new(
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn cass_tuple_new_from_data_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassOwnedExclusivePtr<CassTuple, CMut> {
@@ -89,12 +89,12 @@ unsafe extern "C" fn cass_tuple_new_from_data_type(
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn cass_tuple_free(tuple: CassOwnedExclusivePtr<CassTuple, CMut>) {
     BoxFFI::free(tuple);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn cass_tuple_data_type(
     tuple: CassBorrowedSharedPtr<CassTuple, CConst>,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
@@ -128,7 +128,7 @@ make_binders!(user_type, cass_tuple_set_user_type);
 #[cfg(test)]
 mod tests {
     use crate::cass_types::{
-        cass_data_type_add_sub_type, cass_data_type_free, cass_data_type_new, CassValueType,
+        CassValueType, cass_data_type_add_sub_type, cass_data_type_free, cass_data_type_new,
     };
 
     use super::{cass_tuple_data_type, cass_tuple_new};

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -83,7 +83,7 @@ impl From<&CassUserType> for CassCqlValue {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_user_type_new_from_data_type(
     data_type_raw: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassOwnedExclusivePtr<CassUserType, CMut> {
@@ -101,11 +101,11 @@ pub unsafe extern "C" fn cass_user_type_new_from_data_type(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_user_type_free(user_type: CassOwnedExclusivePtr<CassUserType, CMut>) {
     BoxFFI::free(user_type);
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_user_type_data_type(
     user_type: CassBorrowedSharedPtr<CassUserType, CConst>,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {

--- a/scylla-rust-wrapper/src/uuid.rs
+++ b/scylla-rust-wrapper/src/uuid.rs
@@ -68,18 +68,18 @@ fn monotonic_timestamp(last_timestamp: &mut AtomicU64) -> u64 {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cass_uuid_version(uuid: CassUuid) -> cass_uint8_t {
     ((uuid.time_and_version >> 60) & 0x0F) as cass_uint8_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cass_uuid_timestamp(uuid: CassUuid) -> cass_uint64_t {
     let timestamp: u64 = uuid.time_and_version & 0x0FFFFFFFFFFFFFFF;
     to_milliseconds(timestamp.wrapping_sub(TIME_OFFSET_BETWEEN_UTC_AND_EPOCH))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_min_from_time(timestamp: cass_uint64_t, output: *mut CassUuid) {
     let uuid = CassUuid {
         time_and_version: set_version(from_unix_timestamp(timestamp), 1),
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn cass_uuid_min_from_time(timestamp: cass_uint64_t, outpu
     unsafe { std::ptr::write(output, uuid) };
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_max_from_time(timestamp: cass_uint64_t, output: *mut CassUuid) {
     let uuid = CassUuid {
         time_and_version: set_version(from_unix_timestamp(timestamp), 1),
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn cass_uuid_max_from_time(timestamp: cass_uint64_t, outpu
     unsafe { std::ptr::write(output, uuid) };
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_gen_new() -> CassOwnedExclusivePtr<CassUuidGen, CMut> {
     // Inspired by C++ driver implementation in its intent.
     // The original driver tries to generate a number that
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn cass_uuid_gen_new() -> CassOwnedExclusivePtr<CassUuidGe
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_gen_new_with_node(
     node: cass_uint64_t,
 ) -> CassOwnedExclusivePtr<CassUuidGen, CMut> {
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn cass_uuid_gen_new_with_node(
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_gen_time(
     uuid_gen: CassBorrowedExclusivePtr<CassUuidGen, CMut>,
     output: *mut CassUuid,
@@ -148,7 +148,7 @@ pub unsafe extern "C" fn cass_uuid_gen_time(
     unsafe { std::ptr::write(output, uuid) };
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_gen_random(_uuid_gen: *mut CassUuidGen, output: *mut CassUuid) {
     let time_and_version: u64 = rand::random();
     let clock_seq_and_node: u64 = rand::random();
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn cass_uuid_gen_random(_uuid_gen: *mut CassUuidGen, outpu
     unsafe { std::ptr::write(output, uuid) };
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_gen_from_time(
     uuid_gen: CassBorrowedExclusivePtr<CassUuidGen, CMut>,
     timestamp: cass_uint64_t,
@@ -213,7 +213,7 @@ impl From<Uuid> for CassUuid {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_string(uuid_raw: CassUuid, output: *mut c_char) {
     let uuid: Uuid = uuid_raw.into();
 
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn cass_uuid_string(uuid_raw: CassUuid, output: *mut c_cha
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_from_string(
     value: *const c_char,
     output: *mut CassUuid,
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn cass_uuid_from_string(
     unsafe { cass_uuid_from_string_n(value, strlen(value), output) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_from_string_n(
     value: *const c_char,
     value_length: size_t,
@@ -258,7 +258,7 @@ pub unsafe extern "C" fn cass_uuid_from_string_n(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_gen_free(uuid_gen: CassOwnedExclusivePtr<CassUuidGen, CMut>) {
     BoxFFI::free(uuid_gen);
 }

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -2,12 +2,12 @@ use std::{convert::TryInto, net::IpAddr, sync::Arc};
 
 use scylla::cluster::metadata::NativeType;
 use scylla::frame::response::result::ColumnType;
+use scylla::serialize::SerializationError;
 use scylla::serialize::value::{
     BuiltinSerializationErrorKind, MapSerializationErrorKind, SerializeValue,
     SetOrListSerializationErrorKind, TupleSerializationErrorKind, UdtSerializationErrorKind,
 };
 use scylla::serialize::writers::{CellWriter, WrittenCellProof};
-use scylla::serialize::SerializationError;
 use scylla::value::{CqlDate, CqlDecimal, CqlDuration};
 use uuid::Uuid;
 
@@ -417,7 +417,7 @@ mod tests {
 
     use crate::{
         cass_types::{CassDataType, CassDataTypeInner, CassValueType, MapDataType, UDTDataType},
-        value::{is_type_compatible, CassCqlValue},
+        value::{CassCqlValue, is_type_compatible},
     };
 
     fn all_value_data_types() -> Vec<CassDataType> {


### PR DESCRIPTION
According to documentation, the `no_mangle` attribute is considered unsafe and compiler emits errors when it's used without `unsafe()` marker.

See: https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.