### PR TITLE
Allow clippy public API related complaints

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,5 +10,4 @@
 - [ ] All commit messages clearly explain what they change and why.
 - [ ] PR description sums up the changes and reasons why they should be introduced.
 - [ ] I have implemented Rust unit tests for the features/changes introduced.
-- [ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.
-- [ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.
+- [ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.

--- a/scylla-rust-wrapper/clippy.toml
+++ b/scylla-rust-wrapper/clippy.toml
@@ -17,5 +17,6 @@ disallowed-methods = [
     "std::rc::Rc::into_raw",
 
     "const_ptr::as_ref",
-    "mut_ptr::as_mut"
+    "mut_ptr::as_mut",
 ]
+avoid-breaking-exported-api = false

--- a/scylla-rust-wrapper/src/iterator.rs
+++ b/scylla-rust-wrapper/src/iterator.rs
@@ -489,7 +489,7 @@ impl<'result> CassUdtIterator<'result> {
 
         // SAFETY: `CassDataType` is obtained from `CassResultMetadata`, which is immutable.
         let metadata = match unsafe { value.value_type.get_unchecked() } {
-            CassDataTypeInner::UDT(udt) => udt.field_types.as_slice(),
+            CassDataTypeInner::Udt(udt) => udt.field_types.as_slice(),
             _ => panic!("Expected UDT type. Typecheck should have prevented such scenario!"),
         };
 

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn cass_user_type_new_from_data_type(
     };
 
     match unsafe { data_type.get_unchecked() } {
-        CassDataTypeInner::UDT(udt_data_type) => {
+        CassDataTypeInner::Udt(udt_data_type) => {
             let field_values = vec![None; udt_data_type.field_types.len()];
             BoxFFI::into_ptr(Box::new(CassUserType {
                 data_type,

--- a/scylla-rust-wrapper/src/value.rs
+++ b/scylla-rust-wrapper/src/value.rs
@@ -416,7 +416,7 @@ mod tests {
     use scylla::value::{CqlDate, CqlDecimal, CqlDuration};
 
     use crate::{
-        cass_types::{CassDataType, CassDataTypeInner, CassValueType, MapDataType, UDTDataType},
+        cass_types::{CassDataType, CassDataTypeInner, CassValueType, MapDataType, UdtDataType},
         value::{CassCqlValue, is_type_compatible},
     };
 
@@ -631,7 +631,7 @@ mod tests {
         let user_udt_name = "user".to_owned();
         let empty_str = "".to_owned();
 
-        let data_type_udt_simple = CassDataType::new_arced(CassDataTypeInner::UDT(UDTDataType {
+        let data_type_udt_simple = CassDataType::new_arced(CassDataTypeInner::Udt(UdtDataType {
             field_types: simple_fields.clone(),
             keyspace: ks_keyspace_name.clone(),
             name: user_udt_name.clone(),
@@ -770,14 +770,14 @@ mod tests {
         // UDT
         {
             let data_type_udt_simple_empty_keyspace =
-                CassDataType::new_arced(CassDataTypeInner::UDT(UDTDataType {
+                CassDataType::new_arced(CassDataTypeInner::Udt(UdtDataType {
                     field_types: simple_fields.clone(),
                     keyspace: empty_str.to_owned(),
                     name: user_udt_name.clone(),
                     frozen: false,
                 }));
             let data_type_udt_simple_empty_name =
-                CassDataType::new_arced(CassDataTypeInner::UDT(UDTDataType {
+                CassDataType::new_arced(CassDataTypeInner::Udt(UdtDataType {
                     field_types: simple_fields.clone(),
                     keyspace: ks_keyspace_name.clone(),
                     name: empty_str.clone(),
@@ -790,7 +790,7 @@ mod tests {
                 ("bar".to_owned(), data_type_bool.clone()),
             ];
             let data_type_udt_small =
-                CassDataType::new_arced(CassDataTypeInner::UDT(UDTDataType {
+                CassDataType::new_arced(CassDataTypeInner::Udt(UdtDataType {
                     field_types: small_fields.clone(),
                     keyspace: ks_keyspace_name.clone(),
                     name: user_udt_name.clone(),


### PR DESCRIPTION
This is fully analogous to https://github.com/scylladb/scylla-rust-driver/pull/1359/commits/15448c4fe47a31507abe4113d4ebb2b43d57fa3f. Pasting the commit message:

> Turns out clippy has a terrible and shocking default: it won't make
> suggestions that require introducing breaking changes.
> This means that e.g. if we introduce a type which has a naming that
> clippy would normally complain about, it won't if the type is pub!

1. Clippy is made check public API, too.
2. The affected names are fixed.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/build.yml` in `gtest_filter`.~~
- ~~[ ] I have enabled appropriate tests in `.github/workflows/cassandra.yml` in `gtest_filter`.~~