### PR TITLE
integration: increase timestamp tolerance in Timestamps test

### DIFF
--- a/tests/src/integration/tests/test_basics.cpp
+++ b/tests/src/integration/tests/test_basics.cpp
@@ -73,7 +73,7 @@ CASSANDRA_INTEGRATION_TEST_F(BasicsTests, Timestamps) {
 
   // Validate the timestamps
   ASSERT_NE(timestamp_1, timestamp_2);
-  ASSERT_LT(timestamp_2 - timestamp_1 - BigInteger(pause_duration * 1000), BigInteger(150000));
+  ASSERT_LT(timestamp_2 - timestamp_1 - BigInteger(pause_duration * 1000), BigInteger(500000));
 }
 
 /**


### PR DESCRIPTION
The Timestamps test in the integration suite was failing due to the timestamp difference being bigger than the tolerated threshold. Git blame reveals that the threshold was alread increased from 100ms to 150ms by Gor in 2022. I assume 500 ms will be enough for now.

A question aside is whether this test comparison gives us any benefit at all. It seems to be a flaky test that is not very useful. Perhaps we should consider just removing this flaky timing-based check.

Fixes: #312

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~~