### PR TITLE
Adjust and enable 5 out of 11 ExecutionProfile integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_InvalidName\
 :ExecutionProfileTest.Integration_Cassandra_RequestTimeout\
 :ExecutionProfileTest.Integration_Cassandra_Consistency\
+:ExecutionProfileTest.Integration_Cassandra_SerialConsistency\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
@@ -75,6 +76,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_InvalidName\
 :ExecutionProfileTest.Integration_Cassandra_RequestTimeout\
 :ExecutionProfileTest.Integration_Cassandra_Consistency\
+:ExecutionProfileTest.Integration_Cassandra_SerialConsistency\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
 :ExecutionProfileTest.Integration_Cassandra_InvalidName\
 :ExecutionProfileTest.Integration_Cassandra_RequestTimeout\
+:ExecutionProfileTest.Integration_Cassandra_Consistency\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
@@ -73,6 +74,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
 :ExecutionProfileTest.Integration_Cassandra_InvalidName\
 :ExecutionProfileTest.Integration_Cassandra_RequestTimeout\
+:ExecutionProfileTest.Integration_Cassandra_Consistency\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_RequestTimeout\
 :ExecutionProfileTest.Integration_Cassandra_Consistency\
 :ExecutionProfileTest.Integration_Cassandra_SerialConsistency\
+:ExecutionProfileTest.Integration_Cassandra_LatencyAwareRouting\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
@@ -77,6 +78,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_RequestTimeout\
 :ExecutionProfileTest.Integration_Cassandra_Consistency\
 :ExecutionProfileTest.Integration_Cassandra_SerialConsistency\
+:ExecutionProfileTest.Integration_Cassandra_LatencyAwareRouting\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
+:ExecutionProfileTest.Integration_Cassandra_InvalidName\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
 :ControlConnectionTests.Integration_Cassandra_FullOutage\
 :ControlConnectionTests.Integration_Cassandra_TerminatedUsingMultipleIoThreadsWithError\
-:ExecutionProfileTest.InvalidName\
 :*NoCompactEnabledConnection\
 :PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount\
 :UseKeyspaceCaseSensitiveTests.Integration_Cassandra_ConnectWithKeyspace)
@@ -70,6 +70,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
+:ExecutionProfileTest.Integration_Cassandra_InvalidName\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
@@ -77,7 +78,6 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ControlConnectionTests.Integration_Cassandra_FullOutage\
 :ControlConnectionTests.Integration_Cassandra_TerminatedUsingMultipleIoThreadsWithError\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
-:ExecutionProfileTest.InvalidName\
 :*NoCompactEnabledConnection\
 :PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount\
 :UseKeyspaceCaseSensitiveTests.Integration_Cassandra_ConnectWithKeyspace)

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
 :ExecutionProfileTest.Integration_Cassandra_InvalidName\
+:ExecutionProfileTest.Integration_Cassandra_RequestTimeout\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
@@ -71,6 +72,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
 :ExecutionProfileTest.Integration_Cassandra_InvalidName\
+:ExecutionProfileTest.Integration_Cassandra_RequestTimeout\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -102,4 +102,8 @@ void set_sleeping_history_listener_on_statement(CassStatement* statement, uint64
   testing_statement_set_sleeping_history_listener(statement, sleep_time_ms);
 }
 
+void set_sleeping_history_listener_on_batch(CassBatch* batch, uint64_t sleep_time_ms) {
+  testing_batch_set_sleeping_history_listener(batch, sleep_time_ms);
+}
+
 }}} // namespace datastax::internal::testing

--- a/src/testing.hpp
+++ b/src/testing.hpp
@@ -52,6 +52,8 @@ CASS_EXPORT void set_record_attempted_hosts(CassStatement* statement, bool enabl
 
 CASS_EXPORT void set_sleeping_history_listener_on_statement(CassStatement* statement, uint64_t sleep_time_ms);
 
+CASS_EXPORT void set_sleeping_history_listener_on_batch(CassBatch* batch, uint64_t sleep_time_ms);
+
 }}} // namespace datastax::internal::testing
 
 #endif

--- a/src/testing_rust_impls.h
+++ b/src/testing_rust_impls.h
@@ -26,6 +26,11 @@ CASS_EXPORT void testing_free_contact_points(char* contact_points);
 // This can be used to enforce a sleep time during statement execution, which increases the latency.
 CASS_EXPORT void testing_statement_set_sleeping_history_listener(CassStatement *statement,
                                                                  cass_uint64_t sleep_time_ms);
+
+// Sets a sleeping history listener on the batch.
+// This can be used to enforce a sleep time during batch execution, which increases the latency.
+CASS_EXPORT void testing_batch_set_sleeping_history_listener(CassBatch *batch,
+    cass_uint64_t sleep_time_ms);
 }
 
 #endif

