### PR TITLE
Connection pool size configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
+:MetricsTests.Integration_Cassandra_StatsShardConnections\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
@@ -68,6 +69,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
+:MetricsTests.Integration_Cassandra_StatsShardConnections\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -1780,8 +1780,31 @@ cass_cluster_set_queue_size_event(CassCluster* cluster,
                                   unsigned queue_size));
 
 /**
- * Sets the number of connections made to each server in each
- * IO thread.
+ * Sets the number of connections opened by the driver to each host.
+ *
+ * Notice that this overrides the number of connections per shard
+ * set by `cass_cluster_set_core_connections_per_shard()`.
+ *
+ * <b>Default:</b> 1 per shard (i.e. `cass_cluster_set_core_connections_per_shard(cluster, 1)`)
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] num_connections
+ * @return CASS_OK if successful, otherwise an error occurred.
+ *
+ * @see cass_cluster_set_core_connections_per_shard()
+ */
+CASS_EXPORT CassError
+cass_cluster_set_core_connections_per_host(CassCluster* cluster,
+                                           unsigned num_connections);
+
+/**
+ * Sets the number of connections opened by the driver to each shard.
+ *
+ * Cassandra nodes are treated as if they have one shard.
+ * 
+ * This will override the `cass_cluster_set_core_connections_per_host`, if set.
  *
  * <b>Default:</b> 1
  *
@@ -1790,9 +1813,11 @@ cass_cluster_set_queue_size_event(CassCluster* cluster,
  * @param[in] cluster
  * @param[in] num_connections
  * @return CASS_OK if successful, otherwise an error occurred.
+ *
+ * @see cass_cluster_set_core_connections_per_host()
  */
 CASS_EXPORT CassError
-cass_cluster_set_core_connections_per_host(CassCluster* cluster,
+cass_cluster_set_core_connections_per_shard(CassCluster* cluster,
                                            unsigned num_connections);
 
 /**

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -65,10 +65,6 @@ CASS_EXPORT CassError cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib
 CASS_EXPORT void cass_cluster_set_constant_reconnect(CassCluster* cluster, cass_uint64_t delay_ms) {
   throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_constant_reconnect\n");
 }
-CASS_EXPORT CassError cass_cluster_set_core_connections_per_host(CassCluster* cluster,
-                                                                 unsigned num_connections) {
-  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_core_connections_per_host\n");
-}
 CASS_EXPORT CassError cass_cluster_set_host_listener_callback(CassCluster* cluster,
                                                               CassHostListenerCallback callback,
                                                               void* data) {

--- a/tests/src/integration/objects/cluster.hpp
+++ b/tests/src/integration/objects/cluster.hpp
@@ -170,6 +170,19 @@ public:
     return *this;
   }
 
+    /**
+   * Assign the number of connections made to each shard
+   *
+   * NOTE: One extra connection is established (the control connection)
+   *
+   * @param connections Number of connection per shard (default: 1)
+   * @return Cluster object
+   */
+  Cluster& with_core_connections_per_shard(unsigned int connections = 1u) {
+    EXPECT_EQ(CASS_OK, cass_cluster_set_core_connections_per_shard(get(), connections));
+    return *this;
+  }
+
   /**
    * Sets credentials for plain text authentication
    *


### PR DESCRIPTION
Fixes: https://github.com/scylladb/cpp-rust-driver/issues/240
Ref: https://github.com/scylladb/cpp-rust-driver/issues/132

~Depends on: https://github.com/scylladb/cpp-rust-driver/pull/280 (I need metrics support to implement one integration test).~ <- already on master

Implements:
- `cass_cluster_set_core_connections_per_host`
- `cass_cluster_set_core_connections_per_shard` (as an extension to cpp-driver API)

## Integration tests
### Existing ErrorsConnectionTimeouts metrics test
```c++
CASSANDRA_INTEGRATION_TEST_F(MetricsTests, ErrorsConnectionTimeouts) {
  CHECK_FAILURE;

  Session session =
      default_cluster().with_core_connections_per_host(2).with_connect_timeout(1).connect(
          "", false); // Quick connection timeout and no assertion

  CassMetrics metrics = session.metrics();
  EXPECT_GE(2u, metrics.errors.connection_timeouts);
}
```

I don't know who implemented this test, but (IMO) it's just wrong. So my understanding of intentions is:
1. we set 2 connections per host
2. we set low connect timeout
3. we expect at least 2 connection timeouts registered in the metrics

If those were the intentions, the `EXPECT_GE(2u, metrics.errors.connection_timeouts);` is wrong - it should be the other way around. Currently it expects `2 >= connection_timeouts`.

Ok, so let's say we fix it. It still won't work with rust driver. The `Session` object will not even be built - we will fail to open a control connection (because of timeouts) and fail to fetch the metadata. In particular, we won't even be able to call `Session::get_metrics()` - the `cass_session_get_metrics` will return early with some log error message.

Thus, I'm not enabling this test.

Fun fact: in my local setup, this test passes. Even though, the connect timeout is low, it is not triggered. And then, the `metrics.errors.connection_timeouts` is 0 - this means that aforementioned assertion passes as well.

### My new `StatsShardConnections` metrics test
I implemented simple test where we configure a pool size to be 2 connections per shard (`cass_cluster_set_core_connections_per_shard`). It checks whether all connections are registered in the metrics. The expected value is at least `nr_hosts * nr_shards * 2`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.