### PR TITLE
Implement local address and local port range configuration

### DIFF
--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -74,9 +74,6 @@ CASS_EXPORT CassError cass_cluster_set_host_listener_callback(CassCluster* clust
                                                               void* data) {
   throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_host_listener_callback\n");
 }
-CASS_EXPORT CassError cass_cluster_set_local_address(CassCluster* cluster, const char* name) {
-  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_local_address\n");
-}
 CASS_EXPORT CassError cass_cluster_set_no_compact(CassCluster* cluster, cass_bool_t enabled) {
   throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_no_compact\n");
 }


### PR DESCRIPTION
Fixes: https://github.com/scylladb/cpp-rust-driver/issues/239

This pr implements `cass_cluster_set_local_addres[_n]` and `cass_cluster_set_local_port_range`.

## Integration tests:
There will be a follow-up PR which enables the integration tests that we "unlocked" by implementing these. The reason is that it requires to adjust some test logic (e.g. logs filtering) and error handling. Don't want to introduce too much noise to this PR.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~