### PR TITLE
Null pointer provided to `cass_cluster_set_contact_points` should clear the list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
+:DisconnectedNullStringApiArgsTest.Integration_Cassandra_SetContactPoints\
+:DisconnectedNullStringApiArgsTest.Integration_Cassandra_ConnectKeyspaceNullKeyspace\
 :ExecutionProfileTest.Integration_Cassandra_InvalidName\
 :ExecutionProfileTest.Integration_Cassandra_RequestTimeout\
 :ExecutionProfileTest.Integration_Cassandra_Consistency\
@@ -74,6 +76,8 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
+:DisconnectedNullStringApiArgsTest.Integration_Cassandra_SetContactPoints\
+:DisconnectedNullStringApiArgsTest.Integration_Cassandra_ConnectKeyspaceNullKeyspace\
 :ExecutionProfileTest.Integration_Cassandra_InvalidName\
 :ExecutionProfileTest.Integration_Cassandra_RequestTimeout\
 :ExecutionProfileTest.Integration_Cassandra_Consistency\


### PR DESCRIPTION
Ref: #132 

As PR title says - currently we throw an error if user provides null pointer. Because of that, one integration was disabled.

## Helper method
Notice that `update_comma_delimited_list` is a `set_filtering()` function from https://github.com/scylladb/cpp-rust-driver/pull/291/commits/d79cbe768a5849270b34f94643a5195818c5f568. It can be reused for whitelist/blacklist filtering config as well.

## Integration tests
I enabled 2 out of 6 `DisconnectedNullStringApiArgsTests` tests:
- SetContactPoints
- ConnectKeyspaceNullKeyspace

Both of these check whether the driver behaves as expected when null string is provided. Remaining tests will be enabled as a part of https://github.com/scylladb/cpp-rust-driver/pull/291

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.