### PR TITLE
Implement `cass_retry_policy_logging_new` and enable some exec profile integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :TimestampTests.Integration_Cassandra_MonotonicTimestampGenerator\
 :ExecutionProfileTest.Integration_Cassandra_RoundRobin\
 :ExecutionProfileTest.Integration_Cassandra_TokenAwareRouting\
-:ExecutionProfileTest.Integration_Cassandra_RetryPolicy\
 :ExecutionProfileTest.Integration_Cassandra_SpeculativeExecutionPolicy\
 :DCExecutionProfileTest.Integration_Cassandra_DCAware\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
@@ -107,7 +106,6 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :TimestampTests.Integration_Cassandra_MonotonicTimestampGenerator\
 :ExecutionProfileTest.Integration_Cassandra_RoundRobin\
 :ExecutionProfileTest.Integration_Cassandra_TokenAwareRouting\
-:ExecutionProfileTest.Integration_Cassandra_RetryPolicy\
 :ExecutionProfileTest.Integration_Cassandra_SpeculativeExecutionPolicy\
 :DCExecutionProfileTest.Integration_Cassandra_DCAware\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -109,11 +109,11 @@ pub unsafe extern "C" fn cass_batch_set_retry_policy(
 
     let maybe_arced_retry_policy: Option<Arc<dyn scylla::policies::retry::RetryPolicy>> =
         ArcFFI::as_ref(retry_policy).map(|policy| match policy {
-            CassRetryPolicy::DefaultRetryPolicy(default) => {
+            CassRetryPolicy::Default(default) => {
                 default.clone() as Arc<dyn scylla::policies::retry::RetryPolicy>
             }
-            CassRetryPolicy::FallthroughRetryPolicy(fallthrough) => fallthrough.clone(),
-            CassRetryPolicy::DowngradingConsistencyRetryPolicy(downgrading) => downgrading.clone(),
+            CassRetryPolicy::Fallthrough(fallthrough) => fallthrough.clone(),
+            CassRetryPolicy::DowngradingConsistency(downgrading) => downgrading.clone(),
         });
 
     Arc::make_mut(&mut batch.state)

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -114,6 +114,7 @@ pub unsafe extern "C" fn cass_batch_set_retry_policy(
             }
             CassRetryPolicy::Fallthrough(fallthrough) => fallthrough.clone(),
             CassRetryPolicy::DowngradingConsistency(downgrading) => downgrading.clone(),
+            CassRetryPolicy::Logging(logging) => Arc::clone(logging) as _,
         });
 
     Arc::make_mut(&mut batch.state)

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -115,6 +115,8 @@ pub unsafe extern "C" fn cass_batch_set_retry_policy(
             CassRetryPolicy::Fallthrough(fallthrough) => fallthrough.clone(),
             CassRetryPolicy::DowngradingConsistency(downgrading) => downgrading.clone(),
             CassRetryPolicy::Logging(logging) => Arc::clone(logging) as _,
+            #[cfg(cpp_integration_testing)]
+            CassRetryPolicy::Ignoring(ignoring) => Arc::clone(ignoring) as _,
         });
 
     Arc::make_mut(&mut batch.state)

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -1146,6 +1146,7 @@ pub unsafe extern "C" fn cass_cluster_set_retry_policy(
         Some(CassRetryPolicy::Default(default)) => Arc::clone(default) as _,
         Some(CassRetryPolicy::Fallthrough(fallthrough)) => Arc::clone(fallthrough) as _,
         Some(CassRetryPolicy::DowngradingConsistency(downgrading)) => Arc::clone(downgrading) as _,
+        Some(CassRetryPolicy::Logging(logging)) => Arc::clone(logging) as _,
         None => {
             tracing::error!("Provided null retry policy pointer to cass_cluster_set_retry_policy!");
             return;

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -1143,11 +1143,9 @@ pub unsafe extern "C" fn cass_cluster_set_retry_policy(
     };
 
     let retry_policy: Arc<dyn RetryPolicy> = match ArcFFI::as_ref(retry_policy) {
-        Some(CassRetryPolicy::DefaultRetryPolicy(default)) => Arc::clone(default) as _,
-        Some(CassRetryPolicy::FallthroughRetryPolicy(fallthrough)) => Arc::clone(fallthrough) as _,
-        Some(CassRetryPolicy::DowngradingConsistencyRetryPolicy(downgrading)) => {
-            Arc::clone(downgrading) as _
-        }
+        Some(CassRetryPolicy::Default(default)) => Arc::clone(default) as _,
+        Some(CassRetryPolicy::Fallthrough(fallthrough)) => Arc::clone(fallthrough) as _,
+        Some(CassRetryPolicy::DowngradingConsistency(downgrading)) => Arc::clone(downgrading) as _,
         None => {
             tracing::error!("Provided null retry policy pointer to cass_cluster_set_retry_policy!");
             return;

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -1147,6 +1147,8 @@ pub unsafe extern "C" fn cass_cluster_set_retry_policy(
         Some(CassRetryPolicy::Fallthrough(fallthrough)) => Arc::clone(fallthrough) as _,
         Some(CassRetryPolicy::DowngradingConsistency(downgrading)) => Arc::clone(downgrading) as _,
         Some(CassRetryPolicy::Logging(logging)) => Arc::clone(logging) as _,
+        #[cfg(cpp_integration_testing)]
+        Some(CassRetryPolicy::Ignoring(ignoring)) => Arc::clone(ignoring) as _,
         None => {
             tracing::error!("Provided null retry policy pointer to cass_cluster_set_retry_policy!");
             return;

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -5,7 +5,6 @@ use crate::exec_profile::{CassExecProfile, ExecProfileName, exec_profile_builder
 use crate::future::CassFuture;
 use crate::load_balancing::{CassHostFilter, LoadBalancingConfig, LoadBalancingKind};
 use crate::retry_policy::CassRetryPolicy;
-use crate::retry_policy::RetryPolicy::*;
 use crate::ssl::CassSsl;
 use crate::timestamp_generator::CassTimestampGen;
 use crate::types::*;
@@ -1144,9 +1143,11 @@ pub unsafe extern "C" fn cass_cluster_set_retry_policy(
     };
 
     let retry_policy: Arc<dyn RetryPolicy> = match ArcFFI::as_ref(retry_policy) {
-        Some(DefaultRetryPolicy(default)) => Arc::clone(default) as _,
-        Some(FallthroughRetryPolicy(fallthrough)) => Arc::clone(fallthrough) as _,
-        Some(DowngradingConsistencyRetryPolicy(downgrading)) => Arc::clone(downgrading) as _,
+        Some(CassRetryPolicy::DefaultRetryPolicy(default)) => Arc::clone(default) as _,
+        Some(CassRetryPolicy::FallthroughRetryPolicy(fallthrough)) => Arc::clone(fallthrough) as _,
+        Some(CassRetryPolicy::DowngradingConsistencyRetryPolicy(downgrading)) => {
+            Arc::clone(downgrading) as _
+        }
         None => {
             tracing::error!("Provided null retry policy pointer to cass_cluster_set_retry_policy!");
             return;

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -27,9 +27,6 @@ use crate::cluster::{
 };
 use crate::load_balancing::{LoadBalancingConfig, LoadBalancingKind};
 use crate::retry_policy::CassRetryPolicy;
-use crate::retry_policy::RetryPolicy::{
-    DefaultRetryPolicy, DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy,
-};
 use crate::session::CassSessionInner;
 use crate::statement::CassStatement;
 use crate::types::{
@@ -670,9 +667,11 @@ pub unsafe extern "C" fn cass_execution_profile_set_retry_policy(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
     let retry_policy: Arc<dyn RetryPolicy> = match ArcFFI::as_ref(retry_policy) {
-        Some(DefaultRetryPolicy(default)) => Arc::clone(default) as _,
-        Some(FallthroughRetryPolicy(fallthrough)) => Arc::clone(fallthrough) as _,
-        Some(DowngradingConsistencyRetryPolicy(downgrading)) => Arc::clone(downgrading) as _,
+        Some(CassRetryPolicy::DefaultRetryPolicy(default)) => Arc::clone(default) as _,
+        Some(CassRetryPolicy::FallthroughRetryPolicy(fallthrough)) => Arc::clone(fallthrough) as _,
+        Some(CassRetryPolicy::DowngradingConsistencyRetryPolicy(downgrading)) => {
+            Arc::clone(downgrading) as _
+        }
         None => {
             tracing::error!(
                 "Provided null retry policy pointer to cass_execution_profile_set_retry_policy!"

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -667,11 +667,9 @@ pub unsafe extern "C" fn cass_execution_profile_set_retry_policy(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
     let retry_policy: Arc<dyn RetryPolicy> = match ArcFFI::as_ref(retry_policy) {
-        Some(CassRetryPolicy::DefaultRetryPolicy(default)) => Arc::clone(default) as _,
-        Some(CassRetryPolicy::FallthroughRetryPolicy(fallthrough)) => Arc::clone(fallthrough) as _,
-        Some(CassRetryPolicy::DowngradingConsistencyRetryPolicy(downgrading)) => {
-            Arc::clone(downgrading) as _
-        }
+        Some(CassRetryPolicy::Default(default)) => Arc::clone(default) as _,
+        Some(CassRetryPolicy::Fallthrough(fallthrough)) => Arc::clone(fallthrough) as _,
+        Some(CassRetryPolicy::DowngradingConsistency(downgrading)) => Arc::clone(downgrading) as _,
         None => {
             tracing::error!(
                 "Provided null retry policy pointer to cass_execution_profile_set_retry_policy!"

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -671,6 +671,8 @@ pub unsafe extern "C" fn cass_execution_profile_set_retry_policy(
         Some(CassRetryPolicy::Fallthrough(fallthrough)) => Arc::clone(fallthrough) as _,
         Some(CassRetryPolicy::DowngradingConsistency(downgrading)) => Arc::clone(downgrading) as _,
         Some(CassRetryPolicy::Logging(logging)) => Arc::clone(logging) as _,
+        #[cfg(cpp_integration_testing)]
+        Some(CassRetryPolicy::Ignoring(ignoring)) => Arc::clone(ignoring) as _,
         None => {
             tracing::error!(
                 "Provided null retry policy pointer to cass_execution_profile_set_retry_policy!"

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -670,6 +670,7 @@ pub unsafe extern "C" fn cass_execution_profile_set_retry_policy(
         Some(CassRetryPolicy::Default(default)) => Arc::clone(default) as _,
         Some(CassRetryPolicy::Fallthrough(fallthrough)) => Arc::clone(fallthrough) as _,
         Some(CassRetryPolicy::DowngradingConsistency(downgrading)) => Arc::clone(downgrading) as _,
+        Some(CassRetryPolicy::Logging(logging)) => Arc::clone(logging) as _,
         None => {
             tracing::error!(
                 "Provided null retry policy pointer to cass_execution_profile_set_retry_policy!"

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -174,3 +174,29 @@ pub unsafe extern "C" fn testing_batch_set_sleeping_history_listener(
         .batch
         .set_history_listener(history_listener)
 }
+
+/// A retry policy that always ignores all errors.
+///
+/// Useful for testing purposes.
+#[derive(Debug)]
+pub struct IgnoringRetryPolicy;
+
+#[derive(Debug)]
+struct IgnoringRetrySession;
+
+impl scylla::policies::retry::RetryPolicy for IgnoringRetryPolicy {
+    fn new_session(&self) -> Box<dyn scylla::policies::retry::RetrySession> {
+        Box::new(IgnoringRetrySession)
+    }
+}
+
+impl scylla::policies::retry::RetrySession for IgnoringRetrySession {
+    fn decide_should_retry(
+        &mut self,
+        _request_info: scylla::policies::retry::RequestInfo,
+    ) -> RetryDecision {
+        RetryDecision::IgnoreWriteError
+    }
+
+    fn reset(&mut self) {}
+}

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -9,10 +9,12 @@ use scylla::policies::retry::RetryDecision;
 
 use crate::argconv::{
     ArcFFI, BoxFFI, CConst, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr,
+    CassOwnedSharedPtr,
 };
 use crate::batch::CassBatch;
 use crate::cluster::CassCluster;
 use crate::future::{CassFuture, CassResultValue};
+use crate::retry_policy::CassRetryPolicy;
 use crate::statement::{BoundStatement, CassStatement};
 use crate::types::{cass_int32_t, cass_uint16_t, cass_uint64_t, size_t};
 
@@ -199,4 +201,12 @@ impl scylla::policies::retry::RetrySession for IgnoringRetrySession {
     }
 
     fn reset(&mut self) {}
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn testing_retry_policy_ignoring_new()
+-> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
+    ArcFFI::into_ptr(Arc::new(CassRetryPolicy::Ignoring(Arc::new(
+        IgnoringRetryPolicy,
+    ))))
 }

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -5,13 +5,11 @@ use std::sync::Arc;
 
 use crate::argconv::{ArcFFI, CMut, CassOwnedSharedPtr, FFI, FromArc};
 
-pub enum RetryPolicy {
+pub enum CassRetryPolicy {
     DefaultRetryPolicy(Arc<DefaultRetryPolicy>),
     FallthroughRetryPolicy(Arc<FallthroughRetryPolicy>),
     DowngradingConsistencyRetryPolicy(Arc<DowngradingConsistencyRetryPolicy>),
 }
-
-pub type CassRetryPolicy = RetryPolicy;
 
 impl FFI for CassRetryPolicy {
     type Origin = FromArc;
@@ -19,7 +17,7 @@ impl FFI for CassRetryPolicy {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn cass_retry_policy_default_new() -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
-    ArcFFI::into_ptr(Arc::new(RetryPolicy::DefaultRetryPolicy(Arc::new(
+    ArcFFI::into_ptr(Arc::new(CassRetryPolicy::DefaultRetryPolicy(Arc::new(
         DefaultRetryPolicy,
     ))))
 }
@@ -27,14 +25,16 @@ pub extern "C" fn cass_retry_policy_default_new() -> CassOwnedSharedPtr<CassRetr
 #[unsafe(no_mangle)]
 pub extern "C" fn cass_retry_policy_downgrading_consistency_new()
 -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
-    ArcFFI::into_ptr(Arc::new(RetryPolicy::DowngradingConsistencyRetryPolicy(
-        Arc::new(DowngradingConsistencyRetryPolicy),
-    )))
+    ArcFFI::into_ptr(Arc::new(
+        CassRetryPolicy::DowngradingConsistencyRetryPolicy(Arc::new(
+            DowngradingConsistencyRetryPolicy,
+        )),
+    ))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn cass_retry_policy_fallthrough_new() -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
-    ArcFFI::into_ptr(Arc::new(RetryPolicy::FallthroughRetryPolicy(Arc::new(
+    ArcFFI::into_ptr(Arc::new(CassRetryPolicy::FallthroughRetryPolicy(Arc::new(
         FallthroughRetryPolicy,
     ))))
 }

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -63,6 +63,8 @@ pub enum CassRetryPolicy {
     Fallthrough(Arc<FallthroughRetryPolicy>),
     DowngradingConsistency(Arc<DowngradingConsistencyRetryPolicy>),
     Logging(Arc<CassLoggingRetryPolicy>),
+    #[cfg(cpp_integration_testing)]
+    Ignoring(Arc<crate::integration_testing::IgnoringRetryPolicy>),
 }
 
 impl RetryPolicy for CassRetryPolicy {
@@ -72,6 +74,8 @@ impl RetryPolicy for CassRetryPolicy {
             Self::Fallthrough(policy) => policy.new_session(),
             Self::DowngradingConsistency(policy) => policy.new_session(),
             Self::Logging(policy) => policy.new_session(),
+            #[cfg(cpp_integration_testing)]
+            Self::Ignoring(policy) => policy.new_session(),
         }
     }
 }

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use crate::argconv::{ArcFFI, CMut, CassOwnedSharedPtr, FFI, FromArc};
 
 pub enum CassRetryPolicy {
-    DefaultRetryPolicy(Arc<DefaultRetryPolicy>),
-    FallthroughRetryPolicy(Arc<FallthroughRetryPolicy>),
-    DowngradingConsistencyRetryPolicy(Arc<DowngradingConsistencyRetryPolicy>),
+    Default(Arc<DefaultRetryPolicy>),
+    Fallthrough(Arc<FallthroughRetryPolicy>),
+    DowngradingConsistency(Arc<DowngradingConsistencyRetryPolicy>),
 }
 
 impl FFI for CassRetryPolicy {
@@ -17,7 +17,7 @@ impl FFI for CassRetryPolicy {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn cass_retry_policy_default_new() -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
-    ArcFFI::into_ptr(Arc::new(CassRetryPolicy::DefaultRetryPolicy(Arc::new(
+    ArcFFI::into_ptr(Arc::new(CassRetryPolicy::Default(Arc::new(
         DefaultRetryPolicy,
     ))))
 }
@@ -25,16 +25,14 @@ pub extern "C" fn cass_retry_policy_default_new() -> CassOwnedSharedPtr<CassRetr
 #[unsafe(no_mangle)]
 pub extern "C" fn cass_retry_policy_downgrading_consistency_new()
 -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
-    ArcFFI::into_ptr(Arc::new(
-        CassRetryPolicy::DowngradingConsistencyRetryPolicy(Arc::new(
-            DowngradingConsistencyRetryPolicy,
-        )),
-    ))
+    ArcFFI::into_ptr(Arc::new(CassRetryPolicy::DowngradingConsistency(Arc::new(
+        DowngradingConsistencyRetryPolicy,
+    ))))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn cass_retry_policy_fallthrough_new() -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
-    ArcFFI::into_ptr(Arc::new(CassRetryPolicy::FallthroughRetryPolicy(Arc::new(
+    ArcFFI::into_ptr(Arc::new(CassRetryPolicy::Fallthrough(Arc::new(
         FallthroughRetryPolicy,
     ))))
 }

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -1,14 +1,79 @@
 use scylla::policies::retry::{
-    DefaultRetryPolicy, DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy,
+    DefaultRetryPolicy, DowngradingConsistencyRetryPolicy, FallthroughRetryPolicy, RequestInfo,
+    RetryDecision, RetryPolicy, RetrySession,
 };
 use std::sync::Arc;
 
-use crate::argconv::{ArcFFI, CMut, CassOwnedSharedPtr, FFI, FromArc};
+use crate::argconv::{ArcFFI, CMut, CassBorrowedSharedPtr, CassOwnedSharedPtr, FFI, FromArc};
 
+#[derive(Debug)]
+pub struct CassLoggingRetryPolicy {
+    child_policy: Arc<CassRetryPolicy>,
+}
+
+struct CassLoggingRetrySession {
+    child_session: Box<dyn RetrySession>,
+}
+
+impl RetryPolicy for CassLoggingRetryPolicy {
+    fn new_session(&self) -> Box<dyn RetrySession> {
+        Box::new(CassLoggingRetrySession {
+            child_session: self.child_policy.new_session(),
+        })
+    }
+}
+
+impl RetrySession for CassLoggingRetrySession {
+    fn decide_should_retry(&mut self, request_info: RequestInfo) -> RetryDecision {
+        let error = request_info.error;
+        let initial_consistency = request_info.consistency;
+        let decision = self.child_session.decide_should_retry(request_info);
+
+        match &decision {
+            RetryDecision::RetrySameTarget(consistency) => tracing::info!(
+                "Retrying on the same target; Error: {}; Initial Consistency: {:?}; New Consistency: {:?}",
+                error,
+                initial_consistency,
+                consistency
+            ),
+            RetryDecision::RetryNextTarget(consistency) => tracing::info!(
+                "Retrying on the next target; Error: {}; Initial Consistency: {:?}; New Consistency: {:?}",
+                error,
+                initial_consistency,
+                consistency
+            ),
+            RetryDecision::IgnoreWriteError => {
+                tracing::info!("Ignoring write error; Error: {}", error)
+            }
+            // cpp-driver does not log in case of DontRetry decision.
+            _ => {}
+        }
+
+        decision
+    }
+
+    fn reset(&mut self) {
+        self.child_session.reset();
+    }
+}
+
+#[derive(Debug)]
 pub enum CassRetryPolicy {
     Default(Arc<DefaultRetryPolicy>),
     Fallthrough(Arc<FallthroughRetryPolicy>),
     DowngradingConsistency(Arc<DowngradingConsistencyRetryPolicy>),
+    Logging(Arc<CassLoggingRetryPolicy>),
+}
+
+impl RetryPolicy for CassRetryPolicy {
+    fn new_session(&self) -> Box<dyn RetrySession> {
+        match self {
+            Self::Default(policy) => policy.new_session(),
+            Self::Fallthrough(policy) => policy.new_session(),
+            Self::DowngradingConsistency(policy) => policy.new_session(),
+            Self::Logging(policy) => policy.new_session(),
+        }
+    }
 }
 
 impl FFI for CassRetryPolicy {
@@ -34,6 +99,20 @@ pub extern "C" fn cass_retry_policy_downgrading_consistency_new()
 pub extern "C" fn cass_retry_policy_fallthrough_new() -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
     ArcFFI::into_ptr(Arc::new(CassRetryPolicy::Fallthrough(Arc::new(
         FallthroughRetryPolicy,
+    ))))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn cass_retry_policy_logging_new(
+    child_policy_raw: CassBorrowedSharedPtr<CassRetryPolicy, CMut>,
+) -> CassOwnedSharedPtr<CassRetryPolicy, CMut> {
+    let Some(child_policy) = ArcFFI::cloned_from_ptr(child_policy_raw) else {
+        tracing::error!("Provided null pointer to child policy in cass_retry_policy_logging_new!");
+        return ArcFFI::null();
+    };
+
+    ArcFFI::into_ptr(Arc::new(CassRetryPolicy::Logging(Arc::new(
+        CassLoggingRetryPolicy { child_policy },
     ))))
 }
 

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -588,6 +588,8 @@ pub unsafe extern "C" fn cass_statement_set_retry_policy(
             CassRetryPolicy::Fallthrough(fallthrough) => fallthrough.clone(),
             CassRetryPolicy::DowngradingConsistency(downgrading) => downgrading.clone(),
             CassRetryPolicy::Logging(logging) => Arc::clone(logging) as _,
+            #[cfg(cpp_integration_testing)]
+            CassRetryPolicy::Ignoring(ignoring) => Arc::clone(ignoring) as _,
         });
 
     match &mut statement.statement {

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -587,6 +587,7 @@ pub unsafe extern "C" fn cass_statement_set_retry_policy(
             }
             CassRetryPolicy::Fallthrough(fallthrough) => fallthrough.clone(),
             CassRetryPolicy::DowngradingConsistency(downgrading) => downgrading.clone(),
+            CassRetryPolicy::Logging(logging) => Arc::clone(logging) as _,
         });
 
     match &mut statement.statement {

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -582,11 +582,11 @@ pub unsafe extern "C" fn cass_statement_set_retry_policy(
 
     let maybe_arced_retry_policy: Option<Arc<dyn scylla::policies::retry::RetryPolicy>> =
         ArcFFI::as_ref(retry_policy).map(|policy| match policy {
-            CassRetryPolicy::DefaultRetryPolicy(default) => {
+            CassRetryPolicy::Default(default) => {
                 default.clone() as Arc<dyn scylla::policies::retry::RetryPolicy>
             }
-            CassRetryPolicy::FallthroughRetryPolicy(fallthrough) => fallthrough.clone(),
-            CassRetryPolicy::DowngradingConsistencyRetryPolicy(downgrading) => downgrading.clone(),
+            CassRetryPolicy::Fallthrough(fallthrough) => fallthrough.clone(),
+            CassRetryPolicy::DowngradingConsistency(downgrading) => downgrading.clone(),
         });
 
     match &mut statement.statement {

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -121,4 +121,8 @@ void set_sleeping_history_listener_on_batch(CassBatch* batch, uint64_t sleep_tim
   testing_batch_set_sleeping_history_listener(batch, sleep_time_ms);
 }
 
+CassRetryPolicy* retry_policy_ignoring_new() {
+  return testing_retry_policy_ignoring_new();
+}
+
 }}} // namespace datastax::internal::testing

--- a/src/testing.hpp
+++ b/src/testing.hpp
@@ -54,6 +54,8 @@ CASS_EXPORT void set_sleeping_history_listener_on_statement(CassStatement* state
 
 CASS_EXPORT void set_sleeping_history_listener_on_batch(CassBatch* batch, uint64_t sleep_time_ms);
 
+CASS_EXPORT CassRetryPolicy* retry_policy_ignoring_new();
+
 }}} // namespace datastax::internal::testing
 
 #endif

--- a/src/testing_rust_impls.h
+++ b/src/testing_rust_impls.h
@@ -40,4 +40,18 @@ CASS_EXPORT void testing_batch_set_sleeping_history_listener(CassBatch *batch,
     cass_uint64_t sleep_time_ms);
 }
 
+/**
+ * Creates a new ignoring retry policy.
+ *
+ * This policy never retries any requests, regardless of the error.
+ * It simply ignores the error.
+ *
+ * @public @memberof CassRetryPolicy
+ *
+ * @return Returns a retry policy that must be freed.
+ *
+ * @see cass_retry_policy_free()
+ */
+CASS_EXPORT CassRetryPolicy* testing_retry_policy_ignoring_new();
+
 #endif

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -160,9 +160,6 @@ cass_materialized_view_meta_field_by_name(const CassMaterializedViewMeta* view_m
                                           const char* name) {
   throw std::runtime_error("UNIMPLEMENTED cass_materialized_view_meta_field_by_name\n");
 }
-CASS_EXPORT CassRetryPolicy* cass_retry_policy_logging_new(CassRetryPolicy* child_retry_policy) {
-  throw std::runtime_error("UNIMPLEMENTED cass_retry_policy_logging_new\n");
-}
 CASS_EXPORT CassVersion cass_schema_meta_version(const CassSchemaMeta* schema_meta) {
   throw std::runtime_error("UNIMPLEMENTED cass_schema_meta_version\n");
 }

--- a/tests/src/integration/objects/retry_policy.hpp
+++ b/tests/src/integration/objects/retry_policy.hpp
@@ -17,6 +17,7 @@
 #ifndef __TEST_RETRY_POLICY_HPP__
 #define __TEST_RETRY_POLICY_HPP__
 #include "cassandra.h"
+#include "testing.hpp"
 
 #include "objects/object_base.hpp"
 
@@ -80,6 +81,19 @@ public:
    */
   FallthroughRetryPolicy()
       : RetryPolicy(cass_retry_policy_fallthrough_new()) {}
+};
+
+/**
+ * Wrapped ignoring retry policy
+ */
+class IgnoreRetryPolicy : public RetryPolicy {
+public:
+  /**
+   * Create the ignoring retry policy object from the native driver
+   * ignoring retry policy object
+   */
+  IgnoreRetryPolicy()
+      : RetryPolicy(datastax::internal::testing::retry_policy_ignoring_new()) {}
 };
 
 /**

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -25,8 +25,7 @@ class ExecutionProfileTest : public Integration {
 public:
   ExecutionProfileTest()
       : insert_(NULL)
-      //, child_retry_policy_(IgnoreRetryPolicy::policy()) // Used for counting retry
-      , child_retry_policy_(DefaultRetryPolicy())
+      , child_retry_policy_(IgnoreRetryPolicy()) // Used for counting retry
       , logging_retry_policy_(child_retry_policy_)
       , skip_base_execution_profile_(false) {
     // LWTs do not work with tablets.
@@ -632,7 +631,7 @@ CASSANDRA_INTEGRATION_TEST_F(ExecutionProfileTest, RetryPolicy) {
   CHECK_FAILURE;
 
   // Create a logger criteria for retry policy validation
-  logger_.add_critera("Ignoring unavailable error");
+  logger_.add_critera("Ignoring write error");
 
   // Execute a simple query without assigned profile
   Statement statement(default_select_all());

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -27,8 +27,7 @@ public:
       : insert_(NULL)
       //, child_retry_policy_(IgnoreRetryPolicy::policy()) // Used for counting retry
       , child_retry_policy_(DefaultRetryPolicy())
-      // We do not implement logging retry policy in cpp-rust-driver
-      // , logging_retry_policy_(child_retry_policy_)
+      , logging_retry_policy_(child_retry_policy_)
       , skip_base_execution_profile_(false) {
     // LWTs do not work with tablets.
     disable_tablets_ = true;
@@ -62,8 +61,7 @@ public:
                                    .with_whitelist_filtering(Options::host_prefix() + "1")
                                    .with_load_balance_round_robin();
       profiles_["retry_policy"] = ExecutionProfile::build()
-      // We do not implement logging retry policy in cpp-rust-driver
-                                      .with_retry_policy(child_retry_policy_)
+                                      .with_retry_policy(logging_retry_policy_)
                                       .with_consistency(CASS_CONSISTENCY_THREE);
       profiles_["speculative_execution"] =
           ExecutionProfile::build().with_constant_speculative_execution_policy(100, 20);
@@ -104,8 +102,8 @@ protected:
   /**
    * Logging retry policy for 'retry_policy' execution profile
    */
-  // We do not implement logging retry policy in cpp-rust-driver
-  // LoggingRetryPolicy logging_retry_policy_;
+  LoggingRetryPolicy logging_retry_policy_;
+
   /**
    * Flag to determine if base execution profiles should be built or not
    */


### PR DESCRIPTION
The logging retry policy is used in tests in order to observe and verify retry decisions.
Therefore, implementing it allows us enable more integration tests.

As the semantics of retry policy differ between C++ driver and Rust driver, the logs are a bit different, so the tests need to be adjusted.
- C++:
```c++
// On request error
    LOG_INFO("Retrying on request error at consistency %s (initial consistency: %s, error: %s, "
               "retries: %d)",

    LOG_INFO("Ignoring request error (initial consistency: %s, error: %s, retries: %d)",
               cass_consistency_string(cl), error->message().to_string().c_str(), num_retries);

// On unavailable
    LOG_INFO("Retrying on unavailable error at consistency %s (initial consistency: %s, required "
               "replica: %d, alive replica: %d, retries: %d)",
               cass_consistency_string(decision.retry_consistency()), cass_consistency_string(cl),
               required, alive, num_retries);

    LOG_INFO("Ignoring unavailable error (initial consistency: %s, required replica: %d, alive "
               "replica: %d, retries: %d)",
               cass_consistency_string(cl), required, alive, num_retries);

// On write timeout
    LOG_INFO("Retrying on write timeout at consistency %s (initial consistency: %s, required "
               "acknowledgments: %d, received acknowledgments: %d, write type: %s, retries: %d)",
               cass_consistency_string(decision.retry_consistency()), cass_consistency_string(cl),
               required, received, cass_write_type_string(write_type), num_retries);

    LOG_INFO("Ignoring write timeout (initial consistency: %s, required acknowledgments: %d, "
               "received acknowledgments: %d, write type: %s, retries: %d)",
               cass_consistency_string(cl), required, received, cass_write_type_string(write_type),
               num_retries);

// On read timeout
     LOG_INFO("Retrying on read timeout at consistency %s (initial consistency: %s, required "
               "responses: %d, received responses: %d, data retrieved: %s, retries: %d)",
               cass_consistency_string(decision.retry_consistency()), cass_consistency_string(cl),
               required, received, data_recevied ? "true" : "false", num_retries);
     
     LOG_INFO("Ignoring read timeout (initial consistency: %s, required responses: %d, received "
               "responses: %d, data retrieved: %s, retries: %d)",
               cass_consistency_string(cl), required, received, data_recevied ? "true" : "false",
               num_retries);
```

- CPP-Rust (based on Rust driver's semantics):
```rust
match &decision {
      RetryDecision::RetrySameTarget(consistency) => tracing::info!(
          "Retrying on the same target; Error: {}; Initial Consistency: {:?}; New Consistency: {:?}",
          error,
          initial_consistency,
          consistency
      ),
      RetryDecision::RetryNextTarget(consistency) => tracing::info!(
          "Retrying on the next target; Error: {}; Initial Consistency: {:?}; New Consistency: {:?}",
          error,
          initial_consistency,
          consistency
      ),
      RetryDecision::IgnoreWriteError => {
          tracing::info!("Ignoring write error; Error: {}", error)
      }
```


Fixes: https://github.com/scylladb/cpp-rust-driver/issues/260
Ref: #132 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- [x] I have enabled appropriate tests in `Makefile` in `gtest_filter`.