### PR TITLE
DC-aware LBP - better support the deprecated parameters

### DIFF
--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -2,16 +2,16 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
   # Should include `INTEGRATION_TEST_BIN` from the `Makefile`
   # TODO: Remove `build/libscylla-cpp-driver.*` after https://github.com/scylladb/cpp-rust-driver/issues/164 is fixed.
   INTEGRATION_TEST_BIN: |
-    build/cassandra-integration-tests 
+    build/cassandra-integration-tests
     build/libscylla-cpp-driver.*
   INTEGRATION_TEST_BIN_CACHE_KEY: integration-test-bin-${{ github.sha }}
   # Goes to `Makefile` to let it pickup cached binary
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Update apt cache
         run: sudo apt-get update -y
 
@@ -57,7 +57,13 @@ jobs:
 
     strategy:
       matrix:
-        scylla-version: [ENTERPRISE-RELEASE, ENTERPRISE-PRIOR-RELEASE, OSS-RELEASE, OSS-PRIOR-RELEASE, 5.4.8]
+        scylla-version:
+          [
+            ENTERPRISE-RELEASE,
+            ENTERPRISE-PRIOR-RELEASE,
+            OSS-RELEASE,
+            OSS-PRIOR-RELEASE,
+          ]
       fail-fast: false
 
     steps:
@@ -67,7 +73,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Update apt cache
         run: sudo apt-get update -y
@@ -165,13 +171,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
+          distribution: "adopt"
 
       - name: Setup Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-          
+          python-version: "3.11"
+
       - name: Update apt cache
         run: sudo apt-get update -y
 

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
+:DcAwarePolicyTest.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\
 :SchemaMetadataTest.Integration_Cassandra_VirtualMetadata\
@@ -97,6 +98,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
+:DcAwarePolicyTest.*\
 :-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
 :PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_RoundRobin\
 :ExecutionProfileTest.Integration_Cassandra_TokenAwareRouting\
 :ExecutionProfileTest.Integration_Cassandra_SpeculativeExecutionPolicy\
-:DCExecutionProfileTest.Integration_Cassandra_DCAware\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
 :ControlConnectionTests.Integration_Cassandra_FullOutage\
 :ControlConnectionTests.Integration_Cassandra_TerminatedUsingMultipleIoThreadsWithError\
@@ -107,7 +106,6 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_RoundRobin\
 :ExecutionProfileTest.Integration_Cassandra_TokenAwareRouting\
 :ExecutionProfileTest.Integration_Cassandra_SpeculativeExecutionPolicy\
-:DCExecutionProfileTest.Integration_Cassandra_DCAware\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
 :ControlConnectionTests.Integration_Cassandra_FullOutage\
 :ControlConnectionTests.Integration_Cassandra_TerminatedUsingMultipleIoThreadsWithError\

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -838,8 +838,19 @@ pub(crate) unsafe fn set_load_balance_dc_aware_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
 
