### PR TITLE
argconv: Make FFI traits unsafe

### DIFF
--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -22,7 +22,7 @@ pub struct CassBatch {
     pub(crate) exec_profile: Option<PerStatementExecProfile>,
 }
 
-impl FFI for CassBatch {
+unsafe impl FFI for CassBatch {
     type Origin = FromBox;
 }
 

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -137,7 +137,7 @@ pub(crate) enum CassDataTypeInner {
     Custom(String),
 }
 
-impl FFI for CassDataType {
+unsafe impl FFI for CassDataType {
     type Origin = FromArc;
 }
 

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -139,7 +139,7 @@ impl CassCluster {
     }
 }
 
-impl FFI for CassCluster {
+unsafe impl FFI for CassCluster {
     type Origin = FromBox;
 }
 

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -35,7 +35,7 @@ pub struct CassCollection {
     pub(crate) items: Vec<CassCqlValue>,
 }
 
-impl FFI for CassCollection {
+unsafe impl FFI for CassCollection {
     type Origin = FromBox;
 }
 

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -39,7 +39,7 @@ pub struct CassExecProfile {
     pub(crate) load_balancing_config: LoadBalancingConfig,
 }
 
-impl FFI for CassExecProfile {
+unsafe impl FFI for CassExecProfile {
     type Origin = FromBox;
 }
 

--- a/scylla-rust-wrapper/src/execution_error.rs
+++ b/scylla-rust-wrapper/src/execution_error.rs
@@ -19,7 +19,7 @@ pub enum CassErrorResult {
     Deserialization(#[from] DeserializationError),
 }
 
-impl FFI for CassErrorResult {
+unsafe impl FFI for CassErrorResult {
     type Origin = FromArc;
 }
 

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -64,7 +64,7 @@ pub struct CassFuture {
     recording_listener: Option<Arc<crate::integration_testing::RecordingHistoryListener>>,
 }
 
-impl FFI for CassFuture {
+unsafe impl FFI for CassFuture {
     type Origin = FromArc;
 }
 

--- a/scylla-rust-wrapper/src/iterator.rs
+++ b/scylla-rust-wrapper/src/iterator.rs
@@ -661,7 +661,7 @@ pub enum CassIterator<'result_or_schema> {
     ColumnsMeta(CassColumnsMetaIterator<'result_or_schema>),
 }
 
-impl FFI for CassIterator<'_> {
+unsafe impl FFI for CassIterator<'_> {
     type Origin = FromBox;
 }
 

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -16,7 +16,7 @@ use tracing_subscriber::Layer;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::prelude::*;
 
-impl FFI for CassLogMessage {
+unsafe impl FFI for CassLogMessage {
     type Origin = FromRef;
 }
 

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -13,7 +13,7 @@ pub struct CassSchemaMeta {
     pub(crate) keyspaces: HashMap<String, CassKeyspaceMeta>,
 }
 
-impl FFI for CassSchemaMeta {
+unsafe impl FFI for CassSchemaMeta {
     type Origin = FromBox;
 }
 
@@ -27,7 +27,7 @@ pub struct CassKeyspaceMeta {
 }
 
 // Owned by CassSchemaMeta
-impl FFI for CassKeyspaceMeta {
+unsafe impl FFI for CassKeyspaceMeta {
     type Origin = FromRef;
 }
 
@@ -44,7 +44,7 @@ pub struct CassTableMeta {
 // Either:
 // - owned by CassMaterializedViewMeta - won't be given to user
 // - Owned by CassKeyspaceMeta (in Arc), referenced (Weak) by CassMaterializedViewMeta
-impl FFI for CassTableMeta {
+unsafe impl FFI for CassTableMeta {
     type Origin = FromRef;
 }
 
@@ -55,7 +55,7 @@ pub struct CassMaterializedViewMeta {
 }
 
 // Shared ownership by CassKeyspaceMeta and CassTableMeta
-impl FFI for CassMaterializedViewMeta {
+unsafe impl FFI for CassMaterializedViewMeta {
     type Origin = FromRef;
 }
 
@@ -66,7 +66,7 @@ pub struct CassColumnMeta {
 }
 
 // Owned by CassTableMeta
-impl FFI for CassColumnMeta {
+unsafe impl FFI for CassColumnMeta {
     type Origin = FromRef;
 }
 

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -72,7 +72,7 @@ impl CassPrepared {
     }
 }
 
-impl FFI for CassPrepared {
+unsafe impl FFI for CassPrepared {
     type Origin = FromArc;
 }
 

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -52,7 +52,7 @@ pub(crate) struct CassRowsResultSharedData {
 pub type CassNode = Coordinator;
 
 // Borrowed from CassResult in cass_future_coordinator.
-impl FFI for CassNode {
+unsafe impl FFI for CassNode {
     type Origin = FromRef;
 }
 
@@ -122,7 +122,7 @@ impl CassResult {
     }
 }
 
-impl FFI for CassResult {
+unsafe impl FFI for CassResult {
     type Origin = FromArc;
 }
 
@@ -169,7 +169,7 @@ pub struct CassRow<'result> {
     pub(crate) result_metadata: &'result CassResultMetadata,
 }
 
-impl FFI for CassRow<'_> {
+unsafe impl FFI for CassRow<'_> {
     type Origin = FromRef;
 }
 
@@ -441,7 +441,7 @@ pub struct CassValue<'result> {
     pub(crate) value_type: &'result Arc<CassDataType>,
 }
 
-impl FFI for CassValue<'_> {
+unsafe impl FFI for CassValue<'_> {
     type Origin = FromRef;
 }
 

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -80,7 +80,7 @@ impl RetryPolicy for CassRetryPolicy {
     }
 }
 
-impl FFI for CassRetryPolicy {
+unsafe impl FFI for CassRetryPolicy {
     type Origin = FromArc;
 }
 

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -150,7 +150,7 @@ impl CassSessionInner {
 
 pub type CassSession = RwLock<Option<CassSessionInner>>;
 
-impl FFI for CassSession {
+unsafe impl FFI for CassSession {
     type Origin = FromArc;
 }
 

--- a/scylla-rust-wrapper/src/ssl.rs
+++ b/scylla-rust-wrapper/src/ssl.rs
@@ -19,7 +19,7 @@ pub struct CassSsl {
     pub(crate) trusted_store: *mut X509_STORE,
 }
 
-impl FFI for CassSsl {
+unsafe impl FFI for CassSsl {
     type Origin = FromArc;
 }
 

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -222,7 +222,7 @@ pub struct CassStatement {
     pub(crate) record_hosts: bool,
 }
 
-impl FFI for CassStatement {
+unsafe impl FFI for CassStatement {
     type Origin = FromBox;
 }
 

--- a/scylla-rust-wrapper/src/timestamp_generator.rs
+++ b/scylla-rust-wrapper/src/timestamp_generator.rs
@@ -10,7 +10,7 @@ pub enum CassTimestampGen {
     Monotonic(Arc<MonotonicTimestampGenerator>),
 }
 
-impl FFI for CassTimestampGen {
+unsafe impl FFI for CassTimestampGen {
     type Origin = FromBox;
 }
 

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -17,7 +17,7 @@ pub struct CassTuple {
     pub(crate) items: Vec<Option<CassCqlValue>>,
 }
 
-impl FFI for CassTuple {
+unsafe impl FFI for CassTuple {
     type Origin = FromBox;
 }
 

--- a/scylla-rust-wrapper/src/user_type.rs
+++ b/scylla-rust-wrapper/src/user_type.rs
@@ -14,7 +14,7 @@ pub struct CassUserType {
     pub(crate) field_values: Vec<Option<CassCqlValue>>,
 }
 
-impl FFI for CassUserType {
+unsafe impl FFI for CassUserType {
     type Origin = FromBox;
 }
 

--- a/scylla-rust-wrapper/src/uuid.rs
+++ b/scylla-rust-wrapper/src/uuid.rs
@@ -17,7 +17,7 @@ pub struct CassUuidGen {
     pub(crate) last_timestamp: AtomicU64,
 }
 
-impl FFI for CassUuidGen {
+unsafe impl FFI for CassUuidGen {
     type Origin = FromBox;
 }
 


### PR DESCRIPTION
The FFI traits are inherently unsafe. In order to know which trait is correct to be implemented, manual analysis of the CPP Driver's code is required. Thus the traits should be marked as unsafe, indicating that special care and reasoning is needed when implementing them.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
