### PR TITLE
errors: make EmptyPlan return LIB_NO_HOSTS_AVAILABLE

### DIFF
--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -32,7 +32,7 @@ impl ToCassError for ExecutionError {
         match self {
             ExecutionError::BadQuery(bad_query) => bad_query.to_cass_error(),
             ExecutionError::RequestTimeout(_) => CassError::CASS_ERROR_LIB_REQUEST_TIMED_OUT,
-            ExecutionError::EmptyPlan => CassError::CASS_ERROR_LIB_INVALID_STATE,
+            ExecutionError::EmptyPlan => CassError::CASS_ERROR_LIB_NO_HOSTS_AVAILABLE,
             ExecutionError::MetadataError(e) => e.to_cass_error(),
             ExecutionError::ConnectionPoolError(e) => e.to_cass_error(),
             ExecutionError::PrepareError(e) => e.to_cass_error(),


### PR DESCRIPTION
Cherry-picked from https://github.com/scylladb/cpp-rust-driver/pull/291/commits/22e1c29cdcf2e4c522dcd99f51001ba782b5120d. I want to have this early for enforcing/getting coordinator tests.

As I mentioned before - this error is returned when we for some reason cannot route the request to one of the hosts. I forgot to address this earlier (there was no test case for empty plan). I'll introduce one later in this PR.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.