### PR TITLE
session: fix closing semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :DisconnectedNullStringApiArgsTest.*\
 :MetricsTests.*\
 :DcAwarePolicyTest.*\
+:AsyncTests.*\
 :-SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\
 :SchemaMetadataTest.Integration_Cassandra_VirtualMetadata\
 :HeartbeatTests.Integration_Cassandra_HeartbeatFailed\
@@ -95,6 +96,7 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :DisconnectedNullStringApiArgsTest.*\
 :MetricsTests.*\
 :DcAwarePolicyTest.*\
+:AsyncTests.*\
 :-PreparedTests.Integration_Cassandra_FailFastWhenPreparedIDChangesDuringReprepare\
 :SchemaMetadataTest.Integration_Cassandra_RegularMetadataNotMarkedVirtual\
 :SchemaMetadataTest.Integration_Cassandra_VirtualMetadata\

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -79,6 +79,10 @@ enum FutureError {
 struct JoinHandleTimeout(JoinHandle<()>);
 
 impl CassFuture {
+    pub(crate) fn make_ready_raw(res: CassFutureResult) -> CassOwnedSharedPtr<CassFuture, CMut> {
+        Self::new_ready(res).into_raw()
+    }
+
     pub(crate) fn make_raw(
         fut: impl Future<Output = CassFutureResult> + Send + 'static,
         #[cfg(cpp_integration_testing)] recording_listener: Option<
@@ -133,8 +137,6 @@ impl CassFuture {
         cass_fut
     }
 
-    // This is left just because it might be useful in tests.
-    #[expect(unused)]
     pub(crate) fn new_ready(r: CassFutureResult) -> Arc<Self> {
         Arc::new(CassFuture {
             state: Mutex::new(CassFutureState::default()),

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -598,23 +598,7 @@ pub unsafe extern "C" fn cass_session_close(
         return ArcFFI::null();
     };
 
-    CassFuture::make_raw(
-        async move {
-            let mut session_guard = session_opt.write().await;
-            if session_guard.connected.is_none() {
-                return Err((
-                    CassError::CASS_ERROR_LIB_UNABLE_TO_CLOSE,
-                    "Already closing or closed".msg(),
-                ));
-            }
-
-            session_guard.connected = None;
-
-            Ok(CassResultValue::Empty)
-        },
-        #[cfg(cpp_integration_testing)]
-        None,
-    )
+    CassConnectedSession::close_fut(session_opt).into_raw()
 }
 
 #[unsafe(no_mangle)]

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -868,7 +868,7 @@ mod tests {
         )]
     }
 
-    pub(crate) async fn test_with_one_proxy_one(
+    pub(crate) async fn test_with_one_proxy(
         test: impl FnOnce(SocketAddr, RunningProxy) -> RunningProxy + Send + 'static,
         rules: impl IntoIterator<Item = RequestRule>,
     ) {
@@ -899,7 +899,7 @@ mod tests {
     #[ntest::timeout(5000)]
     async fn session_clones_and_freezes_exec_profiles_mapping() {
         init_logger();
-        test_with_one_proxy_one(
+        test_with_one_proxy(
             session_clones_and_freezes_exec_profiles_mapping_do,
             handshake_rules()
                 .into_iter()
@@ -994,7 +994,7 @@ mod tests {
     #[ntest::timeout(5000)]
     async fn session_resolves_exec_profile_on_first_query() {
         init_logger();
-        test_with_one_proxy_one(
+        test_with_one_proxy(
             session_resolves_exec_profile_on_first_query_do,
             handshake_rules().into_iter().chain(
                 iter::once(RequestRule(
@@ -1281,7 +1281,7 @@ mod tests {
     #[ntest::timeout(30000)]
     async fn retry_policy_on_statement_and_batch_is_handled_properly() {
         init_logger();
-        test_with_one_proxy_one(
+        test_with_one_proxy(
             retry_policy_on_statement_and_batch_is_handled_properly_do,
             retry_policy_on_statement_and_batch_is_handled_properly_rules(),
         )


### PR DESCRIPTION
Note: generated with GPT-4o and manually redacted.

# Fix Session Closing Semantics and Enable `AsyncTests` Suite

## Summary

This pull request introduces critical improvements to the session closing mechanism. Additionally, it enables the `AsyncTests::Close` test suite, aligns the behavior with the expectations of the CPP Driver, and satisfies the contract defined in the `cassandra.h` documentation regarding `cass_session_free()` and `cass_session_close()`.

## Key Changes

1. **Empirical Proof of Flaws in Current Implementation**:
   - A temporary commit (`913a7c2b`) was introduced to empirically demonstrate flaws in the current implementation. The `AsyncTests::Close` test was tuned to fail by increasing concurrent requests, adding sleep times, and switching to a multi-threaded runtime with a hardcoded number of worker threads. This highlights issues with session closure concurrent to running requests.
   - Subsequent commits address these flaws by ensuring synchronous read-locking of the session upon scheduling a request.
   - **Note:** This temporary commit will be removed before merging the PR into the master branch.

1. **Simplified Future Logic**:
   - Introduced `CassFuture::make_ready_raw()` to streamline the creation of ready futures.
   - Ensured that session connectivity is checked synchronously before creating operation futures, reducing complexity and potential errors.

1. **Improved Session Closing Logic**:
   - The `RwLock` mechanism now ensures that the session is protected from premature drops by synchronously taking a read lock for all running requests. This guarantees that `cass_session_close()` and `cass_session_free()` block until all requests are completed, aligning with the expectations of the `AsyncTests::Close` suite. The synchronous taking of the lock is done nonblockingly, which prevents the issues described in #329.
   - The session closing process now ensures (by virtue of `RwLock`) that all in-flight requests are completed before the session is freed. This prevents potential data loss or inconsistencies during session closure.

1. **Enabled `AsyncTests::Close` Suite**:
   - The `Session::execute(_batch)` methods has already been cloning the Session's `Arc`, preventing use-after-free (UAF) scenarios when the session is closed while requests are still running [introduced in c1e40d7ebfc28882e6b42cd3853f9eae4f1ddf92].

1. **Implemented a unit test for `cass_session_free`**:
   - It ensures the function synchronously waits for all in-flight requests to complete.

## Notes to reviewers
- Verify that the `AsyncTests::Close` test's semantics are satisfied.
- Ensure that session operations behave as expected under concurrent request and session closure scenarios.
- Make sure that the session access/modify semantics are correct:
  - preparing statements,
  - executing statements,
  - executing batches,
  - connecting session,
  - closing session.
- Confirm that no deadlocks occur in the `current_thread` runtime.
- Validate that the temporary commit (`913a7c2b`) is removed before merging.

Fixes: #304
Fixes: #329

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- [x] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
- [x] I added appropriate `Fixes:` annotations to PR description.
