### PR TITLE
integration: use NTS by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :BatchSingleNodeClusterTests*:BatchCounterSingleNodeClusterTests*:BatchCounterThreeNodeClusterTests*\
 :ErrorTests.*\
 :SslNoClusterTests*:SslNoSslOnClusterTests*\
-:SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator:SchemaMetadataTest.*View*\
+:SchemaMetadataTest.*\
 :TracingTests.*\
 :ByNameTests.*\
 :CompressionTests.*\
@@ -37,6 +37,8 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_SerialConsistency\
 :ExecutionProfileTest.Integration_Cassandra_LatencyAwareRouting\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
+:SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\
+:SchemaMetadataTest.Integration_Cassandra_VirtualMetadata\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
 :ControlConnectionTests.Integration_Cassandra_FullOutage\
@@ -68,7 +70,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ControlConnectionTests.*\
 :ErrorTests.*\
 :SslClientAuthenticationTests*:SslNoClusterTests*:SslNoSslOnClusterTests*:SslTests*\
-:SchemaMetadataTest.*KeyspaceMetadata:SchemaMetadataTest.*MetadataIterator:SchemaMetadataTest.*View*\
+:SchemaMetadataTest.*\
 :TracingTests.*\
 :ByNameTests.*\
 :CompressionTests.*\
@@ -89,6 +91,8 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_LatencyAwareRouting\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
+:SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\
+:SchemaMetadataTest.Integration_Cassandra_VirtualMetadata\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
 :ControlConnectionTests.Integration_Cassandra_FullOutage\

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SPACE := ${EMPTY} ${EMPTY}
 ifndef SCYLLA_TEST_FILTER
 SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :BasicsTests.*\
+:BasicsNoTabletsTests.*\
 :ConfigTests.*\
 :NullStringApiArgsTest.*\
 :ConsistencyTwoNodeClusterTests.*\
@@ -58,6 +59,7 @@ endif
 ifndef CASSANDRA_TEST_FILTER
 CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :BasicsTests.*\
+:BasicsNoTabletsTests.*\
 :ConfigTests.*\
 :NullStringApiArgsTest.*\
 :ConsistencyTwoNodeClusterTests.*\

