### PR TITLE
CassConsistency: adjust converion to serial variants of Consistency

### DIFF
--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -845,6 +845,8 @@ impl TryFrom<CassConsistency> for Consistency {
             CassConsistency::CASS_CONSISTENCY_LOCAL_QUORUM => Ok(Consistency::LocalQuorum),
             CassConsistency::CASS_CONSISTENCY_EACH_QUORUM => Ok(Consistency::EachQuorum),
             CassConsistency::CASS_CONSISTENCY_LOCAL_ONE => Ok(Consistency::LocalOne),
+            CassConsistency::CASS_CONSISTENCY_LOCAL_SERIAL => Ok(Consistency::LocalSerial),
+            CassConsistency::CASS_CONSISTENCY_SERIAL => Ok(Consistency::Serial),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
According to the comment in rust-driver:
```
// Apparently, Consistency can be set to Serial or LocalSerial in SELECT statements 
// to make them use Paxos.
```

As @wprzytula noticed here: https://github.com/scylladb/cpp-rust-driver/pull/199#discussion_r1865021804, this is a bug fix.

The other reason I want to have this merged quickly, is because I need it for one of the `ExecutionProfile` integration tests. I'll enable the test in a separate PR where I adjust some of the remaning tests from this suite.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.