### PR TITLE
Implement exposing/enforcing coordinator for request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :SerialConsistencyTests.*\
 :HeartbeatTests.*\
 :PreparedTests.*\
+:StatementNoClusterTests.*\
 :NamedParametersTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :ControlConnectionTests.*\
@@ -69,6 +70,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :SerialConsistencyTests.*\
 :HeartbeatTests.*\
 :PreparedTests.*\
+:StatementNoClusterTests.*\
 :NamedParametersTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :ControlConnectionTests.*\

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :HeartbeatTests.*\
 :PreparedTests.*\
 :StatementNoClusterTests.*\
+:StatementTests.*\
 :NamedParametersTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :ControlConnectionTests.*\
@@ -71,6 +72,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :HeartbeatTests.*\
 :PreparedTests.*\
 :StatementNoClusterTests.*\
+:StatementTests.*\
 :NamedParametersTests.*\
 :CassandraTypes/CassandraTypesTests/*.Integration_Cassandra_*\
 :ControlConnectionTests.*\

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
 :ServerSideFailureTests.*\
+:ServerSideFailureThreeNodeTests.*\
 :TimestampTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
@@ -87,6 +88,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :PreparedMetadataTests.*\
 :UseKeyspaceCaseSensitiveTests.*\
 :ServerSideFailureTests.*\
+:ServerSideFailureThreeNodeTests.*\
 :TimestampTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1112,12 +1112,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "1.1.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.1.0#ef5b0ada61989cedf9bcf5d715c8b36214f8b36f"
+version = "1.2.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.2.0#bc6b24da1b17aa4d33df6a0f0283f08937ff1a19"
 dependencies = [
  "arc-swap",
  "async-trait",
- "byteorder",
  "bytes",
  "chrono",
  "dashmap",
@@ -1125,14 +1124,11 @@ dependencies = [
  "hashbrown 0.14.5",
  "histogram",
  "itertools",
- "lazy_static",
- "lz4_flex",
  "openssl",
  "rand 0.9.0",
  "rand_pcg",
  "scylla-cql",
  "smallvec",
- "snap",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -1171,10 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "1.1.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.1.0#ef5b0ada61989cedf9bcf5d715c8b36214f8b36f"
+version = "1.2.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.2.0#bc6b24da1b17aa4d33df6a0f0283f08937ff1a19"
 dependencies = [
- "async-trait",
  "byteorder",
  "bytes",
  "chrono",
@@ -1191,8 +1186,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "1.1.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.1.0#ef5b0ada61989cedf9bcf5d715c8b36214f8b36f"
+version = "1.2.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.2.0#bc6b24da1b17aa4d33df6a0f0283f08937ff1a19"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1202,8 +1197,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-proxy"
-version = "0.0.3"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.1.0#ef5b0ada61989cedf9bcf5d715c8b36214f8b36f"
+version = "0.0.4"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.2.0#bc6b24da1b17aa4d33df6a0f0283f08937ff1a19"
 dependencies = [
  "bigdecimal",
  "byteorder",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.1.0", features = [
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.2.0", features = [
     "openssl-010",
     "metrics",
 ] }
@@ -34,7 +34,7 @@ bindgen = "0.65"
 chrono = "0.4.20"
 
 [dev-dependencies]
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.1.0" }
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.2.0" }
 bytes = "1.10.0"
 
 assert_matches = "1.5.0"

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
 
+#[derive(Debug)]
 pub enum CassResultValue {
     Empty,
     QueryResult(Arc<CassResult>),

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -63,11 +63,6 @@ pub unsafe extern "C" fn testing_cluster_get_contact_points(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn testing_free_contact_points(contact_points: *mut c_char) {
-    let _ = unsafe { CString::from_raw(contact_points) };
-}
-
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn testing_future_get_host(
     future_raw: CassBorrowedSharedPtr<CassFuture, CConst>,
     host: *mut *mut c_char,
@@ -107,8 +102,8 @@ pub unsafe extern "C" fn testing_future_get_host(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn testing_free_host(host: *mut c_char) {
-    let _ = unsafe { CString::from_raw(host) };
+pub unsafe extern "C" fn testing_free_cstring(s: *mut c_char) {
+    let _ = unsafe { CString::from_raw(s) };
 }
 
 #[derive(Debug)]

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -7,9 +7,12 @@ use scylla::errors::{RequestAttemptError, RequestError};
 use scylla::observability::history::{AttemptId, HistoryListener, RequestId, SpeculativeId};
 use scylla::policies::retry::RetryDecision;
 
-use crate::argconv::{BoxFFI, CMut, CassBorrowedExclusivePtr};
+use crate::argconv::{
+    ArcFFI, BoxFFI, CConst, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr,
+};
 use crate::batch::CassBatch;
 use crate::cluster::CassCluster;
+use crate::future::{CassFuture, CassResultValue};
 use crate::statement::{BoundStatement, CassStatement};
 use crate::types::{cass_int32_t, cass_uint16_t, cass_uint64_t, size_t};
 
@@ -62,6 +65,50 @@ pub unsafe extern "C" fn testing_cluster_get_contact_points(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn testing_free_contact_points(contact_points: *mut c_char) {
     let _ = unsafe { CString::from_raw(contact_points) };
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn testing_future_get_host(
+    future_raw: CassBorrowedSharedPtr<CassFuture, CConst>,
+    host: *mut *mut c_char,
+    host_length: *mut size_t,
+) {
+    let Some(future) = ArcFFI::as_ref(future_raw) else {
+        tracing::error!("Provided null future pointer to testing_future_get_host!");
+        unsafe {
+            *host = std::ptr::null_mut();
+            *host_length = 0;
+        };
+        return;
+    };
+
+    future.with_waited_result(|r| match r {
+        Ok(CassResultValue::QueryResult(result)) => {
+            // unwrap: Coordinator is none only for unit tests.
+            let coordinator = result.coordinator.as_ref().unwrap();
+
+            let ip_addr_str = coordinator.node().address.ip().to_string();
+            let length = ip_addr_str.len();
+
+            let ip_addr_cstr = CString::new(ip_addr_str).expect(
+                "String obtained from IpAddr::to_string() should not contain any nul bytes!",
+            );
+
+            unsafe {
+                *host = ip_addr_cstr.into_raw();
+                *host_length = length as size_t
+            };
+        }
+        _ => unsafe {
+            *host = std::ptr::null_mut();
+            *host_length = 0;
+        },
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn testing_free_host(host: *mut c_char) {
+    let _ = unsafe { CString::from_raw(host) };
 }
 
 #[derive(Debug)]

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -46,6 +46,13 @@ pub(crate) struct CassRowsResultSharedData {
     pub(crate) metadata: Arc<CassResultMetadata>,
 }
 
+pub type CassNode = Coordinator;
+
+// Borrowed from CassResult in cass_future_coordinator.
+impl FFI for CassNode {
+    type Origin = FromRef;
+}
+
 pub struct CassResult {
     pub tracing_id: Option<Uuid>,
     pub paging_state_response: PagingStateResponse,

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -29,17 +29,20 @@ use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
 
+#[derive(Debug)]
 pub enum CassResultKind {
     NonRows,
     Rows(CassRowsResult),
 }
 
+#[derive(Debug)]
 pub struct CassRowsResult {
     // Arc: shared with first_row (yoke).
     pub(crate) shared_data: Arc<CassRowsResultSharedData>,
     pub(crate) first_row: Option<RowWithSelfBorrowedResultData>,
 }
 
+#[derive(Debug)]
 pub(crate) struct CassRowsResultSharedData {
     pub(crate) raw_rows: DeserializedMetadataAndRawRows,
     // Arc: shared with CassPrepared
@@ -53,6 +56,7 @@ impl FFI for CassNode {
     type Origin = FromRef;
 }
 
+#[derive(Debug)]
 pub struct CassResult {
     pub tracing_id: Option<Uuid>,
     pub paging_state_response: PagingStateResponse,
@@ -159,6 +163,7 @@ impl<'frame, 'metadata> DeserializeRow<'frame, 'metadata> for CassRawRow<'frame,
 
 /// The lifetime of CassRow is bound to CassResult.
 /// It will be freed, when CassResult is freed.(see #[cass_result_free])
+#[derive(Debug)]
 pub struct CassRow<'result> {
     pub columns: Vec<CassValue<'result>>,
     pub result_metadata: &'result CassResultMetadata,
@@ -230,7 +235,7 @@ mod row_with_self_borrowed_result_data {
 
     /// A simple wrapper over CassRow.
     /// Needed, so we can implement Yokeable for it, instead of implementing it for CassRow.
-    #[derive(Yokeable)]
+    #[derive(Debug, Yokeable)]
     struct CassRowWrapper<'result>(CassRow<'result>);
 
     /// A wrapper over struct which self-borrows the metadata allocated using Arc.
@@ -243,6 +248,7 @@ mod row_with_self_borrowed_result_data {
     ///
     /// This struct is a shared owner of the row bytes and metadata, and self-borrows this data
     /// to the `CassRow` it contains.
+    #[derive(Debug)]
     pub struct RowWithSelfBorrowedResultData(
         Yoke<CassRowWrapper<'static>, Arc<CassRowsResultSharedData>>,
     );
@@ -307,6 +313,7 @@ pub(crate) mod cass_raw_value {
     use scylla::errors::{DeserializationError, TypeCheckError};
     use thiserror::Error;
 
+    #[derive(Debug)]
     pub(crate) struct CassRawValue<'frame, 'metadata> {
         typ: &'metadata ColumnType<'metadata>,
         slice: Option<FrameSlice<'frame>>,
@@ -428,6 +435,7 @@ pub(crate) mod cass_raw_value {
     }
 }
 
+#[derive(Debug)]
 pub struct CassValue<'result> {
     pub(crate) value: CassRawValue<'result, 'result>,
     pub(crate) value_type: &'result Arc<CassDataType>,

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn cass_session_execute(
                     maybe_result_metadata,
                 ) {
                     Ok(result) => Ok(CassResultValue::QueryResult(Arc::new(result))),
-                    Err(e) => Ok(CassResultValue::QueryError(Arc::new(e))),
+                    Err(e) => Ok(CassResultValue::QueryError(e)),
                 }
             }
             Err(err) => Ok(CassResultValue::QueryError(Arc::new(err.into()))),

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -239,10 +239,11 @@ pub unsafe extern "C" fn cass_session_execute_batch(
 
         let query_res = session.batch(&state.batch, &state.bound_values).await;
         match query_res {
-            Ok(_result) => Ok(CassResultValue::QueryResult(Arc::new(CassResult {
+            Ok(result) => Ok(CassResultValue::QueryResult(Arc::new(CassResult {
                 tracing_id: None,
                 paging_state_response: PagingStateResponse::NoMorePages,
                 kind: CassResultKind::NonRows,
+                coordinator: Some(result.request_coordinator().clone()),
             }))),
             Err(err) => Ok(CassResultValue::QueryError(Arc::new(err.into()))),
         }

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -45,7 +45,7 @@ String get_host_from_future(CassFuture* future) {
   OStringStream ss;
   ss << host_str;
 
-  testing_free_host(host);
+  testing_free_cstring(host);
 
   return ss.str();
 }
@@ -74,7 +74,7 @@ String get_contact_points_from_cluster(CassCluster* cluster) {
   OStringStream ss;
   ss << contact_points_str;
 
-  testing_free_contact_points(contact_points);
+  testing_free_cstring(contact_points);
 
   return ss.str();
 }

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -32,7 +32,22 @@ namespace datastax { namespace internal { namespace testing {
 using namespace core;
 
 String get_host_from_future(CassFuture* future) {
-  throw std::runtime_error("Unimplemented 'get_host_from_future'!");
+  char* host;
+  size_t host_length;
+
+  testing_future_get_host(future, &host, &host_length);
+
+  if (host == nullptr) {
+    throw std::runtime_error("CassFuture returned a null host string.");
+  }
+
+  std::string host_str(host, host_length);
+  OStringStream ss;
+  ss << host_str;
+
+  testing_free_host(host);
+
+  return ss.str();
 }
 
 StringVec get_attempted_hosts_from_future(CassFuture* future) {

--- a/src/testing_rust_impls.h
+++ b/src/testing_rust_impls.h
@@ -22,6 +22,15 @@ CASS_EXPORT void testing_cluster_get_contact_points(CassCluster* cluster, char**
 
 CASS_EXPORT void testing_free_contact_points(char* contact_points);
 
+// Returns an ip address of request coordinator.
+//
+// This method fails if the future resolved to some error.
+//
+// On success, it allocates a host string which needs to be then freed wih `testing_free_host`.
+CASS_EXPORT void testing_future_get_host(const CassFuture* future, char** host, size_t* host_length);
+
+CASS_EXPORT void testing_free_host(char* host);
+
 // Sets a sleeping history listener on the statement.
 // This can be used to enforce a sleep time during statement execution, which increases the latency.
 CASS_EXPORT void testing_statement_set_sleeping_history_listener(CassStatement *statement,

--- a/src/testing_rust_impls.h
+++ b/src/testing_rust_impls.h
@@ -16,20 +16,18 @@ CASS_EXPORT cass_int32_t testing_cluster_get_port(CassCluster* cluster);
 // Then, the resulting pointer is set to null.
 //
 // On success, this function allocates a contact points string, which needs to be then
-// freed with `testing_free_contact_points`.
+// freed with `testing_free_cstring`.
 CASS_EXPORT void testing_cluster_get_contact_points(CassCluster* cluster, char** contact_points,
                                                     size_t* contact_points_length);
-
-CASS_EXPORT void testing_free_contact_points(char* contact_points);
 
 // Returns an ip address of request coordinator.
 //
 // This method fails if the future resolved to some error.
 //
-// On success, it allocates a host string which needs to be then freed wih `testing_free_host`.
+// On success, it allocates a host string which needs to be then freed wih `testing_free_cstring`.
 CASS_EXPORT void testing_future_get_host(const CassFuture* future, char** host, size_t* host_length);
 
-CASS_EXPORT void testing_free_host(char* host);
+CASS_EXPORT void testing_free_cstring(char *s);
 
 // Sets a sleeping history listener on the statement.
 // This can be used to enforce a sleep time during statement execution, which increases the latency.

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -162,9 +162,6 @@ CASS_EXPORT const CassDataType*
 cass_function_meta_return_type(const CassFunctionMeta* function_meta) {
   throw std::runtime_error("UNIMPLEMENTED cass_function_meta_return_type\n");
 }
-CASS_EXPORT const CassNode* cass_future_coordinator(CassFuture* future) {
-  throw std::runtime_error("UNIMPLEMENTED cass_future_coordinator\n");
-}
 CASS_EXPORT const CassValue* cass_index_meta_field_by_name(const CassIndexMeta* index_meta,
                                                            const char* name) {
   throw std::runtime_error("UNIMPLEMENTED cass_index_meta_field_by_name\n");
@@ -220,19 +217,8 @@ CASS_EXPORT CassError cass_statement_set_custom_payload(CassStatement* statement
                                                         const CassCustomPayload* payload) {
   throw std::runtime_error("UNIMPLEMENTED cass_statement_set_custom_payload\n");
 }
-CASS_EXPORT CassError cass_statement_set_host(CassStatement* statement, const char* host,
-                                              int port) {
-  throw std::runtime_error("UNIMPLEMENTED cass_statement_set_host\n");
-}
-CASS_EXPORT CassError cass_statement_set_host_inet(CassStatement* statement, const CassInet* host,
-                                                   int port) {
-  throw std::runtime_error("UNIMPLEMENTED cass_statement_set_host_inet\n");
-}
 CASS_EXPORT CassError cass_statement_set_keyspace(CassStatement* statement, const char* keyspace) {
   throw std::runtime_error("UNIMPLEMENTED cass_statement_set_keyspace\n");
-}
-CASS_EXPORT CassError cass_statement_set_node(CassStatement* statement, const CassNode* node) {
-  throw std::runtime_error("UNIMPLEMENTED cass_statement_set_node\n");
 }
 CASS_EXPORT CassClusteringOrder
 cass_table_meta_clustering_key_order(const CassTableMeta* table_meta, size_t index) {


### PR DESCRIPTION
Fixes: https://github.com/scylladb/cpp-rust-driver/issues/249, Fixes: https://github.com/scylladb/cpp-rust-driver/issues/242
Ref: #132 

## Implemented methods:
- `cass_statement_set_host`
- `cass_statement_set_host_n`
- `cass_statement_set_host_inet`
- `cass_statement_set_node`
- `cass_future_coordinator`

## Problems with implementing `cass_future_coordinator`
`cass_future_coordinator` returns `CassNode*` which should be borrowed from `CassFuture` and live as long as underlying `CassResult` lives.

The problem is that `CassResult` is stored under a `Mutex`. This is why the obtained reference of `Coordinator` has very short lifetime - it's the lifetime of acquired `MutexGuard`. But we need to return something with longer lifetime - our safe FFI API (with borrow-checker) starts to complain.

In the commit where I implement `cass_future_coordinator` I `unsafe`ly extend the lifetime of the coordinator. We can do that, because we are guaranteed that returned pointer will be valid as long as `CassFutureResult` is valid (see SAFETY comment in the code).

However, there is a way to omit this unsafe code and represent the `CassFutureResult` immutability guarantees (after the future is resolved) on a type level. Last commit changes `CassFuture` a bit, so the `CassFutureResult` is stored inside `OnceLock`, and not inside `Mutex`. Only then, can we remove the unsafe code responsible for extending the lifetime in `cass_future_coordinator`. This commit serves as a suggestion of one of (probably many) solutions to this problem. If we decide to do that, I'll probably split this commit into multiple commits before merging.

## Integration tests
Enabled 3 test suites: `StatementTests`, `StatementNoClusterTests` and `ServerSideFailureThreeNodeClusterTests` - 11 tests in total! The logic of each test is explained in commit messages.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- [x] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
- [x] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.