-    if used_hosts_per_remote_dc != 0 || allow_remote_dcs_for_local_cl != 0 {
-        // TODO: Add warning that the parameters are deprecated and not supported in the driver.
+    if used_hosts_per_remote_dc != 0 {
+        tracing::error!(
+            "cass_*_set_load_balance_dc_aware(_n): `used_hosts_per_remote_dc` parameter is no longer \
+            supported in the driver. Set it to 0 to avoid this error."
+        );
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    }
+
+    if allow_remote_dcs_for_local_cl != 0 {
+        tracing::error!(
+            "cass_*_set_load_balance_dc_aware(_n): `allow_remote_dcs_for_local_cl` parameter is no longer \
+            supported in the driver. Set it to 0 to avoid this error."
+        );
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
 

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -827,6 +827,9 @@ pub(crate) unsafe fn set_load_balance_dc_aware_n(
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
     if local_dc_raw.is_null() || local_dc_length == 0 {
+        tracing::error!(
+            "Provided null or empty local DC name to cass_*_set_load_balance_dc_aware(_n)!"
+        );
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
 

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -3,7 +3,9 @@ use crate::cass_error::CassError;
 use crate::cass_types::CassConsistency;
 use crate::exec_profile::{CassExecProfile, ExecProfileName, exec_profile_builder_modify};
 use crate::future::CassFuture;
-use crate::load_balancing::{CassHostFilter, LoadBalancingConfig, LoadBalancingKind};
+use crate::load_balancing::{
+    CassHostFilter, DcRestriction, LoadBalancingConfig, LoadBalancingKind,
+};
 use crate::retry_policy::CassRetryPolicy;
 use crate::ssl::CassSsl;
 use crate::timestamp_generator::CassTimestampGen;
@@ -864,6 +866,11 @@ pub(crate) unsafe fn set_load_balance_dc_aware_n(
         local_dc: local_dc.to_owned(),
         permit_dc_failover,
     });
+    load_balancing_config.filtering.dc_restriction = if permit_dc_failover {
+        DcRestriction::None
+    } else {
+        DcRestriction::Local(local_dc.to_owned())
+    };
 
     CassError::CASS_OK
 }

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -956,27 +956,16 @@ mod tests {
                         Some(LoadBalancingKind::DcAware {
                             local_dc,
                             permit_dc_failover,
+                            allow_remote_dcs_for_local_cl,
                         }) => {
                             assert_eq!(local_dc, "eu");
                             assert!(!permit_dc_failover);
+                            assert!(!allow_remote_dcs_for_local_cl);
                         }
                         _ => panic!("Expected preferred dc"),
                     }
                     assert!(!profile.load_balancing_config.token_awareness_enabled);
                     assert!(profile.load_balancing_config.latency_awareness_enabled);
-                }
-                /* Test invalid configurations */
-                {
-                    // Nonzero (deprecated and unsupported) parameter
-                    assert_cass_error_eq!(
-                        cass_execution_profile_set_load_balance_dc_aware(
-                            profile_raw.borrow_mut(),
-                            c"eu".as_ptr(),
-                            0,
-                            1
-                        ),
-                        CassError::CASS_ERROR_LIB_BAD_PARAMS
-                    );
                 }
             }
 

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -933,7 +933,7 @@ mod tests {
                         cass_execution_profile_set_load_balance_dc_aware(
                             profile_raw.borrow_mut(),
                             c"eu".as_ptr(),
-                            0,
+                            0, // forbid DC failover
                             0
                         ),
                         CassError::CASS_OK
@@ -953,8 +953,12 @@ mod tests {
                     let profile = BoxFFI::as_ref(profile_raw.borrow()).unwrap();
                     let load_balancing_kind = &profile.load_balancing_config.load_balancing_kind;
                     match load_balancing_kind {
-                        Some(LoadBalancingKind::DcAware { local_dc }) => {
-                            assert_eq!(local_dc, "eu")
+                        Some(LoadBalancingKind::DcAware {
+                            local_dc,
+                            permit_dc_failover,
+                        }) => {
+                            assert_eq!(local_dc, "eu");
+                            assert!(!permit_dc_failover);
                         }
                         _ => panic!("Expected preferred dc"),
                     }
@@ -963,16 +967,7 @@ mod tests {
                 }
                 /* Test invalid configurations */
                 {
-                    // Nonzero deprecated parameters
-                    assert_cass_error_eq!(
-                        cass_execution_profile_set_load_balance_dc_aware(
-                            profile_raw.borrow_mut(),
-                            c"eu".as_ptr(),
-                            1,
-                            0
-                        ),
-                        CassError::CASS_ERROR_LIB_BAD_PARAMS
-                    );
+                    // Nonzero (deprecated and unsupported) parameter
                     assert_cass_error_eq!(
                         cass_execution_profile_set_load_balance_dc_aware(
                             profile_raw.borrow_mut(),

--- a/tests/src/integration/tests/test_dc_aware_policy.cpp
+++ b/tests/src/integration/tests/test_dc_aware_policy.cpp
@@ -16,7 +16,11 @@
 
 #include "cassandra.h"
 #include "integration.hpp"
+#include "objects/error_result.hpp"
+#include "objects/execution_profile.hpp"
+#include "objects/statement.hpp"
 
+#include "gtest/gtest.h"
 #include <algorithm>
 #include <iterator>
 
@@ -54,6 +58,45 @@ public:
     EXPECT_EQ(result.first_row().next().as<Varchar>(), Varchar("two"));
 
     return attempted_hosts;
+  }
+
+  void validate_with_statement(Statement const& statement, bool const expect_no_hosts_available_error, bool const expect_remotes_used) {
+    std::vector<std::string> attempted_hosts, temp;
+    Result result;
+
+    result = session_.execute(statement, !expect_no_hosts_available_error);
+    temp = result.attempted_hosts();
+    std::copy(temp.begin(), temp.end(), std::back_inserter(attempted_hosts));
+
+    if (expect_no_hosts_available_error) {
+        EXPECT_EQ(result.error_result().error_code(), CASS_ERROR_LIB_NO_HOSTS_AVAILABLE);
+        return; // No hosts available, so nothing more to check.
+    } else {
+        // The query should succeed, so we can check the result.
+        EXPECT_EQ(result.first_row().next().as<Varchar>(), Varchar("one"));
+    }
+
+    if (expect_remotes_used) {
+        // Verify that remote DC hosts were used.
+        EXPECT_TRUE(contains(ccm_->get_ip_prefix() + "3", attempted_hosts) ||
+                    contains(ccm_->get_ip_prefix() + "4", attempted_hosts));
+
+        // Verify that no local DC hosts where used.
+        //
+        // Commented out, because I'm not sure if this is guaranteed:
+        // the driver may have already noticed that the local DC hosts
+        // are down and removed them from the host list.
+        // EXPECT_TRUE(!contains(ccm_->get_ip_prefix() + "1", attempted_hosts) &&
+        //             !contains(ccm_->get_ip_prefix() + "2", attempted_hosts));
+    } else {
+        // Verify that local DC hosts were used.
+        EXPECT_TRUE(contains(ccm_->get_ip_prefix() + "1", attempted_hosts) ||
+                    contains(ccm_->get_ip_prefix() + "2", attempted_hosts));
+
+        // Verify that no remote DC hosts were used.
+        EXPECT_TRUE(!contains(ccm_->get_ip_prefix() + "3", attempted_hosts) &&
+                    !contains(ccm_->get_ip_prefix() + "4", attempted_hosts));
+    }
   }
 
   Statement select_statement(const std::string& key) {
@@ -117,5 +160,75 @@ CASSANDRA_INTEGRATION_TEST_F(DcAwarePolicyTest, UsedHostsRemoteDc) {
     // Verify that no local DC hosts where used
     EXPECT_TRUE(!contains(ccm_->get_ip_prefix() + "1", attempted_hosts) &&
                 !contains(ccm_->get_ip_prefix() + "2", attempted_hosts));
+  }
+}
+
+/**
+ * Verify that the "allow remote DCs for local CL" setting allows requests that are using
+ * a local consistency level to be routed to remote DC nodes when the local DC nodes
+ * are unavailable.
+ * Also, verify that requests using a local consistency level are not routed to remote DC nodes
+ * when the local DC nodes are unavailable if the "allow remote DCs for local CL" setting is false.
+ *
+ * @test_category load_balancing_policy:dc_aware
+ */
+CASSANDRA_INTEGRATION_TEST_F(DcAwarePolicyTest, AllowRemoteDcsForLocalCl) {
+  CHECK_FAILURE
+
+  cluster_ = default_cluster();
+  char const *const local_dc = "dc1";
+  cluster_.with_load_balance_dc_aware(local_dc, 42, false);
+
+  ExecutionProfile profile_allowing_remote_dcs_for_local_cl = ExecutionProfile::build().with_load_balance_dc_aware(local_dc, 42, true);
+  char const *const profile_name = "allow_remote_dcs_for_local_cl";
+  cluster_.with_execution_profile(profile_name, profile_allowing_remote_dcs_for_local_cl);
+
+  connect(cluster_);
+
+  // Create a test table and add test data to it
+  initialize();
+
+  Statement statement_with_nonlocal_consistency = select_statement("1");
+  statement_with_nonlocal_consistency.set_consistency(CASS_CONSISTENCY_TWO);
+
+  Statement statement_with_local_consistency = select_statement("1");
+  statement_with_local_consistency.set_consistency(CASS_CONSISTENCY_LOCAL_ONE);
+
+  std::cerr << "Testing with `allow_remote_dcs_for_local_cl`=`false`" << std::endl;
+  {
+    std::cerr << "Running nonlocal statement with local DC available" << std::endl;
+    // With local DC available, everything should succeed and only local DC hosts should be used.
+    validate_with_statement(statement_with_nonlocal_consistency, false, false);
+
+    std::cerr << "Running local statement with local DC available" << std::endl;
+    // With local DC available, everything should succeed and only local DC hosts should be used.
+    validate_with_statement(statement_with_local_consistency, false, false);
+
+    // Stop the whole local DC.
+    stop_node(1, true);
+    stop_node(2, true);
+
+    std::cerr << "Running nonlocal statement with local DC unavailable" << std::endl;
+    // With local DC unavailable, remote DC available and nonlocal consistency used, remote hosts should be used and the request should succeed.
+    validate_with_statement(statement_with_nonlocal_consistency, false, true);
+
+    std::cerr << "Running local statement with local DC unavailable" << std::endl;
+    // With local DC unavailable, remote DC available and local consistency used, remote hosts should be forbidden and the request should fail.
+    validate_with_statement(statement_with_local_consistency, true, false);
+  }
+
+  statement_with_local_consistency.set_execution_profile(profile_name);
+  statement_with_nonlocal_consistency.set_execution_profile(profile_name);
+  std::cerr << "Testing with `allow_remote_dcs_for_local_cl`=`true`" << std::endl;
+  {
+      // The local DC nodes are still dead.
+
+      std::cerr << "Running nonlocal statement with local DC unavailable" << std::endl;
+      // With local DC unavailable, remote DC available and nonlocal consistency used, remote hosts should be used and the request should succeed.
+      validate_with_statement(statement_with_nonlocal_consistency, false, true);
+
+      std::cerr << "Running local statement with local DC unavailable" << std::endl;
+      // With local DC unavailable, remote DC available and local consistency used, remote hosts should be used and the request should succeed.
+      validate_with_statement(statement_with_local_consistency, false, true);
   }
 }

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -715,6 +715,11 @@ CASSANDRA_INTEGRATION_TEST_F(ExecutionProfileTest, SpeculativeExecutionPolicy) {
 CASSANDRA_INTEGRATION_TEST_F(DCExecutionProfileTest, DCAware) {
   CHECK_FAILURE;
 
+  // Determine the disallowed IP address for the statement DC-aware execution
+  int const unexpected_node = 3; // The node in DC2.
+  std::stringstream unexpected_ip_address;
+  unexpected_ip_address << ccm_->get_ip_prefix() << unexpected_node;
+
   // Execute statements over all the nodes in the cluster twice
   for (size_t i = 0; i < total_nodes_ * 2; ++i) {
     // Execute the same query with the cluster default profile
@@ -722,28 +727,19 @@ CASSANDRA_INTEGRATION_TEST_F(DCExecutionProfileTest, DCAware) {
     Result result = session_.execute(insert_);
     ASSERT_EQ(CASS_OK, result.error_code());
 
-    // Determine the expected IP address for the statement execution
-    int expected_node = ((i * 2) % number_dc1_nodes_) + 1;
-    std::stringstream expected_ip_address;
-    expected_ip_address << ccm_->get_ip_prefix() << expected_node;
-
     // Execute a batched query with assigned profile
     Batch batch;
     batch.add(insert_);
     batch.set_execution_profile("dc_aware");
     result = session_.execute(batch);
     ASSERT_EQ(CASS_OK, result.error_code());
-    ASSERT_STREQ(expected_ip_address.str().c_str(), result.host().c_str());
-
-    // Increment the expected round robin IP address
-    expected_ip_address.str("");
-    expected_ip_address << ccm_->get_ip_prefix() << expected_node + 1;
+    ASSERT_STRNE(unexpected_ip_address.str().c_str(), result.host().c_str());
 
     // Execute a simple query with assigned profile
     insert_.set_execution_profile("dc_aware");
     result = session_.execute(insert_);
     ASSERT_EQ(CASS_OK, result.error_code());
-    ASSERT_STREQ(expected_ip_address.str().c_str(), result.host().c_str());
+    ASSERT_STRNE(unexpected_ip_address.str().c_str(), result.host().c_str());
   }
 }
 

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -193,15 +193,15 @@ public:
   void SetUp() {
     // Create the execution profiles for the test cases
     profiles_["dc_aware"] = ExecutionProfile::build()
-                                .with_load_balance_dc_aware("dc1", 0, false)
+                                .with_load_balance_dc_aware("dc1", 1, false)
                                 .with_consistency(CASS_CONSISTENCY_LOCAL_ONE);
     profiles_["blacklist_dc"] = ExecutionProfile::build()
                                     .with_blacklist_dc_filtering("dc1")
-                                    .with_load_balance_dc_aware("dc1", 0, false)
+                                    .with_load_balance_dc_aware("dc1", 1, true)
                                     .with_consistency(CASS_CONSISTENCY_LOCAL_ONE);
     profiles_["whitelist_dc"] = ExecutionProfile::build()
                                     .with_whitelist_dc_filtering("dc2")
-                                    .with_load_balance_dc_aware("dc1", 0, false)
+                                    .with_load_balance_dc_aware("dc1", 1, true)
                                     .with_consistency(CASS_CONSISTENCY_LOCAL_ONE);
 
     // Call the parent setup function


### PR DESCRIPTION
# Background
The parameters: `used_hosts_per_remote_dc`,  `allow_remote_dcs_for_local_cl` of the DC-aware LBP have been long deprecated. However, they've been still supported in the cpp-driver, so we should probably support it. At least, we should accept the same set of values as the cpp-driver, which has not been true: values other than `0` would trigger `CASS_ERROR_LIB_BAD_PARAMS`, and `0` would result in a behaviour different than cpp-driver's: it would be ignored and not restrict remote DC hosts at all.

# What's done

## More informative warnings/errors

The messages logged when an invalid / not supported / partially supported value is given as a parameter are made more informative.

## Made `used_hosts_per_remote_dc` semantics closer to cpp-driver's

Due to Rust driver API's, it'd be very hard to support it correctly in the case of `>0`, because of reasons explained in     https://github.com/scylladb/cpp-rust-driver/issues/315. Therefore, the partial support approach is taken:
- case `=0` -> employ `CassHostFilter`, disable DC failover and we're done. Our semantics here are in line with the CPP Driver.
- case `>0` -> Treat this as `+inf` case - don't limit connections nor requests to remote nodes. Emit a warning that the semantics are different than in CPP Driver.

### Allowed `used_hosts_per_remote_dc > 0` and described its limitations

Any nonzero value is treated as `+inf`, which means that the datacenter failover is permitted without restrictions. All remote nodes can have opened connections to and be targeted with requests.

### Fixed `used_hosts_per_remote_dc = 0` semantics and made it fully consistent with cpp-driver's

1. Datacenter failover is disabled, meaning that remote nodes do not appear in query plans.
2. If a DC is remote to **all** LBPs **and** those LBPs disallow DC failover, then the driver will not connect to any hosts in that DC. This addresses the need to minimise overhead and costs of needless connecting to remote DCs.

## Implemented full support of `allow_remote_dcs_for_local_cl`

This was as simple as using another filtering logic in the existing `FilteringLoadBalancingPolicy`. 

# Testing

## Unit tests

Unit tests were introduced for internal abstractions used to configure the `CassHostFilter` to filter out remote nodes, if those are disallowed by all LBPs. Existing unit tests were adjusted to expect `used_hosts_per_remote_dc > 0` as supported.
A unit test was written for the backbone of `allow_remote_dcs_for_local_cl`, `DcLocalConsistencyAllowance`.

## Integration tests

1. Enabled `DCExecutionProfileTest_DCAware` test.
2. Enabled `DcAwarePolicyTest_UsedHostsRemoteDc` test.
3. Written a missing test for the `allow_remote_dcs_for_local_cl` option: `DcAwarePolicyTest_AllowRemoteDcsForLocalCl`.

# Unresolved questions

Behaviour of both our previous and current implementation of functions taking `used_hosts_per_remote_dc` parameter differ from one described in `cassandra.h`. Should we adjust the documentation there to be in line with the implementation?

Fixes: #315

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
~~- [ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.