### PR TITLE
README.md: Remove stale `cass_future_coordinator` from limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The logging API and implementation are compatible with the C++ driver, for more 
 As the `tracing` framework is used under the hood to instrument the collection of logs from the Rust driver and the Cpp-Rust wrapper,
 the logging level and callback are passed through a custom event subscriber which is globally set as default when `cass_log_set_level` is called.
 So, `cass_log_set_level` *must* be called only once as subsequent attempts trying to modify the globally set event subscriber will be ignored.
-Also, Rust programs using Cpp-Rust driver under the hood must avoid calling `tracing::subscriber::set_global_default` as this will cause conflicts.    
+Also, Rust programs using Cpp-Rust driver under the hood must avoid calling `tracing::subscriber::set_global_default` as this will cause conflicts.
 
 ##### Note: The logging configuration must be done before any other driver function is called, otherwise, the default logging callback will be used, and logs will appear on stderr.
 
@@ -153,7 +153,7 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
 
 # Limitations
 
-##### Note: This section may be incomplete, so not everything that is unimplemented is mentioned here.  
+##### Note: This section may be incomplete, so not everything that is unimplemented is mentioned here.
 
 <table>
     <thead>
@@ -169,13 +169,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
         <tr>
             <td>cass_statement_bind_custom[by_name]</td>
             <td>Binding is not implemented for custom types in the Rust driver.</td>
-        </tr>
-        <tr>
-            <td colspan=2 align="center" style="font-weight:bold">Future</td>
-        </tr>
-        <tr>
-            <td>cass_future_coordinator</td>
-            <td>Unimplemented</td>
         </tr>
         <tr>
             <td colspan=2 align="center" style="font-weight:bold">Collection</td>


### PR DESCRIPTION
When `cass_future_coordinator` was implemented, we forgot to remove it from the limitations section of the README.md file.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~~