### PR TITLE
Don't panic when null pointer is provided - log error and return instead

### DIFF
--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -60,7 +60,11 @@ pub unsafe extern "C" fn cass_batch_set_consistency(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     consistency: CassConsistency,
 ) -> CassError {
-    let batch = BoxFFI::as_mut_ref(batch).unwrap();
+    let Some(batch) = BoxFFI::as_mut_ref(batch) else {
+        tracing::error!("Provided null batch pointer to cass_batch_set_consistency!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let consistency = match consistency.try_into().ok() {
         Some(c) => c,
         None => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
@@ -77,7 +81,11 @@ pub unsafe extern "C" fn cass_batch_set_serial_consistency(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     serial_consistency: CassConsistency,
 ) -> CassError {
-    let batch = BoxFFI::as_mut_ref(batch).unwrap();
+    let Some(batch) = BoxFFI::as_mut_ref(batch) else {
+        tracing::error!("Provided null batch pointer to cass_batch_set_serial_consistency!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let serial_consistency = match serial_consistency.try_into().ok() {
         Some(c) => c,
         None => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
@@ -94,7 +102,10 @@ pub unsafe extern "C" fn cass_batch_set_retry_policy(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     retry_policy: CassBorrowedSharedPtr<CassRetryPolicy, CMut>,
 ) -> CassError {
-    let batch = BoxFFI::as_mut_ref(batch).unwrap();
+    let Some(batch) = BoxFFI::as_mut_ref(batch) else {
+        tracing::error!("Provided null batch pointer to cass_batch_set_retry_policy!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
     let maybe_arced_retry_policy: Option<Arc<dyn scylla::policies::retry::RetryPolicy>> =
         ArcFFI::as_ref(retry_policy).map(|policy| match policy {
@@ -117,7 +128,10 @@ pub unsafe extern "C" fn cass_batch_set_timestamp(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     timestamp: cass_int64_t,
 ) -> CassError {
-    let batch = BoxFFI::as_mut_ref(batch).unwrap();
+    let Some(batch) = BoxFFI::as_mut_ref(batch) else {
+        tracing::error!("Provided null batch pointer to cass_batch_set_timestamp!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
     Arc::make_mut(&mut batch.state)
         .batch
@@ -131,7 +145,10 @@ pub unsafe extern "C" fn cass_batch_set_request_timeout(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     timeout_ms: cass_uint64_t,
 ) -> CassError {
-    let batch = BoxFFI::as_mut_ref(batch).unwrap();
+    let Some(batch) = BoxFFI::as_mut_ref(batch) else {
+        tracing::error!("Provided null batch pointer to cass_batch_set_request_timeout!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
     batch.batch_request_timeout_ms = Some(timeout_ms);
 
     CassError::CASS_OK
@@ -142,7 +159,11 @@ pub unsafe extern "C" fn cass_batch_set_is_idempotent(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     is_idempotent: cass_bool_t,
 ) -> CassError {
-    let batch = BoxFFI::as_mut_ref(batch).unwrap();
+    let Some(batch) = BoxFFI::as_mut_ref(batch) else {
+        tracing::error!("Provided null batch pointer to cass_batch_set_is_idempotent!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     Arc::make_mut(&mut batch.state)
         .batch
         .set_is_idempotent(is_idempotent != 0);
@@ -155,7 +176,11 @@ pub unsafe extern "C" fn cass_batch_set_tracing(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     enabled: cass_bool_t,
 ) -> CassError {
-    let batch = BoxFFI::as_mut_ref(batch).unwrap();
+    let Some(batch) = BoxFFI::as_mut_ref(batch) else {
+        tracing::error!("Provided null batch pointer to cass_batch_set_tracing!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     Arc::make_mut(&mut batch.state)
         .batch
         .set_tracing(enabled != 0);
@@ -168,9 +193,16 @@ pub unsafe extern "C" fn cass_batch_add_statement(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
     statement: CassBorrowedSharedPtr<CassStatement, CMut>,
 ) -> CassError {
-    let batch = BoxFFI::as_mut_ref(batch).unwrap();
+    let Some(batch) = BoxFFI::as_mut_ref(batch) else {
+        tracing::error!("Provided null batch pointer to cass_batch_add_statement!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+    let Some(statement) = BoxFFI::as_ref(statement) else {
+        tracing::error!("Provided null statement pointer to cass_batch_add_statement!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let state = Arc::make_mut(&mut batch.state);
-    let statement = BoxFFI::as_ref(statement).unwrap();
 
     match &statement.statement {
         BoundStatement::Simple(q) => {

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -60,8 +60,12 @@ macro_rules! make_index_binder {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
             use crate::value::CassCqlValue::*;
+            let Some(this) = BoxFFI::as_mut_ref(this) else {
+                tracing::error!("Provided null pointer to {}!", stringify!($fn_by_idx));
+                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            };
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this).unwrap(), index as usize, v),
+                Ok(v) => $consume_v(this, index as usize, v),
                 Err(e) => e,
             }
         }
@@ -80,9 +84,13 @@ macro_rules! make_name_binder {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
             use crate::value::CassCqlValue::*;
+            let Some(this) = BoxFFI::as_mut_ref(this) else {
+                tracing::error!("Provided null pointer to {}!", stringify!($fn_by_name));
+                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            };
             let name = unsafe { ptr_to_cstr(name) }.unwrap();
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this).unwrap(), name, v),
+                Ok(v) => $consume_v(this, name, v),
                 Err(e) => e,
             }
         }
@@ -102,9 +110,13 @@ macro_rules! make_name_n_binder {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
             use crate::value::CassCqlValue::*;
+            let Some(this) = BoxFFI::as_mut_ref(this) else {
+                tracing::error!("Provided null pointer to {}!", stringify!($fn_by_name_n));
+                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            };
             let name = unsafe { ptr_to_cstr_n(name, name_length) }.unwrap();
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this).unwrap(), name, v),
+                Ok(v) => $consume_v(this, name, v),
                 Err(e) => e,
             }
         }
@@ -122,8 +134,12 @@ macro_rules! make_appender {
             // For some reason detected as unused, which is not true
             #[allow(unused_imports)]
             use crate::value::CassCqlValue::*;
+            let Some(this) = BoxFFI::as_mut_ref(this) else {
+                tracing::error!("Provided null pointer to {}!", stringify!($fn_append));
+                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            };
             match ($e)($($arg), *) {
-                Ok(v) => $consume_v(BoxFFI::as_mut_ref(this).unwrap(), v),
+                Ok(v) => $consume_v(this, v),
                 Err(e) => e,
             }
         }

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -474,7 +474,11 @@ pub unsafe extern "C" fn cass_data_type_new(
 pub unsafe extern "C" fn cass_data_type_new_from_existing(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassOwnedSharedPtr<CassDataType, CMut> {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_new_from_existing!");
+        return ArcFFI::null();
+    };
+
     ArcFFI::into_ptr(CassDataType::new_arced(
         unsafe { data_type.get_unchecked() }.clone(),
     ))
@@ -507,7 +511,11 @@ pub unsafe extern "C" fn cass_data_type_free(data_type: CassOwnedSharedPtr<CassD
 pub unsafe extern "C" fn cass_data_type_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassValueType {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_type!");
+        return CassValueType::CASS_VALUE_TYPE_UNKNOWN;
+    };
+
     unsafe { data_type.get_unchecked() }.get_value_type()
 }
 
@@ -515,7 +523,11 @@ pub unsafe extern "C" fn cass_data_type_type(
 pub unsafe extern "C" fn cass_data_type_is_frozen(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> cass_bool_t {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_is_frozen!");
+        return cass_false;
+    };
+
     let is_frozen = match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(udt) => udt.frozen,
         CassDataTypeInner::List { frozen, .. } => *frozen,
@@ -533,7 +545,11 @@ pub unsafe extern "C" fn cass_data_type_type_name(
     type_name: *mut *const c_char,
     type_name_length: *mut size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_type_name!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(UDTDataType { name, .. }) => {
             unsafe { write_str_to_c(name, type_name, type_name_length) };
@@ -557,7 +573,11 @@ pub unsafe extern "C" fn cass_data_type_set_type_name_n(
     type_name: *const c_char,
     type_name_length: size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type_raw).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type_raw) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_set_type_name_n!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let type_name_string = unsafe { ptr_to_cstr_n(type_name, type_name_length) }
         .unwrap()
         .to_string();
@@ -577,7 +597,11 @@ pub unsafe extern "C" fn cass_data_type_keyspace(
     keyspace: *mut *const c_char,
     keyspace_length: *mut size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_keyspace!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(UDTDataType { name, .. }) => {
             unsafe { write_str_to_c(name, keyspace, keyspace_length) };
@@ -601,7 +625,11 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
     keyspace: *const c_char,
     keyspace_length: size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_set_keyspace_n!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let keyspace_string = unsafe { ptr_to_cstr_n(keyspace, keyspace_length) }
         .unwrap()
         .to_string();
@@ -621,7 +649,11 @@ pub unsafe extern "C" fn cass_data_type_class_name(
     class_name: *mut *const ::std::os::raw::c_char,
     class_name_length: *mut size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_class_name!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::Custom(name) => {
             unsafe { write_str_to_c(name, class_name, class_name_length) };
@@ -645,7 +677,11 @@ pub unsafe extern "C" fn cass_data_type_set_class_name_n(
     class_name: *const ::std::os::raw::c_char,
     class_name_length: size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_set_class_name_n!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let class_string = unsafe { ptr_to_cstr_n(class_name, class_name_length) }
         .unwrap()
         .to_string();
@@ -662,7 +698,11 @@ pub unsafe extern "C" fn cass_data_type_set_class_name_n(
 pub unsafe extern "C" fn cass_data_type_sub_type_count(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> size_t {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_sub_type_count!");
+        return 0;
+    };
+
     match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::Value(..) => 0,
         CassDataTypeInner::UDT(udt_data_type) => udt_data_type.field_types.len() as size_t,
@@ -691,7 +731,11 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     index: size_t,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_sub_data_type!");
+        return ArcFFI::null();
+    };
+
     let sub_type: Option<&Arc<CassDataType>> =
         unsafe { data_type.get_unchecked() }.get_sub_data_type(index as usize);
 
@@ -716,7 +760,13 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n(
     name: *const ::std::os::raw::c_char,
     name_length: size_t,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!(
+            "Provided null data type pointer to cass_data_type_sub_data_type_by_name_n!"
+        );
+        return ArcFFI::null();
+    };
+
     let name_str = unsafe { ptr_to_cstr_n(name, name_length) }.unwrap();
     match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(udt) => match udt.get_field_by_name(name_str) {
@@ -734,7 +784,11 @@ pub unsafe extern "C" fn cass_data_type_sub_type_name(
     name: *mut *const ::std::os::raw::c_char,
     name_length: *mut size_t,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_sub_type_name!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(udt) => match udt.field_types.get(index as usize) {
             None => CassError::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS,
@@ -752,10 +806,16 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
     sub_data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassError {
-    let data_type = ArcFFI::as_ref(data_type).unwrap();
-    match unsafe { data_type.get_mut_unchecked() }
-        .add_sub_data_type(ArcFFI::cloned_from_ptr(sub_data_type).unwrap())
-    {
+    let Some(data_type) = ArcFFI::as_ref(data_type) else {
+        tracing::error!("Provided null data type pointer to cass_data_type_add_sub_type!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+    let Some(sub_data_type) = ArcFFI::cloned_from_ptr(sub_data_type) else {
+        tracing::error!("Provided null sub data type pointer to cass_data_type_add_sub_type!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
+    match unsafe { data_type.get_mut_unchecked() }.add_sub_data_type(sub_data_type) {
         Ok(()) => CassError::CASS_OK,
         Err(e) => e,
     }
@@ -777,12 +837,23 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
     name_length: size_t,
     sub_data_type_raw: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassError {
+    let Some(data_type) = ArcFFI::as_ref(data_type_raw) else {
+        tracing::error!(
+            "Provided null data type pointer to cass_data_type_add_sub_type_by_name_n!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+    let Some(sub_data_type) = ArcFFI::cloned_from_ptr(sub_data_type_raw) else {
+        tracing::error!(
+            "Provided null sub data type pointer to cass_data_type_add_sub_type_by_name_n!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let name_string = unsafe { ptr_to_cstr_n(name, name_length) }
         .unwrap()
         .to_string();
-    let sub_data_type = ArcFFI::cloned_from_ptr(sub_data_type_raw).unwrap();
 
-    let data_type = ArcFFI::as_ref(data_type_raw).unwrap();
     match unsafe { data_type.get_mut_unchecked() } {
         CassDataTypeInner::UDT(udt_data_type) => {
             // The Cpp Driver does not check whether field_types size

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -381,7 +381,10 @@ pub unsafe extern "C" fn cass_cluster_set_application_name_n(
     app_name: *const c_char,
     app_name_len: size_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_application_name_n!");
+        return;
+    };
     let app_name = unsafe { ptr_to_cstr_n(app_name, app_name_len) }
         .unwrap()
         .to_string();
@@ -407,7 +410,10 @@ pub unsafe extern "C" fn cass_cluster_set_application_version_n(
     app_version: *const c_char,
     app_version_len: size_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_application_version_n!");
+        return;
+    };
     let app_version = unsafe { ptr_to_cstr_n(app_version, app_version_len) }
         .unwrap()
         .to_string();
@@ -424,7 +430,10 @@ pub unsafe extern "C" fn cass_cluster_set_client_id(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     client_id: CassUuid,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_client_id!");
+        return;
+    };
 
     let client_uuid: uuid::Uuid = client_id.into();
     let client_uuid_str = client_uuid.to_string();
@@ -442,7 +451,11 @@ pub unsafe extern "C" fn cass_cluster_set_use_schema(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_use_schema!");
+        return;
+    };
+
     cluster.session_builder.config.fetch_schema_metadata = enabled != 0;
 }
 
@@ -451,7 +464,11 @@ pub unsafe extern "C" fn cass_cluster_set_tcp_nodelay(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_tcp_nodelay!");
+        return;
+    };
+
     cluster.session_builder.config.tcp_nodelay = enabled != 0;
 }
 
@@ -461,7 +478,11 @@ pub unsafe extern "C" fn cass_cluster_set_tcp_keepalive(
     enabled: cass_bool_t,
     delay_secs: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_tcp_keepalive!");
+        return;
+    };
+
     let enabled = enabled != 0;
     let tcp_keepalive_interval = enabled.then(|| Duration::from_secs(delay_secs as u64));
 
@@ -500,7 +521,13 @@ pub unsafe extern "C" fn cass_cluster_set_connection_heartbeat_interval(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     interval_secs: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_connection_heartbeat_interval!"
+        );
+        return;
+    };
+
     let keepalive_interval = (interval_secs > 0).then(|| Duration::from_secs(interval_secs as u64));
 
     cluster.session_builder.config.keepalive_interval = keepalive_interval;
@@ -511,7 +538,13 @@ pub unsafe extern "C" fn cass_cluster_set_connection_idle_timeout(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     timeout_secs: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_connection_idle_timeout!"
+        );
+        return;
+    };
+
     let keepalive_timeout = (timeout_secs > 0).then(|| Duration::from_secs(timeout_secs as u64));
 
     cluster.session_builder.config.keepalive_timeout = keepalive_timeout;
@@ -522,7 +555,11 @@ pub unsafe extern "C" fn cass_cluster_set_connect_timeout(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     timeout_ms: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_connect_timeout!");
+        return;
+    };
+
     cluster.session_builder.config.connect_timeout = Duration::from_millis(timeout_ms.into());
 }
 
@@ -618,7 +655,10 @@ pub unsafe extern "C" fn cass_cluster_set_request_timeout(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     timeout_ms: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_request_timeout!");
+        return;
+    };
 
     exec_profile_builder_modify(&mut cluster.default_execution_profile_builder, |builder| {
         // 0 -> no timeout
@@ -631,7 +671,10 @@ pub unsafe extern "C" fn cass_cluster_set_max_schema_wait_time(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     wait_time_ms: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_max_schema_wait_time!");
+        return;
+    };
 
     cluster.session_builder.config.schema_agreement_timeout =
         Duration::from_millis(wait_time_ms.into());
@@ -642,7 +685,12 @@ pub unsafe extern "C" fn cass_cluster_set_schema_agreement_interval(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     interval_ms: c_uint,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_schema_agreement_interval!"
+        );
+        return;
+    };
 
     cluster.session_builder.config.schema_agreement_interval =
         Duration::from_millis(interval_ms.into());
@@ -653,12 +701,16 @@ pub unsafe extern "C" fn cass_cluster_set_port(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     port: c_int,
 ) -> CassError {
-    if port <= 0 {
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_port!");
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
-    }
+    };
+    let Ok(port): Result<u16, _> = port.try_into() else {
+        tracing::error!("Provided invalid port number to cass_cluster_set_port!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
-    cluster.port = port as u16;
+    cluster.port = port;
     CassError::CASS_OK
 }
 
@@ -774,11 +826,14 @@ pub unsafe extern "C" fn cass_cluster_set_credentials_n(
     password_raw: *const c_char,
     password_length: size_t,
 ) {
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_credentials_n!");
+        return;
+    };
     // TODO: string error handling
     let username = unsafe { ptr_to_cstr_n(username_raw, username_length) }.unwrap();
     let password = unsafe { ptr_to_cstr_n(password_raw, password_length) }.unwrap();
 
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
     cluster.auth_username = Some(username.to_string());
     cluster.auth_password = Some(password.to_string());
 }
@@ -787,7 +842,13 @@ pub unsafe extern "C" fn cass_cluster_set_credentials_n(
 pub unsafe extern "C" fn cass_cluster_set_load_balance_round_robin(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_load_balance_round_robin!"
+        );
+        return;
+    };
+
     cluster.load_balancing_config.load_balancing_kind = Some(LoadBalancingKind::RoundRobin);
 }
 
@@ -842,7 +903,12 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
     used_hosts_per_remote_dc: c_uint,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_load_balance_dc_aware_n!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
     unsafe {
         set_load_balance_dc_aware_n(
@@ -880,7 +946,12 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware_n(
     local_rack_raw: *const c_char,
     local_rack_length: size_t,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_load_balance_rack_aware_n!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
     unsafe {
         set_load_balance_rack_aware_n(
@@ -996,7 +1067,13 @@ pub unsafe extern "C" fn cass_cluster_set_use_beta_protocol_version(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enable: cass_bool_t,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_use_beta_protocol_version!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     cluster.use_beta_protocol_version = enable == cass_true;
 
     CassError::CASS_OK
@@ -1007,7 +1084,10 @@ pub unsafe extern "C" fn cass_cluster_set_protocol_version(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     protocol_version: c_int,
 ) -> CassError {
-    let cluster = BoxFFI::as_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_protocol_version!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
     if protocol_version == 4 && !cluster.use_beta_protocol_version {
         // Rust Driver supports only protocol version 4
@@ -1032,11 +1112,16 @@ pub unsafe extern "C" fn cass_cluster_set_constant_speculative_execution_policy(
     constant_delay_ms: cass_int64_t,
     max_speculative_executions: c_int,
 ) -> CassError {
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_constant_speculative_execution_policy!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     if constant_delay_ms < 0 || max_speculative_executions < 0 {
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
-
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
 
     let policy = SimpleSpeculativeExecutionPolicy {
         max_retry_count: max_speculative_executions as usize,
@@ -1054,7 +1139,12 @@ pub unsafe extern "C" fn cass_cluster_set_constant_speculative_execution_policy(
 pub unsafe extern "C" fn cass_cluster_set_no_speculative_execution_policy(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_no_speculative_execution_policy!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
     exec_profile_builder_modify(&mut cluster.default_execution_profile_builder, |builder| {
         builder.speculative_execution_policy(None)
@@ -1068,7 +1158,11 @@ pub unsafe extern "C" fn cass_cluster_set_token_aware_routing(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_token_aware_routing!");
+        return;
+    };
+
     cluster.load_balancing_config.token_awareness_enabled = enabled != 0;
 }
 
@@ -1077,7 +1171,12 @@ pub unsafe extern "C" fn cass_cluster_set_token_aware_routing_shuffle_replicas(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_token_aware_routing_shuffle_replicas!"
+        );
+        return;
+    };
 
     cluster
         .load_balancing_config
@@ -1089,12 +1188,19 @@ pub unsafe extern "C" fn cass_cluster_set_retry_policy(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     retry_policy: CassBorrowedSharedPtr<CassRetryPolicy, CMut>,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster_raw).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_retry_policy!");
+        return;
+    };
 
-    let retry_policy: Arc<dyn RetryPolicy> = match ArcFFI::as_ref(retry_policy).unwrap() {
-        DefaultRetryPolicy(default) => Arc::clone(default) as _,
-        FallthroughRetryPolicy(fallthrough) => Arc::clone(fallthrough) as _,
-        DowngradingConsistencyRetryPolicy(downgrading) => Arc::clone(downgrading) as _,
+    let retry_policy: Arc<dyn RetryPolicy> = match ArcFFI::as_ref(retry_policy) {
+        Some(DefaultRetryPolicy(default)) => Arc::clone(default) as _,
+        Some(FallthroughRetryPolicy(fallthrough)) => Arc::clone(fallthrough) as _,
+        Some(DowngradingConsistencyRetryPolicy(downgrading)) => Arc::clone(downgrading) as _,
+        None => {
+            tracing::error!("Provided null retry policy pointer to cass_cluster_set_retry_policy!");
+            return;
+        }
     };
 
     exec_profile_builder_modify(&mut cluster.default_execution_profile_builder, |builder| {
@@ -1107,8 +1213,14 @@ pub unsafe extern "C" fn cass_cluster_set_ssl(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
 ) {
-    let cluster_from_raw = BoxFFI::as_mut_ref(cluster).unwrap();
-    let cass_ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
+    let Some(cluster_from_raw) = BoxFFI::as_mut_ref(cluster) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_ssl!");
+        return;
+    };
+    let Some(cass_ssl) = ArcFFI::as_ref(ssl) else {
+        tracing::error!("Provided null ssl pointer to cass_cluster_set_ssl!");
+        return;
+    };
 
     let ssl_context_builder = unsafe { SslContextBuilder::from_ptr(cass_ssl.ssl_context) };
     // Reference count is increased as tokio_openssl will try to free `ssl_context` when calling `SSL_free`.
@@ -1122,7 +1234,11 @@ pub unsafe extern "C" fn cass_cluster_set_compression(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     compression_type: CassCompressionType,
 ) {
-    let cluster_from_raw = BoxFFI::as_mut_ref(cluster).unwrap();
+    let Some(cluster_from_raw) = BoxFFI::as_mut_ref(cluster) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_compression!");
+        return;
+    };
+
     let compression = match compression_type {
         CassCompressionType::CASS_COMPRESSION_LZ4 => Some(Compression::Lz4),
         CassCompressionType::CASS_COMPRESSION_SNAPPY => Some(Compression::Snappy),
@@ -1137,7 +1253,11 @@ pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     enabled: cass_bool_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_latency_aware_routing!");
+        return;
+    };
+
     cluster.load_balancing_config.latency_awareness_enabled = enabled != 0;
 }
 
@@ -1150,7 +1270,13 @@ pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing_settings(
     update_rate_ms: cass_uint64_t,
     min_measured: cass_uint64_t,
 ) {
-    let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_latency_aware_routing_settings!"
+        );
+        return;
+    };
+
     cluster.load_balancing_config.latency_awareness_builder = LatencyAwarenessBuilder::new()
         .exclusion_threshold(exclusion_threshold)
         .scale(Duration::from_millis(scale_ms))
@@ -1164,7 +1290,11 @@ pub unsafe extern "C" fn cass_cluster_set_consistency(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     consistency: CassConsistency,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_consistency!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let consistency: Consistency = match consistency.try_into() {
         Ok(c) => c,
         Err(_) => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
@@ -1182,7 +1312,11 @@ pub unsafe extern "C" fn cass_cluster_set_serial_consistency(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
     serial_consistency: CassConsistency,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_serial_consistency!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let serial_consistency: SerialConsistency = match serial_consistency.try_into() {
         Ok(c) => c,
         Err(_) => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
@@ -1211,7 +1345,11 @@ pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
     name_length: size_t,
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
 ) -> CassError {
-    let cluster = BoxFFI::as_mut_ref(cluster).unwrap();
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_execution_profile_n!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let name = if let Some(name) =
         unsafe { ptr_to_cstr_n(name, name_length) }.and_then(|name| name.to_owned().try_into().ok())
     {

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -204,7 +204,11 @@ pub unsafe extern "C" fn cass_statement_set_execution_profile_n(
     name: *const c_char,
     name_length: size_t,
 ) -> CassError {
-    let statement = BoxFFI::as_mut_ref(statement).unwrap();
+    let Some(statement) = BoxFFI::as_mut_ref(statement) else {
+        tracing::error!("Provided null statement pointer to cass_statement_set_execution_profile!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let name: Option<ExecProfileName> = unsafe { ptr_to_cstr_n(name, name_length) }
         .and_then(|name| name.to_owned().try_into().ok());
     statement.exec_profile = name.map(PerStatementExecProfile::new_unresolved);
@@ -226,7 +230,11 @@ pub unsafe extern "C" fn cass_batch_set_execution_profile_n(
     name: *const c_char,
     name_length: size_t,
 ) -> CassError {
-    let batch = BoxFFI::as_mut_ref(batch).unwrap();
+    let Some(batch) = BoxFFI::as_mut_ref(batch) else {
+        tracing::error!("Provided null batch pointer to cass_batch_set_execution_profile!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let name: Option<ExecProfileName> = unsafe { ptr_to_cstr_n(name, name_length) }
         .and_then(|name| name.to_owned().try_into().ok());
     batch.exec_profile = name.map(PerStatementExecProfile::new_unresolved);
@@ -259,7 +267,11 @@ pub unsafe extern "C" fn cass_execution_profile_set_consistency(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     consistency: CassConsistency,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!("Provided null profile pointer to cass_execution_profile_set_consistency!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let consistency: Consistency = match consistency.try_into() {
         Ok(c) => c,
         Err(_) => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
@@ -274,7 +286,12 @@ pub unsafe extern "C" fn cass_execution_profile_set_consistency(
 pub unsafe extern "C" fn cass_execution_profile_set_no_speculative_execution_policy(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_no_speculative_execution_policy!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
     profile_builder.modify_in_place(|builder| builder.speculative_execution_policy(None));
 
@@ -287,7 +304,13 @@ pub unsafe extern "C" fn cass_execution_profile_set_constant_speculative_executi
     constant_delay_ms: cass_int64_t,
     max_speculative_executions: cass_int32_t,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_constant_speculative_execution_policy!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     if constant_delay_ms < 0 || max_speculative_executions < 0 {
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
@@ -308,7 +331,13 @@ pub unsafe extern "C" fn cass_execution_profile_set_latency_aware_routing(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     enabled: cass_bool_t,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_latency_aware_routing!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     profile_builder
         .load_balancing_config
         .latency_awareness_enabled = enabled != 0;
@@ -325,7 +354,13 @@ pub unsafe extern "C" fn cass_execution_profile_set_latency_aware_routing_settin
     update_rate_ms: cass_uint64_t,
     min_measured: cass_uint64_t,
 ) {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_latency_aware_routing_settings!"
+        );
+        return;
+    };
+
     profile_builder
         .load_balancing_config
         .latency_awareness_builder = LatencyAwarenessBuilder::new()
@@ -361,7 +396,12 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware_n(
     used_hosts_per_remote_dc: cass_uint32_t,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_load_balance_dc_aware!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
     unsafe {
         set_load_balance_dc_aware_n(
@@ -399,7 +439,12 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware_n(
     local_rack_raw: *const c_char,
     local_rack_length: size_t,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_load_balance_rack_aware!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
     unsafe {
         set_load_balance_rack_aware_n(
@@ -416,7 +461,13 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware_n(
 pub unsafe extern "C" fn cass_execution_profile_set_load_balance_round_robin(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_load_balance_round_robin!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     profile_builder.load_balancing_config.load_balancing_kind = Some(LoadBalancingKind::RoundRobin);
 
     CassError::CASS_OK
@@ -427,7 +478,13 @@ pub unsafe extern "C" fn cass_execution_profile_set_request_timeout(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     timeout_ms: cass_uint64_t,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_request_timeout!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     profile_builder.modify_in_place(|builder| {
         builder.request_timeout(Some(std::time::Duration::from_millis(timeout_ms)))
     });
@@ -440,12 +497,24 @@ pub unsafe extern "C" fn cass_execution_profile_set_retry_policy(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     retry_policy: CassBorrowedSharedPtr<CassRetryPolicy, CMut>,
 ) -> CassError {
-    let retry_policy: Arc<dyn RetryPolicy> = match ArcFFI::as_ref(retry_policy).unwrap() {
-        DefaultRetryPolicy(default) => Arc::clone(default) as _,
-        FallthroughRetryPolicy(fallthrough) => Arc::clone(fallthrough) as _,
-        DowngradingConsistencyRetryPolicy(downgrading) => Arc::clone(downgrading) as _,
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_retry_policy!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let retry_policy: Arc<dyn RetryPolicy> = match ArcFFI::as_ref(retry_policy) {
+        Some(DefaultRetryPolicy(default)) => Arc::clone(default) as _,
+        Some(FallthroughRetryPolicy(fallthrough)) => Arc::clone(fallthrough) as _,
+        Some(DowngradingConsistencyRetryPolicy(downgrading)) => Arc::clone(downgrading) as _,
+        None => {
+            tracing::error!(
+                "Provided null retry policy pointer to cass_execution_profile_set_retry_policy!"
+            );
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+    };
+
     profile_builder.modify_in_place(|builder| builder.retry_policy(retry_policy));
 
     CassError::CASS_OK
@@ -456,7 +525,12 @@ pub unsafe extern "C" fn cass_execution_profile_set_serial_consistency(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     serial_consistency: CassConsistency,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_serial_consistency!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
 
     let maybe_serial_consistency =
         if serial_consistency == CassConsistency::CASS_CONSISTENCY_UNKNOWN {
@@ -477,7 +551,13 @@ pub unsafe extern "C" fn cass_execution_profile_set_token_aware_routing(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     enabled: cass_bool_t,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_token_aware_routing!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     profile_builder
         .load_balancing_config
         .token_awareness_enabled = enabled != 0;
@@ -490,7 +570,13 @@ pub unsafe extern "C" fn cass_execution_profile_set_token_aware_routing_shuffle_
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
     enabled: cass_bool_t,
 ) -> CassError {
-    let profile_builder = BoxFFI::as_mut_ref(profile).unwrap();
+    let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
+        tracing::error!(
+            "Provided null profile pointer to cass_execution_profile_set_token_aware_routing_shuffle_replicas!"
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     profile_builder
         .load_balancing_config
         .token_aware_shuffling_replicas_enabled = enabled != 0;

--- a/scylla-rust-wrapper/src/execution_error.rs
+++ b/scylla-rust-wrapper/src/execution_error.rs
@@ -68,7 +68,11 @@ pub unsafe extern "C" fn cass_error_result_free(
 pub unsafe extern "C" fn cass_error_result_code(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> CassError {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!("Provided null error result pointer to cass_error_result_code!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     error_result.to_cass_error()
 }
 
@@ -76,7 +80,11 @@ pub unsafe extern "C" fn cass_error_result_code(
 pub unsafe extern "C" fn cass_error_result_consistency(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> CassConsistency {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!("Provided null error result pointer to cass_error_result_consistency!");
+        return CassConsistency::CASS_CONSISTENCY_UNKNOWN;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(
             RequestAttemptError::DbError(DbError::Unavailable { consistency, .. }, _)
@@ -93,7 +101,13 @@ pub unsafe extern "C" fn cass_error_result_consistency(
 pub unsafe extern "C" fn cass_error_result_responses_received(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_int32_t {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!(
+            "Provided null error result pointer to cass_error_result_responses_received!"
+        );
+        return -1;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(attempt_error)) => {
             match attempt_error {
@@ -117,7 +131,13 @@ pub unsafe extern "C" fn cass_error_result_responses_received(
 pub unsafe extern "C" fn cass_error_result_responses_required(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_int32_t {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!(
+            "Provided null error result pointer to cass_error_result_responses_required!"
+        );
+        return -1;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(attempt_error)) => {
             match attempt_error {
@@ -141,7 +161,11 @@ pub unsafe extern "C" fn cass_error_result_responses_required(
 pub unsafe extern "C" fn cass_error_result_num_failures(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_int32_t {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!("Provided null error result pointer to cass_error_result_num_failures!");
+        return -1;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(
             RequestAttemptError::DbError(DbError::ReadFailure { numfailures, .. }, _),
@@ -157,7 +181,11 @@ pub unsafe extern "C" fn cass_error_result_num_failures(
 pub unsafe extern "C" fn cass_error_result_data_present(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> cass_bool_t {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!("Provided null error result pointer to cass_error_result_data_present!");
+        return cass_false;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(
             RequestAttemptError::DbError(DbError::ReadTimeout { data_present, .. }, _),
@@ -185,7 +213,11 @@ pub unsafe extern "C" fn cass_error_result_data_present(
 pub unsafe extern "C" fn cass_error_result_write_type(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> CassWriteType {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!("Provided null error result pointer to cass_error_result_write_type!");
+        return CassWriteType::CASS_WRITE_TYPE_UNKNOWN;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(
             RequestAttemptError::DbError(DbError::WriteTimeout { write_type, .. }, _),
@@ -203,7 +235,11 @@ pub unsafe extern "C" fn cass_error_result_keyspace(
     c_keyspace: *mut *const ::std::os::raw::c_char,
     c_keyspace_len: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!("Provided null error result pointer to cass_error_result_keyspace!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(
             RequestAttemptError::DbError(DbError::AlreadyExists { keyspace, .. }, _),
@@ -227,7 +263,11 @@ pub unsafe extern "C" fn cass_error_result_table(
     c_table: *mut *const ::std::os::raw::c_char,
     c_table_len: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!("Provided null error result pointer to cass_error_result_table!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(
             RequestAttemptError::DbError(DbError::AlreadyExists { table, .. }, _),
@@ -245,7 +285,11 @@ pub unsafe extern "C" fn cass_error_result_function(
     c_function: *mut *const ::std::os::raw::c_char,
     c_function_len: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!("Provided null error result pointer to cass_error_result_function!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(
             RequestAttemptError::DbError(DbError::FunctionFailure { function, .. }, _),
@@ -261,7 +305,11 @@ pub unsafe extern "C" fn cass_error_result_function(
 pub unsafe extern "C" fn cass_error_num_arg_types(
     error_result: CassBorrowedSharedPtr<CassErrorResult, CConst>,
 ) -> size_t {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!("Provided null error result pointer to cass_error_num_arg_types!");
+        return 0;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(
             RequestAttemptError::DbError(DbError::FunctionFailure { arg_types, .. }, _),
@@ -277,7 +325,11 @@ pub unsafe extern "C" fn cass_error_result_arg_type(
     arg_type: *mut *const ::std::os::raw::c_char,
     arg_type_length: *mut size_t,
 ) -> CassError {
-    let error_result: &CassErrorResult = ArcFFI::as_ref(error_result).unwrap();
+    let Some(error_result) = ArcFFI::as_ref(error_result) else {
+        tracing::error!("Provided null error result pointer to cass_error_result_arg_type!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     match error_result {
         CassErrorResult::Execution(ExecutionError::LastAttemptError(
             RequestAttemptError::DbError(DbError::FunctionFailure { arg_types, .. }, _),

--- a/scylla-rust-wrapper/src/ssl.rs
+++ b/scylla-rust-wrapper/src/ssl.rs
@@ -116,7 +116,11 @@ pub unsafe extern "C" fn cass_ssl_add_trusted_cert_n(
     cert: *const c_char,
     cert_length: size_t,
 ) -> CassError {
-    let ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
+    let Some(ssl) = ArcFFI::cloned_from_ptr(ssl) else {
+        tracing::error!("Provided null ssl pointer to cass_ssl_add_trusted_cert_n!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let bio = unsafe { BIO_new_mem_buf(cert as *const c_void, cert_length.try_into().unwrap()) };
 
     if bio.is_null() {
@@ -151,7 +155,10 @@ pub unsafe extern "C" fn cass_ssl_set_verify_flags(
     ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
     flags: i32,
 ) {
-    let ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
+    let Some(ssl) = ArcFFI::cloned_from_ptr(ssl) else {
+        tracing::error!("Provided null ssl pointer to cass_ssl_set_verify_flags!");
+        return;
+    };
 
     match flags {
         CASS_SSL_VERIFY_NONE => unsafe {
@@ -196,7 +203,11 @@ pub unsafe extern "C" fn cass_ssl_set_cert_n(
     cert: *const c_char,
     cert_length: size_t,
 ) -> CassError {
-    let ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
+    let Some(ssl) = ArcFFI::cloned_from_ptr(ssl) else {
+        tracing::error!("Provided null ssl pointer to cass_ssl_set_cert_n!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let bio = unsafe { BIO_new_mem_buf(cert as *const c_void, cert_length.try_into().unwrap()) };
 
     if bio.is_null() {
@@ -295,7 +306,11 @@ pub unsafe extern "C" fn cass_ssl_set_private_key_n(
     password: *mut c_char,
     _password_length: size_t,
 ) -> CassError {
-    let ssl = ArcFFI::cloned_from_ptr(ssl).unwrap();
+    let Some(ssl) = ArcFFI::cloned_from_ptr(ssl) else {
+        tracing::error!("Provided null ssl pointer to cass_ssl_set_private_key_n!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
     let bio = unsafe { BIO_new_mem_buf(key as *const c_void, key_length.try_into().unwrap()) };
 
     if bio.is_null() {

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -87,7 +87,10 @@ impl From<&CassUserType> for CassCqlValue {
 pub unsafe extern "C" fn cass_user_type_new_from_data_type(
     data_type_raw: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassOwnedExclusivePtr<CassUserType, CMut> {
-    let data_type = ArcFFI::cloned_from_ptr(data_type_raw).unwrap();
+    let Some(data_type) = ArcFFI::cloned_from_ptr(data_type_raw) else {
+        tracing::error!("Provided null data type pointer to cass_user_type_new_from_data_type!");
+        return BoxFFI::null_mut();
+    };
 
     match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::UDT(udt_data_type) => {
@@ -109,7 +112,12 @@ pub unsafe extern "C" fn cass_user_type_free(user_type: CassOwnedExclusivePtr<Ca
 pub unsafe extern "C" fn cass_user_type_data_type(
     user_type: CassBorrowedSharedPtr<CassUserType, CConst>,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
-    ArcFFI::as_ptr(&BoxFFI::as_ref(user_type).unwrap().data_type)
+    let Some(user_type) = BoxFFI::as_ref(user_type) else {
+        tracing::error!("Provided null user type pointer to cass_user_type_data_type!");
+        return ArcFFI::null();
+    };
+
+    ArcFFI::as_ptr(&user_type.data_type)
 }
 
 prepare_binders_macro!(@index_and_name CassUserType,

--- a/scylla-rust-wrapper/src/uuid.rs
+++ b/scylla-rust-wrapper/src/uuid.rs
@@ -138,7 +138,10 @@ pub unsafe extern "C" fn cass_uuid_gen_time(
     uuid_gen: CassBorrowedExclusivePtr<CassUuidGen, CMut>,
     output: *mut CassUuid,
 ) {
-    let uuid_gen = BoxFFI::as_mut_ref(uuid_gen).unwrap();
+    let Some(uuid_gen) = BoxFFI::as_mut_ref(uuid_gen) else {
+        tracing::error!("Provided null uuid generator pointer to cass_uuid_gen_time!");
+        return;
+    };
 
     let uuid = CassUuid {
         time_and_version: set_version(monotonic_timestamp(&mut uuid_gen.last_timestamp), 1),
@@ -168,7 +171,10 @@ pub unsafe extern "C" fn cass_uuid_gen_from_time(
     timestamp: cass_uint64_t,
     output: *mut CassUuid,
 ) {
-    let uuid_gen = BoxFFI::as_mut_ref(uuid_gen).unwrap();
+    let Some(uuid_gen) = BoxFFI::as_mut_ref(uuid_gen) else {
+        tracing::error!("Provided null uuid generator pointer to cass_uuid_gen_from_time!");
+        return;
+    };
 
     let uuid = CassUuid {
         time_and_version: set_version(from_unix_timestamp(timestamp), 1),


### PR DESCRIPTION
Fixes: https://github.com/scylladb/cpp-rust-driver/issues/253

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have implemented Rust unit tests for the features/changes introduced.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~
- ~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~