### PR TITLE
Compile `integration_testing.rs` conditionally

### DIFF
--- a/scylla-rust-wrapper/CMakeLists.txt
+++ b/scylla-rust-wrapper/CMakeLists.txt
@@ -27,6 +27,10 @@ else()
   set(CMAKE_Rust_FLAGS "--cfg cpp_rust_unstable")
 endif()
 
+if(CASS_BUILD_INTEGRATION_TESTS)
+  set(CMAKE_Rust_FLAGS "${CMAKE_Rust_FLAGS} --cfg cpp_integration_testing")
+endif()
+
 if(APPLE)
   set(INSTALL_NAME_SHARED "libscylla-cpp-driver.${PROJECT_VERSION_STRING}.dylib")
   set(INSTALL_NAME_SHARED_SYMLINK_VERSION "libscylla-cpp-driver.${PROJECT_VERSION_MAJOR}.dylib")

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -60,3 +60,6 @@ strip = "none"
 
 [lints.rust]
 unsafe-op-in-unsafe-fn = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(cpp_integration_testing)',
+] }

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -11,7 +11,6 @@ use crate::uuid::CassUuid;
 use openssl::ssl::SslContextBuilder;
 use openssl_sys::SSL_CTX_up_ref;
 use scylla::client::execution_profile::ExecutionProfileBuilder;
-use scylla::client::session::SessionConfig;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::client::{SelfIdentity, WriteCoalescingDelay};
 use scylla::frame::Compression;
@@ -161,7 +160,16 @@ impl CassCluster {
     }
 
     #[inline]
-    pub(crate) fn get_session_config(&self) -> &SessionConfig {
+    pub(crate) fn get_client_id(&self) -> Option<uuid::Uuid> {
+        self.client_id
+    }
+}
+
+// Utilities for integration testing
+#[cfg(cpp_integration_testing)]
+impl CassCluster {
+    #[inline]
+    pub(crate) fn get_session_config(&self) -> &scylla::client::session::SessionConfig {
         &self.session_builder.config
     }
 
@@ -173,11 +181,6 @@ impl CassCluster {
     #[inline]
     pub(crate) fn get_contact_points(&self) -> &[String] {
         &self.contact_points
-    }
-
-    #[inline]
-    pub(crate) fn get_client_id(&self) -> Option<uuid::Uuid> {
-        self.client_id
     }
 }
 

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -21,6 +21,7 @@ pub mod execution_error;
 mod external;
 pub mod future;
 pub mod inet;
+#[cfg(cpp_integration_testing)]
 pub mod integration_testing;
 pub mod iterator;
 mod logging;


### PR DESCRIPTION
Fixes: https://github.com/scylladb/cpp-rust-driver/issues/285

After the change we have:

```bash
$ cmake .. && make -j 8
...
$ objdump -TC libscylla-cpp-driver.so | grep testing_ 
<empty output>
```

```bash
$ cmake -DCASS_BUILD_INTEGRATION_TESTS=ON .. && make -j 8
...
$ objdump -TC libscylla-cpp-driver.so | grep testing_
00000000000eed40 g    DF .text	000000000000005e  Base        testing_cluster_get_connect_timeout
00000000000eeda0 g    DF .text	0000000000000052  Base        testing_cluster_get_port
00000000000eee00 g    DF .text	00000000000002b8  Base        testing_cluster_get_contact_points
00000000000ef0c0 g    DF .text	0000000000000026  Base        testing_free_contact_points
00000000000ef190 g    DF .text	00000000000000ee  Base        testing_statement_set_sleeping_history_listener
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~