### PR TITLE
implement `cass_session_get_metrics` and enable some integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :UseKeyspaceCaseSensitiveTests.Integration_Cassandra_ConnectWithKeyspace)
 endif
 
+ifndef SCYLLA_NO_VALGRIND_TEST_FILTER
+SCYLLA_NO_VALGRIND_TEST_FILTER := $(subst ${SPACE},${EMPTY},AsyncTests.Integration_Cassandra_Simple\
+:HeartbeatTests.Integration_Cassandra_HeartbeatFailed)
+endif
+
 ifndef CASSANDRA_TEST_FILTER
 CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :BasicsTests.*\
@@ -70,6 +75,11 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :*NoCompactEnabledConnection\
 :PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount\
 :UseKeyspaceCaseSensitiveTests.Integration_Cassandra_ConnectWithKeyspace)
+endif
+
+ifndef CASSANDRA_NO_VALGRIND_TEST_FILTER
+CASSANDRA_NO_VALGRIND_TEST_FILTER := $(subst ${SPACE},${EMPTY},AsyncTests.Integration_Cassandra_Simple\
+:HeartbeatTests.Integration_Cassandra_HeartbeatFailed)
 endif
 
 ifndef CCM_COMMIT_ID
@@ -226,7 +236,7 @@ endif
 	@echo "Running integration tests on scylla ${SCYLLA_VERSION}"
 	valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite build/cassandra-integration-tests --scylla --version=${SCYLLA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${SCYLLA_TEST_FILTER}"
 	@echo "Running timeout sensitive tests on scylla ${SCYLLA_VERSION}"
-	build/cassandra-integration-tests --scylla --version=${SCYLLA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="AsyncTests.Integration_Cassandra_Simple"
+	build/cassandra-integration-tests --scylla --version=${SCYLLA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${SCYLLA_NO_VALGRIND_TEST_FILTER}"
 
 run-test-integration-cassandra: prepare-integration-test download-ccm-cassandra-image install-java8-if-missing
 ifdef DONT_REBUILD_INTEGRATION_BIN
@@ -237,7 +247,7 @@ endif
 	@echo "Running integration tests on cassandra ${CASSANDRA_VERSION}"
 	valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite build/cassandra-integration-tests --version=${CASSANDRA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${CASSANDRA_TEST_FILTER}"
 	@echo "Running timeout sensitive tests on cassandra ${CASSANDRA_VERSION}"
-	build/cassandra-integration-tests --version=${CASSANDRA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="AsyncTests.Integration_Cassandra_Simple"
+	build/cassandra-integration-tests --version=${CASSANDRA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${CASSANDRA_NO_VALGRIND_TEST_FILTER}"
 
 run-test-unit: install-cargo-if-missing _update-rust-tooling
 	@cd ${CURRENT_DIR}/scylla-rust-wrapper; cargo test

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :LoggingTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
+:MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
@@ -64,6 +65,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :LoggingTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
+:MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
+:MetricsTests.Integration_Cassandra_Requests\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
@@ -66,6 +67,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
+:MetricsTests.Integration_Cassandra_Requests\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -462,6 +462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
+name = "histogram"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95aebe0dec9a429e3207e5e34d97f2a7d1064d5ee6d8ed13ce0a26456de000ae"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1123,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hashbrown 0.14.5",
+ "histogram",
  "itertools",
  "lazy_static",
  "lz4_flex",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.1.0", features = [
     "openssl-010",
+    "metrics",
 ] }
 tokio = { version = "1.27.0", features = ["full"] }
 uuid = "1.1.2"

--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -153,4 +153,9 @@ fn main() {
         &["CassIteratorType_", "CassIteratorType"],
         &out_path,
     );
+    prepare_cppdriver_data(
+        "cppdriver_metrics_types.rs",
+        &["CassMetrics_", "CassMetrics"],
+        &out_path,
+    );
 }

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -119,6 +119,13 @@ pub mod cass_iterator_types {
     include_bindgen_generated!("cppdriver_iterator_types.rs");
 }
 
+/// CassMetrics
+pub mod cass_metrics_types {
+    #![allow(non_camel_case_types, non_snake_case)]
+
+    include_bindgen_generated!("cppdriver_metrics_types.rs");
+}
+
 pub static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| Runtime::new().unwrap());
 pub static LOGGER: LazyLock<RwLock<Logger>> = LazyLock::new(|| {
     RwLock::new(Logger {

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -98,4 +98,8 @@ void set_record_attempted_hosts(CassStatement* statement, bool enable) {
   throw std::runtime_error("Unimplemented 'set_record_attempted_hosts'!");
 }
 
+void set_sleeping_history_listener_on_statement(CassStatement* statement, uint64_t sleep_time_ms) {
+  testing_statement_set_sleeping_history_listener(statement, sleep_time_ms);
+}
+
 }}} // namespace datastax::internal::testing

--- a/src/testing.hpp
+++ b/src/testing.hpp
@@ -50,6 +50,8 @@ CASS_EXPORT String get_server_name(CassFuture* future);
 
 CASS_EXPORT void set_record_attempted_hosts(CassStatement* statement, bool enable);
 
+CASS_EXPORT void set_sleeping_history_listener_on_statement(CassStatement* statement, uint64_t sleep_time_ms);
+
 }}} // namespace datastax::internal::testing
 
 #endif

