### PR TITLE
Refactor `CassFuture` state management - more type safety and clarity 

### DIFF
--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -48,7 +48,6 @@ impl BoundCallback {
     }
 }
 
-#[derive(Default)]
 struct CassFutureState {
     value: Option<CassFutureResult>,
     err_string: Option<String>,
@@ -86,7 +85,12 @@ impl CassFuture {
         fut: impl Future<Output = CassFutureResult> + Send + 'static,
     ) -> Arc<CassFuture> {
         let cass_fut = Arc::new(CassFuture {
-            state: Mutex::new(Default::default()),
+            state: Mutex::new(CassFutureState {
+                value: None,
+                err_string: None,
+                callback: None,
+                join_handle: None,
+            }),
             wait_for_value: Condvar::new(),
         });
         let cass_fut_clone = Arc::clone(&cass_fut);
@@ -117,7 +121,9 @@ impl CassFuture {
         Arc::new(CassFuture {
             state: Mutex::new(CassFutureState {
                 value: Some(r),
-                ..Default::default()
+                err_string: None,
+                callback: None,
+                join_handle: None,
             }),
             wait_for_value: Condvar::new(),
         })

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -48,6 +48,8 @@ impl BoundCallback {
     }
 }
 
+/// State of the execution of the [CassFuture],
+/// together with a join handle of the tokio task that is executing it.
 struct CassFutureState {
     value: Option<CassFutureResult>,
     err_string: Option<String>,
@@ -55,6 +57,10 @@ struct CassFutureState {
     join_handle: Option<JoinHandle<()>>,
 }
 
+/// The C-API representation of a future. Implemented as a wrapper around a Rust future
+/// that can be awaited and has a callback mechanism. It's **eager** in a way that
+/// its execution starts possibly immediately (unless the executor thread pool is nempty,
+/// which is the case for the current-thread executor).
 pub struct CassFuture {
     state: Mutex<CassFutureState>,
     wait_for_value: Condvar,


### PR DESCRIPTION
This PR refactors `CassFutureState`, so that it is represented in a more type-safe way.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~~