--- a/tests/src/integration/objects/statement.hpp
+++ b/tests/src/integration/objects/statement.hpp
@@ -366,6 +366,16 @@ public:
   }
 
   /**
+   * Set a sleeping history listener on the batch.
+   * This can be used to enforce a sleep time during batch execution, which increases the latency.
+   *
+   * @param sleep_time_ms Sleep time in milliseconds
+   */
+  void set_sleep_time(uint64_t sleep_time_ms) {
+    datastax::internal::testing::set_sleeping_history_listener_on_batch(get(), sleep_time_ms);
+  }
+
+  /**
    * Enable/Disable whether the statements in a batch are idempotent. Idempotent
    * batches are able to be automatically retried after timeouts/errors and can
    * be speculatively executed.

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -444,7 +444,7 @@ CASSANDRA_INTEGRATION_TEST_F(ExecutionProfileTest, LatencyAwareRouting) {
   CHECK_FAILURE;
 
   // Execute batch with the assigned profile and add criteria for the logger
-  logger_.add_critera("Calculated new minimum");
+  logger_.add_critera("Latency awareness: updated min average latency to");
   for (int i = 0; i < 1000; ++i) {
     Batch batch;
     batch.add(insert_);

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -42,9 +42,9 @@ public:
     // Create the execution profiles for the test cases
     if (!skip_base_execution_profile_) {
       profiles_["request_timeout"] = ExecutionProfile::build().with_request_timeout(1);
-      // Setting bad consistency type for exec profile is forbidden in cpp-rust-driver
-      // profiles_["consistency"] =
-      //     ExecutionProfile::build().with_consistency(CASS_CONSISTENCY_SERIAL);
+      profiles_["consistency"] =
+          ExecutionProfile::build().with_consistency(CASS_CONSISTENCY_SERIAL);
+      // Setting bad serial-consistency type for exec profile is forbidden in cpp-rust-driver
       // profiles_["serial_consistency"] =
       //     ExecutionProfile::build().with_serial_consistency(CASS_CONSISTENCY_ONE);
       profiles_["round_robin"] =
@@ -317,7 +317,7 @@ CASSANDRA_INTEGRATION_TEST_F(ExecutionProfileTest, Consistency) {
     cass_version = static_cast<CCM::DseVersion>(cass_version).get_cass_version();
   }
   std::string expected_message = "SERIAL is not supported as conditional update commit consistency";
-  if (cass_version >= "4.0.0") {
+  if (!Options::is_scylla() && cass_version >= "4.0.0") {
     expected_message = "You must use conditional updates for serializable writes";
   }
   ASSERT_TRUE(contains(result.error_message(), expected_message));

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -274,11 +274,13 @@ CASSANDRA_INTEGRATION_TEST_F(ExecutionProfileTest, RequestTimeout) {
   Batch batch;
   batch.add(statement);
   batch.set_execution_profile("request_timeout");
+  batch.set_sleep_time(2); // Simulate >=2ms latency
   result = session_.execute(batch, false);
   ASSERT_EQ(CASS_ERROR_LIB_REQUEST_TIMED_OUT, result.error_code());
 
   // Execute a simple query with assigned profile (should timeout)
   statement.set_execution_profile("request_timeout");
+  statement.set_sleep_time(2); // Simulate >=2ms latency
   result = session_.execute(statement, false);
   ASSERT_EQ(CASS_ERROR_LIB_REQUEST_TIMED_OUT, result.error_code());
 }


### PR DESCRIPTION
Ref: #132 

Enabled tests:
- `InvalidName`
- `RequestTimeout`
- `Consistency`
- `SerialConsistency`
- `LatencyAwareRouting`

Tests that we could not enable (yet):
- `RetryPolicy` <- this one requires to implement `cass_retry_policy_logging_new`
- `RoundRobin` <- requires `cass_future_coordinator`
- `TokenAwareRouting` <- currently requires `cass_statement_set_key_index` and `cass_statement_set_keyspace`. These are not going to be supported by rust-driver (most probably). I'll need to investigate if the test could be rewritten using prepared statements. If so, this will be a part of separate PR.
- `BlacklistFiltering` <- requires `cass_[cluster/execution_profile]_set_blacklist_filtering`
- `WhitelistFiltering` <- `cass_[cluster/execution_profile]_set_whitelist_filtering`
- `SpeculativeExecutionPolicy` <- it throws some error related to UDFs. Need to be investigated. However, it also requires a testing utility to get all of the attempted hosts from the result. This could be probably implemented using `HistoryListener`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.