--- a/src/testing_rust_impls.h
+++ b/src/testing_rust_impls.h
@@ -21,6 +21,11 @@ CASS_EXPORT void testing_cluster_get_contact_points(CassCluster* cluster, char**
                                                     size_t* contact_points_length);
 
 CASS_EXPORT void testing_free_contact_points(char* contact_points);
+
+// Sets a sleeping history listener on the statement.
+// This can be used to enforce a sleep time during statement execution, which increases the latency.
+CASS_EXPORT void testing_statement_set_sleeping_history_listener(CassStatement *statement,
+                                                                 cass_uint64_t sleep_time_ms);
 }
 
 #endif

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -205,9 +205,6 @@ CASS_EXPORT CassRetryPolicy* cass_retry_policy_logging_new(CassRetryPolicy* chil
 CASS_EXPORT CassVersion cass_schema_meta_version(const CassSchemaMeta* schema_meta) {
   throw std::runtime_error("UNIMPLEMENTED cass_schema_meta_version\n");
 }
-CASS_EXPORT void cass_session_get_metrics(const CassSession* session, CassMetrics* output) {
-  throw std::runtime_error("UNIMPLEMENTED cass_session_get_metrics\n");
-}
 CASS_EXPORT void
 cass_session_get_speculative_execution_metrics(const CassSession* session,
                                                CassSpeculativeExecutionMetrics* output) {

--- a/tests/src/integration/objects/session.hpp
+++ b/tests/src/integration/objects/session.hpp
@@ -111,7 +111,7 @@ public:
    * @return Driver metrics
    */
   CassMetrics metrics() const {
-    CassMetrics metrics;
+    CassMetrics metrics = {};
     cass_session_get_metrics(get(), &metrics);
     return metrics;
   }

--- a/tests/src/integration/objects/statement.hpp
+++ b/tests/src/integration/objects/statement.hpp
@@ -166,6 +166,16 @@ public:
   }
 
   /**
+   * Set a sleeping history listener on the statement.
+   * This can be used to enforce a sleep time during statement execution, which increases the latency.
+   *
+   * @param sleep_time_ms Sleep time in milliseconds
+   */
+  void set_sleep_time(uint64_t sleep_time_ms) {
+    datastax::internal::testing::set_sleeping_history_listener_on_statement(get(), sleep_time_ms);
+  }
+
+  /**
    * Enable/Disable whether the statement is idempotent. Idempotent statements
    * are able to be automatically retried after timeouts/errors and can be
    * speculatively executed.

--- a/tests/src/integration/tests/test_metrics.cpp
+++ b/tests/src/integration/tests/test_metrics.cpp
@@ -114,9 +114,12 @@ CASSANDRA_INTEGRATION_TEST_F(MetricsTests, ErrorsRequestTimeouts) {
 CASSANDRA_INTEGRATION_TEST_F(MetricsTests, Requests) {
   CHECK_FAILURE;
 
+  Statement statement(SELECT_ALL_SYSTEM_LOCAL_CQL);
+  statement.set_sleep_time(1); // Simulate >=1ms latency.
+
   CassMetrics metrics = session_.metrics();
   for (int i = 0; i < 600 && metrics.requests.fifteen_minute_rate == 0; ++i) {
-    session_.execute_async(SELECT_ALL_SYSTEM_LOCAL_CQL);
+    session_.execute_async(statement);
     metrics = session_.metrics();
     msleep(100);
   }
@@ -124,7 +127,7 @@ CASSANDRA_INTEGRATION_TEST_F(MetricsTests, Requests) {
   EXPECT_LT(metrics.requests.min, CASS_UINT64_MAX);
   EXPECT_GT(metrics.requests.max, 0u);
   EXPECT_GT(metrics.requests.mean, 0u);
-  EXPECT_GT(metrics.requests.stddev, 0u);
+  EXPECT_GE(metrics.requests.stddev, 0u);
   EXPECT_GT(metrics.requests.median, 0u);
   EXPECT_GT(metrics.requests.percentile_75th, 0u);
   EXPECT_GT(metrics.requests.percentile_95th, 0u);


### PR DESCRIPTION
Fixes: https://github.com/scylladb/cpp-rust-driver/issues/257
Ref: https://github.com/scylladb/cpp-rust-driver/issues/132

This PR implements `cass_session_get_metrics` and enables two integration tests.

##  Metrics tests
To be quite honest, I thought we'll be able to enable more tests, but:
    
1. StatsConnections

Requires `cass_cluster_set_num_threads_io`, `cass_cluster_set_core
_connections_per_host`
and `cass_cluster_set_constant_reconnect`.

2. ErrorsConnectionTimeouts

Requires `cass_cluster_set_core_connections_per_host`.

3. SpeculativeExecutionRequests

Requires `cass_session_get_speculative_execution_metrics`.

4. Requests

This one is interesting. It turns out that cpp-driver stores latency
stats as microseconds, while rust-driver stores them as milliseconds.

Because of that, the mean and median latency is rounded to 0 (at least for my machine).
The test expects them to be greater than 0, which makes sense assuming
the driver collects the stats with microsecond precision.

~I'm not sure how to address this one. Is there any way to force
higher >=1ms latencies in the test?~ Thanks to @Lorak-mmk suggestion, I was able to apply the `HistoryListener` hack in the test - this allows us to enforce `>=1ms` latencies for the requests.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.