### PR TITLE
IT: Support `set_record_contacted_hosts()` and `get_attempted_hosts_from_future()`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,4 @@
 - [ ] PR description sums up the changes and reasons why they should be introduced.
 - [ ] I have implemented Rust unit tests for the features/changes introduced.
 - [ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
+- [ ] I added appropriate `Fixes:` annotations to PR description.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.zed
 build/
 scylla-rust-wrapper/target/
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -292,4 +292,4 @@ endif
 	build/cassandra-integration-tests --version=${CASSANDRA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${CASSANDRA_NO_VALGRIND_TEST_FILTER}"
 
 run-test-unit: install-cargo-if-missing _update-rust-tooling
-	@cd ${CURRENT_DIR}/scylla-rust-wrapper; cargo test
+	@cd ${CURRENT_DIR}/scylla-rust-wrapper; RUSTFLAGS="--cfg cpp_rust_unstable --cfg cpp_integration_testing" cargo test

--- a/scylla-rust-wrapper/.cargo/config.toml
+++ b/scylla-rust-wrapper/.cargo/config.toml
@@ -1,3 +1,3 @@
 [build]
-# To enable cpp-rust only features from Rust driver. 
+# To enable cpp-rust only features from Rust driver.
 rustflags = ["--cfg", "cpp_rust_unstable"]

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -1,4 +1,5 @@
 use std::ffi::{CString, c_char};
+use std::fmt::Write as _;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -246,6 +247,85 @@ pub unsafe extern "C" fn testing_statement_set_recording_history_listener(
     let statement = &mut BoxFFI::as_mut_ref(statement_raw).unwrap();
 
     statement.record_hosts = enable != 0;
+}
+
+/// Retrieves hosts that were attempted during the execution of a future.
+/// In order for this to work, the statement must have been configured with
+/// `testing_statement_set_recording_history_listener`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn testing_future_get_attempted_hosts(
+    future_raw: CassBorrowedSharedPtr<CassFuture, CMut>,
+) -> *mut c_char {
+    // This function should return a list of attempted hosts.
+    // Care should be taken to ensure that the list is properly allocated and freed.
+    // The problem is that the return type must be understandable by C code.
+    // See testing.cpp:53 (get_attempted_hosts_from_future()) for an example of how
+    // this is done in C++.
+    //
+    // Idea: Create a concatenated string of attempted hosts.
+    // Return a pointer to that string. Caller is responsible for freeing it.
+
+    let future: &CassFuture = ArcFFI::as_ref(future_raw).unwrap();
+
+    let attempted_hosts = future.attempted_hosts();
+    let concatenated_hosts = attempted_hosts.iter().fold(String::new(), |mut acc, host| {
+        // Convert the SocketAddr to a string.
+        // Delimit address strings with '\n' to enable easy parsing in C.
+
+        write!(&mut acc, "{}\n", host.ip()).unwrap();
+        acc
+    });
+
+    // The caller is responsible for freeing this memory, by calling `testing_free_cstring`.
+    unsafe { CString::from_vec_unchecked(concatenated_hosts.into_bytes()) }.into_raw()
+}
+
+/// Ensures that the `testing_future_get_attempted_hosts` function
+/// behaves correctly, i.e., it returns a list of attempted hosts as a concatenated string.
+#[test]
+fn test_future_get_attempted_hosts() {
+    use scylla::observability::history::HistoryListener as _;
+
+    let listener = Arc::new(RecordingHistoryListener::new());
+    let future = CassFuture::new_from_future(std::future::pending(), Some(listener.clone()));
+
+    fn assert_attempted_hosts_eq(future: &Arc<CassFuture>, hosts: &[String]) {
+        let hosts_str = unsafe { testing_future_get_attempted_hosts(ArcFFI::as_ptr(future)) };
+        let hosts_cstr = unsafe { CString::from_raw(hosts_str) };
+        let hosts_string = hosts_cstr.to_str().unwrap();
+
+        // Split the string by '\n' and collect into a Vec<&str>.
+        let attempted_hosts: Vec<&str> =
+            hosts_string.split('\n').filter(|s| !s.is_empty()).collect();
+
+        assert_eq!(attempted_hosts, hosts);
+    }
+
+    // 1. Test with no attempted hosts.
+    {
+        assert_attempted_hosts_eq(&future, &[]);
+    }
+
+    let addr1: SocketAddr = SocketAddr::from(([127, 0, 0, 1], 9042));
+    let addr2: SocketAddr = SocketAddr::from(([127, 0, 0, 2], 9042));
+
+    // 2. Attempt two hosts and see if they are recorded correctly, in order.
+    {
+        listener.log_attempt_start(RequestId(0), None, addr1);
+        listener.log_attempt_start(RequestId(0), None, addr2);
+        assert_attempted_hosts_eq(&future, &[addr1, addr2].map(|addr| addr.ip().to_string()))
+    }
+
+    let addr3: SocketAddr = SocketAddr::from(([127, 0, 0, 3], 9042));
+
+    // 3. Attempt one more host and see if all hosts are present, in order.
+    {
+        listener.log_attempt_start(RequestId(0), None, addr3);
+        assert_attempted_hosts_eq(
+            &future,
+            &[addr1, addr2, addr3].map(|addr| addr.ip().to_string()),
+        )
+    }
 }
 
 /// A retry policy that always ignores all errors.

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -193,7 +193,6 @@ impl RecordingHistoryListener {
         }
     }
 
