### PR TITLE
Adjust and enable LatencyAwarePolicyTest suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :TracingTests.*\
 :ByNameTests.*\
 :CompressionTests.*\
+:LatencyAwarePolicyTest.*\
 :LoggingTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
@@ -49,6 +50,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :TracingTests.*\
 :ByNameTests.*\
 :CompressionTests.*\
+:LatencyAwarePolicyTest.*\
 :LoggingTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\

--- a/tests/src/integration/tests/test_latency_aware_policy.cpp
+++ b/tests/src/integration/tests/test_latency_aware_policy.cpp
@@ -47,7 +47,7 @@ CASSANDRA_INTEGRATION_TEST_F(LatencyAwarePolicyTest, IsEnabled) {
   connect(cluster_);
 
   logger_.reset();
-  logger_.add_critera("Calculated new minimum:");
+  logger_.add_critera("Latency awareness: updated min average latency to");
 
   for (int i = 0; i < 9; ++i) { // Greater than min measured
     session_.execute("SELECT release_version FROM system.local WHERE key='local'");


### PR DESCRIPTION
Ref: https://github.com/scylladb/cpp-rust-driver/issues/132

This suite consists of only one test case - namely `IsEnabled`, which looks for the latency awareness logs and checks that it is indeed enabled.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.