### PR TITLE
Implement timestamp generators and enable 4 out of 5 TimestampTests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
 :ServerSideFailureTests.*\
+:TimestampTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
@@ -38,6 +39,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_LatencyAwareRouting\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
+:TimestampTests.Integration_Cassandra_MonotonicTimestampGenerator\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
 :ControlConnectionTests.Integration_Cassandra_FullOutage\
 :ControlConnectionTests.Integration_Cassandra_TerminatedUsingMultipleIoThreadsWithError\
@@ -77,6 +79,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
 :ServerSideFailureTests.*\
+:TimestampTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
@@ -90,6 +93,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
+:TimestampTests.Integration_Cassandra_MonotonicTimestampGenerator\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
 :ControlConnectionTests.Integration_Cassandra_FullOutage\
 :ControlConnectionTests.Integration_Cassandra_TerminatedUsingMultipleIoThreadsWithError\

--- a/README.md
+++ b/README.md
@@ -174,25 +174,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
             <td>Unimplemented because of the same reasons as binding for statements.<br> <b>Note</b>: The driver does not check whether the type of the value being set for a field of the UDT is compatible with the field's actual type.</td>
         </tr>
         <tr>
-            <td colspan=2 align="center" style="font-weight:bold">Timestamp generators</td>
-        </tr>
-        <tr>
-            <td>cass_timestamp_gen_server_side_new</td>
-            <td rowspan="5">Timestamp generator is not implemented in the Rust driver.</td>
-        </tr>
-        <tr>
-            <td>cass_timestamp_gen_monotonic_new</td>
-        </tr>
-        <tr>
-            <td>cass_timestamp_gen_monotonic_new_with_settings</td>
-        </tr>
-        <tr>
-            <td>cass_timestamp_gen_free</td>
-        </tr>
-        <tr>
-            <td>cass_cluster_set_timestamp_gen</td>
-        </tr>
-        <tr>
             <td colspan=2 align="center" style="font-weight:bold">Metadata</td>
         </tr>
         <tr>

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -37,6 +37,7 @@ pub mod ssl;
 pub mod statement;
 #[cfg(test)]
 pub mod testing;
+pub mod timestamp_generator;
 pub mod tuple;
 pub mod user_type;
 pub mod uuid;

--- a/scylla-rust-wrapper/src/timestamp_generator.rs
+++ b/scylla-rust-wrapper/src/timestamp_generator.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use scylla::policies::timestamp_generator::MonotonicTimestampGenerator;
+
+use crate::argconv::{BoxFFI, CMut, CassOwnedExclusivePtr, FFI, FromBox};
+
+pub enum CassTimestampGen {
+    ServerSide,
+    Monotonic(Arc<MonotonicTimestampGenerator>),
+}
+
+impl FFI for CassTimestampGen {
+    type Origin = FromBox;
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cass_timestamp_gen_server_side_new()
+-> CassOwnedExclusivePtr<CassTimestampGen, CMut> {
+    BoxFFI::into_ptr(Box::new(CassTimestampGen::ServerSide))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cass_timestamp_gen_monotonic_new()
+-> CassOwnedExclusivePtr<CassTimestampGen, CMut> {
+    BoxFFI::into_ptr(Box::new(CassTimestampGen::Monotonic(Arc::new(
+        // Generator with default settings (warning_threshold=1s, warning_interval=1s)
+        MonotonicTimestampGenerator::new(),
+    ))))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cass_timestamp_gen_monotonic_new_with_settings(
+    warning_threshold_us: i64,
+    warning_interval_ms: i64,
+) -> CassOwnedExclusivePtr<CassTimestampGen, CMut> {
+    let generator = if warning_threshold_us <= 0 {
+        // If threshold is <= 0, we disable the warnings.
+        MonotonicTimestampGenerator::new().without_warnings()
+    } else {
+        let warning_threshold = Duration::from_micros(warning_threshold_us as u64);
+        let warning_interval = if warning_interval_ms <= 0 {
+            // Inverval <= 0 fallbacks to 1ms.
+            Duration::from_millis(1)
+        } else {
+            Duration::from_millis(warning_interval_ms as u64)
+        };
+
+        MonotonicTimestampGenerator::new().with_warning_times(warning_threshold, warning_interval)
+    };
+
+    BoxFFI::into_ptr(Box::new(CassTimestampGen::Monotonic(Arc::new(generator))))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cass_timestamp_gen_free(
+    timestamp_gen_raw: CassOwnedExclusivePtr<CassTimestampGen, CMut>,
+) {
+    BoxFFI::free(timestamp_gen_raw)
+}

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -84,10 +84,6 @@ CASS_EXPORT CassError cass_cluster_set_prepare_on_up_or_add_host(CassCluster* cl
                                                                  cass_bool_t enabled) {
   throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_prepare_on_up_or_add_host\n");
 }
-CASS_EXPORT void cass_cluster_set_timestamp_gen(CassCluster* cluster,
-                                                CassTimestampGen* timestamp_gen) {
-  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_timestamp_gen\n");
-}
 CASS_EXPORT void cass_cluster_set_whitelist_dc_filtering(CassCluster* cluster, const char* dcs) {
   throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_whitelist_dc_filtering\n");
 }

--- a/src/timestamp_generator.cpp
+++ b/src/timestamp_generator.cpp
@@ -22,32 +22,6 @@
 
 using namespace datastax::internal::core;
 
-extern "C" {
-
-CassTimestampGen* cass_timestamp_gen_server_side_new() {
-  TimestampGenerator* timestamp_gen = new ServerSideTimestampGenerator();
-  timestamp_gen->inc_ref();
-  return CassTimestampGen::to(timestamp_gen);
-}
-
-CassTimestampGen* cass_timestamp_gen_monotonic_new() {
-  TimestampGenerator* timestamp_gen = new MonotonicTimestampGenerator();
-  timestamp_gen->inc_ref();
-  return CassTimestampGen::to(timestamp_gen);
-}
-
-CassTimestampGen* cass_timestamp_gen_monotonic_new_with_settings(int64_t warning_threshold_us,
-                                                                 int64_t warning_interval_ms) {
-  TimestampGenerator* timestamp_gen =
-      new MonotonicTimestampGenerator(warning_threshold_us, warning_interval_ms);
-  timestamp_gen->inc_ref();
-  return CassTimestampGen::to(timestamp_gen);
-}
-
-void cass_timestamp_gen_free(CassTimestampGen* timestamp_gen) { timestamp_gen->dec_ref(); }
-
-} // extern "C"
-
 int64_t MonotonicTimestampGenerator::next() {
   while (true) {
     int64_t last = last_.load();


### PR DESCRIPTION
Fixes: https://github.com/scylladb/cpp-rust-driver/issues/46
Ref: #132 

This PR implements timestamp methods.

## Enabled integration `TimestampTests`
-  `Statement`
- `BatchStatement`
- `ServerSideTimestampGeneratorStatement`
- `ServerSideTimestampGeneratorBatchStatement`

## Disabled integration test
There is one test that we need to keep disabled (for now). I want to create a separate issue for this. issue: https://github.com/scylladb/cpp-rust-driver/issues/296.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.