### PR TITLE
ci: fix "Build rpm packages (fedora-40-x86_64)" build failure

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        dist-version: [rocky-9-x86_64, fedora-40-x86_64, fedora-41-x86_64]
+        dist-version: [rocky-9-x86_64, fedora-41-x86_64, fedora-42-x86_64]
       fail-fast: false
     
     steps:


### PR DESCRIPTION
Fedora 40 build target on Mock (rpm build tool) is deleted since Fedora 40 is EOL.
(see: https://docs.fedoraproject.org/en-US/releases/eol/) We need to update the target to Fedora 41 and Fedora 42.