--- a/tests/src/integration/integration.cpp
+++ b/tests/src/integration/integration.cpp
@@ -268,7 +268,7 @@ std::string Integration::default_replication_strategy() {
     replication_strategy_s << "'NetworkTopologyStrategy', 'dc1': " << number_dc1_nodes_ << ", "
                            << "'dc2': " << number_dc2_nodes_;
   } else {
-    replication_strategy_s << "'SimpleStrategy', 'replication_factor': ";
+    replication_strategy_s << "'NetworkTopologyStrategy', 'dc1': ";
 
     // Ensure the replication factor has not been overridden or already set
     if (replication_factor_ == 0) {

--- a/tests/src/integration/integration.hpp
+++ b/tests/src/integration/integration.hpp
@@ -309,6 +309,12 @@ protected:
    * (DEFAULT: true)
    */
   bool is_beta_protocol_;
+  /** Flag to indicate if tablets should be disabled for Scylla keyspace.
+   * There are some cases where the test logic will fail for tablets keyspace
+   * (e.g. when test uses LWT statements).
+   * (DEFAULT: false)
+   */
+  bool disable_tablets_;
   /**
    * Workload to apply to the cluster
    */
@@ -507,6 +513,14 @@ protected:
    * @return Comma delimited IP address (e.g. contact points)
    */
   std::string generate_contact_points(const std::string& ip_prefix, size_t number_of_nodes);
+
+  /**
+   * Check if Scylla supports a specific feature.
+   *
+   * @param feature Feature to check if supported by Scylla
+   * @return True if Scylla supports the feature; false otherwise
+   */
+  bool scylla_supports_feature(const std::string& feature);
 
   /**
    * Variable argument string formatter

--- a/tests/src/integration/tests/test_async.cpp
+++ b/tests/src/integration/tests/test_async.cpp
@@ -23,6 +23,8 @@
  */
 class AsyncTests : public Integration {
 public:
+  AsyncTests() { disable_tablets_ = true; }
+
   void SetUp() {
     // Call the parent setup function
     Integration::SetUp();

--- a/tests/src/integration/tests/test_basics.cpp
+++ b/tests/src/integration/tests/test_basics.cpp
@@ -21,6 +21,11 @@
  */
 class BasicsTests : public Integration {};
 
+class BasicsNoTabletsTests : public BasicsTests {
+ public:
+  BasicsNoTabletsTests() { disable_tablets_ = true; }
+};
+
 /**
  * Perform inserts and validate the timestamps from the server
  *
@@ -81,7 +86,7 @@ CASSANDRA_INTEGRATION_TEST_F(BasicsTests, Timestamps) {
  * @since core:1.0.0
  * @expected_result Cassandra values are inserted and counters are validated
  */
-CASSANDRA_INTEGRATION_TEST_F(BasicsTests, Counters) {
+CASSANDRA_INTEGRATION_TEST_F(BasicsNoTabletsTests, Counters) {
   CHECK_FAILURE;
 
   // Create the table and update/upsert queries for the test

--- a/tests/src/integration/tests/test_batch.cpp
+++ b/tests/src/integration/tests/test_batch.cpp
@@ -105,7 +105,11 @@ protected:
  */
 class BatchCounterSingleNodeClusterTests : public BatchSingleNodeClusterTests {
 public:
-  BatchCounterSingleNodeClusterTests() { value_cql_data_type_ = "counter"; }
+  BatchCounterSingleNodeClusterTests() {
+    value_cql_data_type_ = "counter";
+    // Counter type is not supported with tablets.
+    disable_tablets_ = true;
+  }
 
   /**
    * Validate the result for the text data type

--- a/tests/src/integration/tests/test_consistency.cpp
+++ b/tests/src/integration/tests/test_consistency.cpp
@@ -67,7 +67,11 @@ public:
  */
 class SerialConsistencyTests : public Integration {
 public:
-  SerialConsistencyTests() { number_dc1_nodes_ = 1; }
+  SerialConsistencyTests() {
+    number_dc1_nodes_ = 1;
+    // LWTs do not work with tablets.
+    disable_tablets_ = true;
+  }
 
   virtual void SetUp() {
     // Call the parent setup function

--- a/tests/src/integration/tests/test_consistency.cpp
+++ b/tests/src/integration/tests/test_consistency.cpp
@@ -244,18 +244,18 @@ CASSANDRA_INTEGRATION_TEST_F(ConsistencyTwoNodeClusterTests, SimpleEachQuorum) {
 
 /**
  * Perform multiple inserts and selects using different consistencies against a
- * cluster with a single decommissioned node
+ * cluster with a single stopped node
  *
  * This test will perform insert and select operations using a simple statement
  * while validating the operation were successful or failed against a three
- * three node cluster with a decommissioned node.
+ * three node cluster with a stopped node.
  *
  * @test_category consistency
  * @since core:1.0.0
  * @expected_result Successful insert and select using multiple consistencies:
  *                  `ALL`, `ONE`, `TWO`, and `QUORUM`
  *                  Failed insert and select using multiple consistencies:
- *                  `ALL` (after decommission) and `THREE`
+ *                  `ALL` (after stopping) and `THREE`
  */
 CASSANDRA_INTEGRATION_TEST_F(ConsistencyThreeNodeClusterTests, OneNodeDecommissioned) {
   CHECK_FAILURE;
@@ -266,8 +266,8 @@ CASSANDRA_INTEGRATION_TEST_F(ConsistencyThreeNodeClusterTests, OneNodeDecommissi
   session_.execute(insert_);
   session_.execute(select_);
 
-  // Decommission node two
-  decommission_node(2);
+  // Stop node two
+  stop_node(2);
 
   // Perform a check using consistency `QUORUM` (N=2, RF=3)
   insert_.set_consistency(CASS_CONSISTENCY_QUORUM);
@@ -302,18 +302,18 @@ CASSANDRA_INTEGRATION_TEST_F(ConsistencyThreeNodeClusterTests, OneNodeDecommissi
 
 /**
  * Perform multiple inserts and selects using different consistencies against a
- * cluster with a two decommissioned nodes
+ * cluster with two stopped nodes
  *
  * This test will perform insert and select operations using a simple statement
  * while validating the operation were successful or failed against a three
- * node cluster with two decommissioned nodes.
+ * node cluster with two stopped nodes.
  *
  * @test_category consistency
  * @since core:1.0.0
  * @expected_result Successful insert and select using multiple consistencies:
  *                  `ALL`, and `ONE`
  *                  Failed insert and select using multiple consistencies:
- *                  `ALL` (after decommission), `QUORUM`, `TWO`, and `THREE`
+ *                  `ALL` (after stopped), `QUORUM`, `TWO`, and `THREE`
  */
 CASSANDRA_INTEGRATION_TEST_F(ConsistencyThreeNodeClusterTests, TwoNodesDecommissioned) {
   CHECK_FAILURE;
@@ -324,9 +324,9 @@ CASSANDRA_INTEGRATION_TEST_F(ConsistencyThreeNodeClusterTests, TwoNodesDecommiss
   session_.execute(insert_);
   session_.execute(select_);
 
-  // Decommission node two and three
-  decommission_node(2);
-  decommission_node(3);
+  // Stop node two and three
+  stop_node(2);
+  stop_node(3);
 
   // Perform a check using consistency `ONE` (N=1, RF=3)
   insert_.set_consistency(CASS_CONSISTENCY_ONE);

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -30,6 +30,8 @@ public:
       // We do not implement logging retry policy in cpp-rust-driver
       // , logging_retry_policy_(child_retry_policy_)
       , skip_base_execution_profile_(false) {
+    // LWTs do not work with tablets.
+    disable_tablets_ = true;
     replication_factor_ = 2;
     number_dc1_nodes_ = 2;
     is_beta_protocol_ = false; // Issue with beta protocol v5 and functions on Cassandra v3.10.0+

--- a/tests/src/integration/tests/test_schema_metadata.cpp
+++ b/tests/src/integration/tests/test_schema_metadata.cpp
@@ -22,7 +22,11 @@
 
 class SchemaMetadataTest : public Integration {
 public:
-  SchemaMetadataTest() { is_schema_metadata_ = true; }
+  SchemaMetadataTest() { 
+    is_schema_metadata_ = true;
+    // Materialized views do not work with tablets.
+    disable_tablets_ = true;
+  }
 
   void SetUp() {
     SKIP_IF_CASSANDRA_VERSION_LT(2.2.0);


### PR DESCRIPTION
For the tests with single DC clusters, we would always use `SimpleStrategy`. This PR addresses this, and changes it so we use `NetworkTopologyStrategy` for Scylla clusters. For Cassandra clusters, we will still use `SimpleStrategy` - it's because Cassandra `3.11.19` (the version we currently test against) does not allow `replication_factor` option with NTS.

For `SimpleStrategy` keyspaces, Scylla disables the tablets by default. When we transition to NTS, some tests start to fail - it is expected - some features are currently not working with tablets. In this PR, we disable the tablets for tests which:
1. use counters
2. use LWTs
3. use materialized views
4. try to decomission a node (`ccm` decomission seems to fail for nodes with tablets keyspaces - the exact error is included in corresponding commit's message).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.