-    #[expect(unused)] // <- next commit removes this
     pub(crate) fn get_attempted_hosts(&self) -> Vec<SocketAddr> {
         self.attempted_hosts.lock().unwrap().clone()
     }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -81,7 +81,7 @@ impl CassSessionInner {
         let exec_profile_map = cluster.execution_profile_map().clone();
         let host_filter = cluster.build_host_filter();
 
-        CassFuture::make_raw(Self::connect_fut(
+        let fut = Self::connect_fut(
             session_opt,
             session_builder,
             exec_profile_map,
@@ -91,7 +91,13 @@ impl CassSessionInner {
                 // If user did not set a client id, generate a random uuid v4.
                 .unwrap_or_else(uuid::Uuid::new_v4),
             keyspace,
-        ))
+        );
+
+        CassFuture::make_raw(
+            fut,
+            #[cfg(cpp_integration_testing)]
+            None,
+        )
     }
 
     async fn connect_fut(
@@ -255,10 +261,16 @@ pub unsafe extern "C" fn cass_session_execute_batch(
     };
 
     match request_timeout_ms {
-        Some(timeout_ms) => {
-            CassFuture::make_raw(async move { request_with_timeout(timeout_ms, future).await })
-        }
-        None => CassFuture::make_raw(future),
+        Some(timeout_ms) => CassFuture::make_raw(
+            async move { request_with_timeout(timeout_ms, future).await },
+            #[cfg(cpp_integration_testing)]
+            None,
+        ),
+        None => CassFuture::make_raw(
+            future,
+            #[cfg(cpp_integration_testing)]
+            None,
+        ),
     }
 }
 
@@ -297,19 +309,24 @@ pub unsafe extern "C" fn cass_session_execute(
     let mut statement = statement_opt.statement.clone();
 
     #[cfg(cpp_integration_testing)]
-    statement_opt.record_hosts.then(|| {
+    let recording_listener = statement_opt.record_hosts.then(|| {
         let recording_listener =
             Arc::new(crate::integration_testing::RecordingHistoryListener::new());
         match statement {
             BoundStatement::Simple(ref mut unprepared) => {
-                unprepared.query.set_history_listener(recording_listener);
+                unprepared
+                    .query
+                    .set_history_listener(Arc::clone(&recording_listener) as _);
             }
             BoundStatement::Prepared(ref mut prepared) => {
+                // It's extremely interesting to me that this `as _` cast is required
+                // for the type checker to accept this code.
                 Arc::make_mut(&mut prepared.statement)
                     .statement
-                    .set_history_listener(recording_listener);
+                    .set_history_listener(Arc::clone(&recording_listener) as _);
             }
         };
+        recording_listener
     });
 
     let statement_exec_profile = statement_opt.exec_profile.clone();
@@ -426,10 +443,16 @@ pub unsafe extern "C" fn cass_session_execute(
     };
 
     match request_timeout_ms {
-        Some(timeout_ms) => {
-            CassFuture::make_raw(async move { request_with_timeout(timeout_ms, future).await })
-        }
-        None => CassFuture::make_raw(future),
+        Some(timeout_ms) => CassFuture::make_raw(
+            async move { request_with_timeout(timeout_ms, future).await },
+            #[cfg(cpp_integration_testing)]
+            recording_listener,
+        ),
+        None => CassFuture::make_raw(
+            future,
+            #[cfg(cpp_integration_testing)]
+            recording_listener,
+        ),
     }
 }
 
@@ -449,31 +472,35 @@ pub unsafe extern "C" fn cass_session_prepare_from_existing(
 
     let statement = cass_statement.statement.clone();
 
-    CassFuture::make_raw(async move {
-        let query = match &statement {
-            BoundStatement::Simple(q) => q,
-            BoundStatement::Prepared(ps) => {
-                return Ok(CassResultValue::Prepared(ps.statement.clone()));
+    CassFuture::make_raw(
+        async move {
+            let query = match &statement {
+                BoundStatement::Simple(q) => q,
+                BoundStatement::Prepared(ps) => {
+                    return Ok(CassResultValue::Prepared(Arc::clone(&ps.statement)));
+                }
+            };
+
+            let session_guard = session.read().await;
+            if session_guard.is_none() {
+                return Err((
+                    CassError::CASS_ERROR_LIB_NO_HOSTS_AVAILABLE,
+                    "Session is not connected".msg(),
+                ));
             }
-        };
+            let session = &session_guard.as_ref().unwrap().session;
+            let prepared = session
+                .prepare(query.query.clone())
+                .await
+                .map_err(|err| (err.to_cass_error(), err.msg()))?;
 
-        let session_guard = session.read().await;
-        if session_guard.is_none() {
-            return Err((
-                CassError::CASS_ERROR_LIB_NO_HOSTS_AVAILABLE,
-                "Session is not connected".msg(),
-            ));
-        }
-        let session = &session_guard.as_ref().unwrap().session;
-        let prepared = session
-            .prepare(query.query.clone())
-            .await
-            .map_err(|err| (err.to_cass_error(), err.msg()))?;
-
-        Ok(CassResultValue::Prepared(Arc::new(
-            CassPrepared::new_from_prepared_statement(prepared),
-        )))
-    })
+            Ok(CassResultValue::Prepared(Arc::new(
+                CassPrepared::new_from_prepared_statement(prepared),
+            )))
+        },
+        #[cfg(cpp_integration_testing)]
+        None,
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -503,7 +530,7 @@ pub unsafe extern "C" fn cass_session_prepare_n(
         .unwrap_or_default();
     let query = Statement::new(query_str.to_string());
 
-    CassFuture::make_raw(async move {
+    let fut = async move {
         let session_guard = cass_session.read().await;
         if session_guard.is_none() {
             return Err((
@@ -524,7 +551,13 @@ pub unsafe extern "C" fn cass_session_prepare_n(
         Ok(CassResultValue::Prepared(Arc::new(
             CassPrepared::new_from_prepared_statement(prepared),
         )))
-    })
+    };
+
+    CassFuture::make_raw(
+        fut,
+        #[cfg(cpp_integration_testing)]
+        None,
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -541,19 +574,23 @@ pub unsafe extern "C" fn cass_session_close(
         return ArcFFI::null();
     };
 
-    CassFuture::make_raw(async move {
-        let mut session_guard = session_opt.write().await;
-        if session_guard.is_none() {
-            return Err((
-                CassError::CASS_ERROR_LIB_UNABLE_TO_CLOSE,
-                "Already closing or closed".msg(),
-            ));
-        }
+    CassFuture::make_raw(
+        async move {
+            let mut session_guard = session_opt.write().await;
+            if session_guard.is_none() {
+                return Err((
+                    CassError::CASS_ERROR_LIB_UNABLE_TO_CLOSE,
+                    "Already closing or closed".msg(),
+                ));
+            }
 
-        *session_guard = None;
+            *session_guard = None;
 
-        Ok(CassResultValue::Empty)
-    })
+            Ok(CassResultValue::Empty)
+        },
+        #[cfg(cpp_integration_testing)]
+        None,
+    )
 }
 
 #[unsafe(no_mangle)]

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -31,7 +31,7 @@ use thiserror::Error;
 
 #[derive(Clone)]
 pub enum BoundStatement {
-    Simple(BoundSimpleQuery),
+    Simple(BoundSimpleStatement),
     Prepared(BoundPreparedStatement),
 }
 
@@ -111,13 +111,13 @@ impl BoundPreparedStatement {
 }
 
 #[derive(Clone)]
-pub(crate) struct BoundSimpleQuery {
+pub(crate) struct BoundSimpleStatement {
     pub(crate) query: Statement,
     pub(crate) bound_values: Vec<MaybeUnset<Option<CassCqlValue>>>,
     pub(crate) name_to_bound_index: HashMap<String, usize>,
 }
 
-impl BoundSimpleQuery {
+impl BoundSimpleStatement {
     fn bind_cql_value(&mut self, index: usize, value: Option<CassCqlValue>) -> CassError {
         match self.bound_values.get_mut(index) {
             Some(v) => {
@@ -236,7 +236,7 @@ impl CassStatement {
         }
     }
 
-    pub(crate) fn new_unprepared(statement: BoundSimpleQuery) -> Self {
+    pub(crate) fn new_unprepared(statement: BoundSimpleStatement) -> Self {
         Self::new(BoundStatement::Simple(statement))
     }
 
@@ -304,7 +304,7 @@ pub unsafe extern "C" fn cass_statement_new_n(
 
     let query = Statement::new(query_str.to_string());
 
-    let simple_query = BoundSimpleQuery {
+    let simple_query = BoundSimpleStatement {
         query,
         bound_values: vec![Unset; parameter_count as usize],
         name_to_bound_index: HashMap::with_capacity(parameter_count as usize),

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -218,6 +218,8 @@ pub struct CassStatement {
     pub(crate) request_timeout_ms: Option<cass_uint64_t>,
 
     pub(crate) exec_profile: Option<PerStatementExecProfile>,
+    #[cfg(cpp_integration_testing)]
+    pub(crate) record_hosts: bool,
 }
 
 impl FFI for CassStatement {
@@ -233,6 +235,8 @@ impl CassStatement {
             paging_enabled: false,
             request_timeout_ms: None,
             exec_profile: None,
+            #[cfg(cpp_integration_testing)]
+            record_hosts: false,
         }
     }
 

--- a/src/testing_rust_impls.h
+++ b/src/testing_rust_impls.h
@@ -40,6 +40,19 @@ CASS_EXPORT void testing_batch_set_sleeping_history_listener(CassBatch *batch,
     cass_uint64_t sleep_time_ms);
 }
 
+// Sets a recording history listener on the statement.
+// This can be used to collect addresses of hosts attempted during statement execution.
+// Those can be later retrieved using `testing_future_get_attempted_hosts`.
+CASS_EXPORT void testing_statement_set_recording_history_listener(CassStatement *statement,
+    cass_bool_t enable);
+
+// Retrieves a concatenated string of attempted hosts from the future.
+// Hosts are delimited with '\n' character.
+// Hosts are recorded only if `testing_statement_set_recording_history_listener`
+// was called on the statement previously.
+// The returned pointer is allocated and must be freed with `testing_free_cstring`.
+CASS_EXPORT char* testing_future_get_attempted_hosts(CassFuture *future);
+
 /**
  * Creates a new ignoring retry policy.
  *


### PR DESCRIPTION
This PR re-implements `set_record_contacted_hosts()` and associated `get_attempted_hosts_from_future()` integration test functions in the Rust wrapper.

For now, no test using it is enabled. This is because none of them has its other requirements met. In #321, I'll be able to enable DCAware test suite. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
