### PR TITLE
Release 0.5.0

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-cpp-driver-rust"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "assert_matches",
  "bindgen",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cpp-driver-rust"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"
 repository = "https://github.com/scylladb/scylla-rust-driver"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB CPP Rust Driver 0.5.0, an API-compatible rewrite of https://github.com/scylladb/cpp-driver as a wrapper for the Rust driver. It will fully replace the CPP driver, which is already reaching its End of Life.

The driver version shall be considered **Beta**.

Some minor features still need to be included. See [_Limitations_](https://github.com/scylladb/cpp-rust-driver/?tab=readme-ov-file#limitations) and [_Unimplemented functions from cassandra.h_](https://github.com/scylladb/cpp-rust-driver/?tab=readme-ov-file#unimplemented-functions-from-cassandrah) sections in README.md.

The underlying Rust driver used version: [1.2.0](https://github.com/scylladb/scylla-rust-driver/releases/tag/v1.2.0).

## Changes

**Implemented API functions:**
- **Connection**
    - `cass_cluster_set_coalesce_delay` ([#252](https://github.com/scylladb/cpp-rust-driver/pull/252))
    - `cass_cluster_set_local_address[_n]` and `cass_cluster_set_local_port_range` ([#254](https://github.com/scylladb/cpp-rust-driver/pull/254))
    - `cass_cluster_set_core_connections_per_host` and `cass_cluster_set_core_connections_per_shard` ([#281](https://github.com/scylladb/cpp-rust-driver/pull/281))
- **Timestamp generation** ([#295](https://github.com/scylladb/cpp-rust-driver/pull/295)):
    - `cass_timestamp_gen_server_side_new`
    - `cass_timestamp_gen_monotonic_new`
    - `cass_timestamp_gen_monotonic_new_with_settings`
    - `cass_timestamp_gen_free`
    - `cass_cluster_set_timestamp_gen`
- **Host filtering** ([#291](https://github.com/scylladb/cpp-rust-driver/pull/291)):
    - `cass_execution_profile_set_whitelist_filtering`
    - `cass_execution_profile_set_whitelist_filtering_n`
    - `cass_execution_profile_set_blacklist_filtering`
    - `cass_execution_profile_set_blacklist_filtering_n`
    - `cass_execution_profile_set_whitelist_dc_filtering`
    - `cass_execution_profile_set_whitelist_dc_filtering_n`
    - `cass_execution_profile_set_blacklist_dc_filtering`
    - `cass_execution_profile_set_blacklist_dc_filtering_n`
    - `cass_cluster_set_whitelist_filtering`
    - `cass_cluster_set_whitelist_filtering_n`
    - `cass_cluster_set_blacklist_filtering`
    - `cass_cluster_set_blacklist_filtering_n`
    - `cass_cluster_set_whitelist_dc_filtering`
    - `cass_cluster_set_whitelist_dc_filtering_n`
    - `cass_cluster_set_blacklist_dc_filtering`
    - `cass_cluster_set_blacklist_dc_filtering_n`
- **Inspecting/enforcing coordinator** ([#299](https://github.com/scylladb/cpp-rust-driver/pull/299), [#316](https://github.com/scylladb/cpp-rust-driver/pull/316)):
    - `cass_statement_set_host`
    - `cass_statement_set_host_n`
    - `cass_statement_set_host_inet`
    - `cass_statement_set_node`
    - `cass_future_coordinator`
- **Observability**:
    - `cass_session_get_metrics` ([#280](https://github.com/scylladb/cpp-rust-driver/pull/280))
    - `cass_retry_policy_logging_new` ([#287](https://github.com/scylladb/cpp-rust-driver/pull/287))

**New features / enhancements**
- Made returned errors more in line with the CPP Driver's. ([#255](https://github.com/scylladb/cpp-rust-driver/pull/255), [#297](https://github.com/scylladb/cpp-rust-driver/pull/297))
- When an unexpected null pointer is provided, the driver no longer panics; instead, the error is logged and returned. ([#300](https://github.com/scylladb/cpp-rust-driver/pull/300))
- The parameters: `used_hosts_per_remote_dc` and `allow_remote_dcs_for_local_cl` of the DC-aware LBP are now properly supported. ([#321](https://github.com/scylladb/cpp-rust-driver/pull/321))

**Bug fixes:**
- Fixed conversion of serial variants of `CassConsistency`. Now, `CassConsistency` SERIAL or LOCAL_SERIAL can be used as consistency for SELECTs to make them use Paxos. ([#289](https://github.com/scylladb/cpp-rust-driver/pull/289))
- Null pointer provided to `cass_cluster_set_contact_points` now correctly clears the list. ([#293](https://github.com/scylladb/cpp-rust-driver/pull/293))
- Fixed errors when `-DCASS_BUILD_SHARED=OFF` was specified upon build. ([#310](https://github.com/scylladb/cpp-rust-driver/pull/310))

**CI / developer tool improvements:**
- Enabled subset of `ControlConnectionTests` suite. ([#255](https://github.com/scylladb/cpp-rust-driver/pull/255))
- Adjusted and enabled `LatencyAwarePolicyTest` suite. ([#256](https://github.com/scylladb/cpp-rust-driver/pull/256))
- Enabled two tests from `MetricsTests` suite. ([#280](https://github.com/scylladb/cpp-rust-driver/pull/280))
- Enabled tests from `ExecutionProfileTest` suite. ([#287](https://github.com/scylladb/cpp-rust-driver/pull/287), [#290](https://github.com/scylladb/cpp-rust-driver/pull/290))
- `integration_testing.rs` is now compiled conditionally, only in the testing mode. ([#288](https://github.com/scylladb/cpp-rust-driver/pull/288))
- `NetworkTopologyStrategy` is now used in integration tests by default. ([#292](https://github.com/scylladb/cpp-rust-driver/pull/292))
- Enabled some tests from the `ServerSideFailure` suite. ([#294](https://github.com/scylladb/cpp-rust-driver/pull/294))
- Enabled most tests from the `TimestampTests` suite. ([#295](https://github.com/scylladb/cpp-rust-driver/pull/295))
- Enabled tests from `StatementNoClusterTests`, `StatementTests` and `ServerSideFailureThreeNodeTests` suites. ([#299](https://github.com/scylladb/cpp-rust-driver/pull/299))
- Fixed rpm package build failure on fedora-40-x86_64, by updating the target to newer fedoras 41 and 42. ([#311](https://github.com/scylladb/cpp-rust-driver/pull/311))
- Increased timestamp tolerance in `Timestamps` test to combat flakiness. ([#313](https://github.com/scylladb/cpp-rust-driver/pull/313))
- Allowed clippy public API-related complaints. ([#317](https://github.com/scylladb/cpp-rust-driver/pull/317))
- Implemented `set_record_contacted_hosts()` and `get_attempted_hosts_from_future()` for use in integration tests. ([#322](https://github.com/scylladb/cpp-rust-driver/pull/322))
- Enabled `DcAwarePolicyTest` suite and extended it with one new test case. ([#321](https://github.com/scylladb/cpp-rust-driver/pull/321))

**Documentation:**
- Updated docs' dependencies. ([#286](https://github.com/scylladb/cpp-rust-driver/pull/286))
- Written `MAINTENANCE.md`, a guide for maintainers. Currently contains information about the release process. ([#306](https://github.com/scylladb/cpp-rust-driver/pull/306))
- Documented most important CMake options in README. ([#307](https://github.com/scylladb/cpp-rust-driver/pull/307))
- Listed all unimplemented API functions in README. ([#320](https://github.com/scylladb/cpp-rust-driver/pull/320))

**Others:**
- Privatised a major part of the wrapper's API that anyway wasn't intended to be public. ([#318](https://github.com/scylladb/cpp-rust-driver/pull/318))

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/cpp-rust-driver/](https://github.com/scylladb/cpp-rust-driver/)
Contributions are most welcome!

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:
| commits | author              |
|---------|---------------------|
|  113    | Mikołaj Uzarski     |
|   38    | Wojciech Przytuła   |
|    2    | Takuya ASADA        |
|    1    | David Garcia        |
