### PR TITLE
Don't panic on `cass_session_get_client_id()` on disconnected sessions

### DIFF
--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -28,7 +28,7 @@ use crate::cluster::{
 use crate::config_value::MaybeUnsetConfig;
 use crate::load_balancing::{LoadBalancingConfig, LoadBalancingKind};
 use crate::retry_policy::CassRetryPolicy;
-use crate::session::CassSessionInner;
+use crate::session::CassConnectedSession;
 use crate::statement::CassStatement;
 use crate::types::{
     cass_bool_t, cass_double_t, cass_int32_t, cass_int64_t, cass_uint32_t, cass_uint64_t, size_t,
@@ -113,7 +113,7 @@ impl PerStatementExecProfile {
     #[allow(clippy::manual_async_fn)]
     pub(crate) fn get_or_resolve_profile_handle<'a>(
         &'a self,
-        cass_session_inner: &'a CassSessionInner,
+        cass_connected_session: &'a CassConnectedSession,
     ) -> impl Future<Output = Result<ExecutionProfileHandle, (CassError, String)>> + 'a {
         async move {
             let already_resolved = {
@@ -130,7 +130,7 @@ impl PerStatementExecProfile {
                 let inner = &mut *self.0.write().unwrap();
                 match &*inner {
                     PerStatementExecProfileInner::Unresolved(name) => {
-                        let handle = cass_session_inner.resolve_exec_profile(name)?;
+                        let handle = cass_connected_session.resolve_exec_profile(name)?;
                         *inner = PerStatementExecProfileInner::Resolved(handle.clone());
                         handle
                     }


### PR DESCRIPTION
## Problem statement
`cass_session_get_client_id()` contained a bug: for disconnected sessions, it would panic on `unwrap()`, because the `client_id` was only stored on the `CassConnectedSession`, which is `None` when the session is disconnected.

## Solution
This PR fixes the bug by storing the `client_id` on the `CassSessionInner` struct, so that it is always available, even when
the session is disconnected.
Upon session creation (`cass_session_new()`), a random UUID v4 is generated and stored in the `CassSessionInner`. If the user sets a custom client id in the `CassCluster`, it will replace the random one upon `cass_session_connect()`.

## Testing

A unit test is added, which asserts the following:
1. We can get a client ID from a not-yet-connected session.
2. The client ID is inherited from the cluster when connecting.
3. We can still get the client ID after disconnecting the session, which is still the cluster's client ID, if set.

## Open for discussion
Note that we're using `RUNTIME.block_on()` to drive the future returned from `RwLock::read_owned()` to completion. This is necessary because `RwLock::blocking_read()` does not have an owned version.

I had a longer thought about `blocking_read()` (which we use in some places) vs `RUNTIME.block_on(read[_owned]())`, and I think that `blocking_read()` is strictly worse: it simply blocks the current thread until the lock is acquired, while `RUNTIME.block_on()` will also allow other tasks to run while waiting for the lock, which is not only more efficient, but also prevents deadlocks in some cases. In a follow-up PR, I'm thus going to replace all `blocking_read()` with `RUNTIME.block_on(read[_owned]())`.



## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
