### PR TITLE
IT: Enable more tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.*\
 :DCExecutionProfileTest.*\
 :DisconnectedNullStringApiArgsTest.*\
-:MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
-:MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts\
-:MetricsTests.Integration_Cassandra_Requests\
-:MetricsTests.Integration_Cassandra_StatsShardConnections\
+:MetricsTests.*\
 :DcAwarePolicyTest.*\
 :-SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\
 :SchemaMetadataTest.Integration_Cassandra_VirtualMetadata\
@@ -52,6 +49,8 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ControlConnectionTests.Integration_Cassandra_TerminatedUsingMultipleIoThreadsWithError\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionAlreadyExists\
+:MetricsTests.Integration_Cassandra_StatsConnections\
+:MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests\
 :*NoCompactEnabledConnection\
 :PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount)
 endif
@@ -94,10 +93,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.*\
 :DCExecutionProfileTest.*\
 :DisconnectedNullStringApiArgsTest.*\
-:MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
-:MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts\
-:MetricsTests.Integration_Cassandra_Requests\
-:MetricsTests.Integration_Cassandra_StatsShardConnections\
+:MetricsTests.*\
 :DcAwarePolicyTest.*\
 :-PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\
@@ -113,6 +109,8 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionAlreadyExists\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
+:MetricsTests.Integration_Cassandra_StatsConnections\
+:MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests\
 :*NoCompactEnabledConnection\
 :PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount)
 endif

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :DCExecutionProfileTest.*\
 :DisconnectedNullStringApiArgsTest.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
+:MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
 :DcAwarePolicyTest.*\
@@ -94,6 +95,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :DCExecutionProfileTest.*\
 :DisconnectedNullStringApiArgsTest.*\
 :MetricsTests.Integration_Cassandra_ErrorsRequestTimeouts\
+:MetricsTests.Integration_Cassandra_ErrorsConnectionTimeouts\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
 :DcAwarePolicyTest.*\

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionAlreadyExists\
 :*NoCompactEnabledConnection\
-:PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount\
-:UseKeyspaceCaseSensitiveTests.Integration_Cassandra_ConnectWithKeyspace)
+:PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount)
 endif
 
 ifndef SCYLLA_NO_VALGRIND_TEST_FILTER
@@ -113,8 +112,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionAlreadyExists\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
 :*NoCompactEnabledConnection\
-:PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount\
-:UseKeyspaceCaseSensitiveTests.Integration_Cassandra_ConnectWithKeyspace)
+:PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount)
 endif
 
 ifndef CASSANDRA_NO_VALGRIND_TEST_FILTER

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
 :DcAwarePolicyTest.*\
-:-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
-:SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\
+:-SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\
 :SchemaMetadataTest.Integration_Cassandra_VirtualMetadata\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
 :TimestampTests.Integration_Cassandra_MonotonicTimestampGenerator\
@@ -99,8 +98,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :MetricsTests.Integration_Cassandra_Requests\
 :MetricsTests.Integration_Cassandra_StatsShardConnections\
 :DcAwarePolicyTest.*\
-:-PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare\
-:PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
+:-PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\
 :SchemaMetadataTest.Integration_Cassandra_VirtualMetadata\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\

--- a/tests/src/integration/objects/session.hpp
+++ b/tests/src/integration/objects/session.hpp
@@ -286,7 +286,7 @@ protected:
     session.connect_future_.wait(false);
     if (assert_ok && session.connect_error_code() != CASS_OK) {
       throw Exception("Unable to Establish Session Connection: " +
-                          session.connect_error_description(),
+                          session.connect_error_description() + " - " + session.connect_error_message(),
                       session.connect_error_code(), session.connect_error_message());
     }
     return session;

--- a/tests/src/integration/tests/test_prepared.cpp
+++ b/tests/src/integration/tests/test_prepared.cpp
@@ -62,12 +62,13 @@ CASSANDRA_INTEGRATION_TEST_F(PreparedTests, FailFastWhenPreparedIDChangesDuringR
                                  table_name_.c_str(), "int", "int"));
 
   // Execute the insert statement and validate the error code
-  logger_.add_critera("ID mismatch while trying to prepare query");
+  logger_.add_critera("Prepared statement id changed after repreparation");
   Statement insert_statement = insert_prepared.bind();
   insert_statement.bind<Integer>(0, Integer(0));
   insert_statement.bind<Integer>(1, Integer(1));
   Result result = session_.execute(insert_statement, false);
   EXPECT_TRUE(contains(result.error_message(), "Prepared statement id changed after repreparation"));
+  EXPECT_EQ(1u, logger_.count());
 }
 
 /**

--- a/tests/src/integration/tests/test_prepared.cpp
+++ b/tests/src/integration/tests/test_prepared.cpp
@@ -100,7 +100,7 @@ CASSANDRA_INTEGRATION_TEST_F(PreparedTests, PreparedIDUnchangedDuringReprepare) 
       format_string(CASSANDRA_KEY_VALUE_TABLE_FORMAT, table_name_.c_str(), "int", "int"));
 
   // Execute the insert statement and validate success
-  logger_.add_critera("Prepared query with ID");
+  logger_.add_critera("repreparing statement with id");
   Statement insert_statement = insert_prepared.bind();
   insert_statement.bind<Integer>(0, Integer(0));
   insert_statement.bind<Integer>(1, Integer(1));


### PR DESCRIPTION
This PR enables some more integration tests and does some work needed for that.

### The enabled tests are:
1. `PreparedIDUnchangedDuringReprepare` (along with a tiny `FailFastWhenPreparedIDChangesDuringReprepare` enhancement);
2. `UseKeyspaceCaseSensitiveTests.ConnectWithKeyspace`;
3. `MetricsTests.ErrorsConnectionTimeouts`.

### One bug was fixed
When a quoted (case-sensitive) keyspace name is passed, the underlying Rust Driver would reject it. Now it handles it properly.

### Bonus
For better debuggability, C++ exceptions in IT now include the error message in their string, which exhibits Rust Driver's underlying errors.

Makes progress towards: #132

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- [x] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
