### PR TITLE
Fix serial consistency handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,7 @@ CASSANDRA_NO_VALGRIND_TEST_FILTER := $(subst ${SPACE},${EMPTY},AsyncTests.Integr
 endif
 
 ifndef CCM_COMMIT_ID
-	# TODO: change it back to master/next when https://github.com/scylladb/scylla-ccm/issues/646 is fixed.
-	export CCM_COMMIT_ID := 5392dd68
+	export CCM_COMMIT_ID := master
 endif
 
 ifndef SCYLLA_VERSION

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -3,10 +3,8 @@ use crate::cass_error::CassError;
 use crate::types::*;
 use scylla::cluster::metadata::{CollectionType, NativeType};
 use scylla::frame::response::result::ColumnType;
-use scylla::frame::types::{Consistency, SerialConsistency};
 use scylla::statement::batch::BatchType;
 use std::cell::UnsafeCell;
-use std::convert::TryFrom;
 use std::os::raw::c_char;
 use std::sync::Arc;
 
@@ -891,39 +889,6 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
             name_length,
             ArcFFI::as_ptr(&sub_data_type),
         )
-    }
-}
-
-impl TryFrom<CassConsistency> for Consistency {
-    type Error = ();
-
-    fn try_from(c: CassConsistency) -> Result<Consistency, Self::Error> {
-        match c {
-            CassConsistency::CASS_CONSISTENCY_ANY => Ok(Consistency::Any),
-            CassConsistency::CASS_CONSISTENCY_ONE => Ok(Consistency::One),
-            CassConsistency::CASS_CONSISTENCY_TWO => Ok(Consistency::Two),
-            CassConsistency::CASS_CONSISTENCY_THREE => Ok(Consistency::Three),
-            CassConsistency::CASS_CONSISTENCY_QUORUM => Ok(Consistency::Quorum),
-            CassConsistency::CASS_CONSISTENCY_ALL => Ok(Consistency::All),
-            CassConsistency::CASS_CONSISTENCY_LOCAL_QUORUM => Ok(Consistency::LocalQuorum),
-            CassConsistency::CASS_CONSISTENCY_EACH_QUORUM => Ok(Consistency::EachQuorum),
-            CassConsistency::CASS_CONSISTENCY_LOCAL_ONE => Ok(Consistency::LocalOne),
-            CassConsistency::CASS_CONSISTENCY_LOCAL_SERIAL => Ok(Consistency::LocalSerial),
-            CassConsistency::CASS_CONSISTENCY_SERIAL => Ok(Consistency::Serial),
-            _ => Err(()),
-        }
-    }
-}
-
-impl TryFrom<CassConsistency> for SerialConsistency {
-    type Error = ();
-
-    fn try_from(serial: CassConsistency) -> Result<SerialConsistency, Self::Error> {
-        match serial {
-            CassConsistency::CASS_CONSISTENCY_SERIAL => Ok(SerialConsistency::Serial),
-            CassConsistency::CASS_CONSISTENCY_LOCAL_SERIAL => Ok(SerialConsistency::LocalSerial),
-            _ => Err(()),
-        }
     }
 }
 

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -40,6 +40,8 @@ use crate::cass_compression_types::CassCompressionType;
 // According to `cassandra.h` the defaults for
 // - consistency for statements is LOCAL_ONE,
 const DEFAULT_CONSISTENCY: Consistency = Consistency::LocalOne;
+// - serial consistency for statements is ANY, which corresponds to None in Rust Driver.
+const DEFAULT_SERIAL_CONSISTENCY: Option<SerialConsistency> = None;
 // - request client timeout is 12000 millis,
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(12000);
 // - fetching schema metadata is true
@@ -174,6 +176,7 @@ pub(crate) fn build_session_builder(
 pub unsafe extern "C" fn cass_cluster_new() -> CassOwnedExclusivePtr<CassCluster, CMut> {
     let default_execution_profile_builder = ExecutionProfileBuilder::default()
         .consistency(DEFAULT_CONSISTENCY)
+        .serial_consistency(DEFAULT_SERIAL_CONSISTENCY)
         .request_timeout(Some(DEFAULT_REQUEST_TIMEOUT));
 
     // Default config options - according to cassandra.h

--- a/scylla-rust-wrapper/src/config_value.rs
+++ b/scylla-rust-wrapper/src/config_value.rs
@@ -1,0 +1,100 @@
+use scylla::statement::{Consistency, SerialConsistency};
+
+use crate::cass_types::CassConsistency;
+
+/// Represents a configuration value that may or may not be set.
+/// If a configuration value is unset, it means that the default value
+/// should be used.
+pub(crate) enum MaybeUnsetConfig<T> {
+    Unset,
+    Set(T),
+}
+
+/// Represents types that can be converted from a C value have the special unset value.
+/// This is used to handle cases where a configuration value may not be set,
+/// allowing the driver to clearly distinguish between an unset value and a set value.
+pub(crate) trait MaybeUnsetConfigValue: Sized {
+    type CValue;
+    type Error;
+
+    /// Checks if the given C value is considered unset.
+    fn is_unset(cvalue: &Self::CValue) -> bool;
+
+    /// Converts a maybe unset C value to a Rust value, returning an error if the value
+    /// is invalid.
+    fn from_c_value(cvalue: Self::CValue) -> Result<MaybeUnsetConfig<Self>, Self::Error> {
+        if Self::is_unset(&cvalue) {
+            Ok(MaybeUnsetConfig::Unset)
+        } else {
+            let rust_value = Self::from_set_c_value(cvalue)?;
+            Ok(MaybeUnsetConfig::Set(rust_value))
+        }
+    }
+
+    /// Converts a **set** C value to a Rust value, returning an error if the value
+    /// is invalid or if the value is unset.
+    fn from_set_c_value(cvalue: Self::CValue) -> Result<Self, Self::Error>;
+}
+
+impl<T: MaybeUnsetConfigValue> MaybeUnsetConfig<T> {
+    /// Converts a maybe unset C value to a Rust value, returning an error if the value
+    /// is invalid.
+    pub(crate) fn from_c_value(cvalue: T::CValue) -> Result<Self, T::Error> {
+        <T as MaybeUnsetConfigValue>::from_c_value(cvalue)
+    }
+}
+
+impl MaybeUnsetConfigValue for Consistency {
+    type CValue = CassConsistency;
+    type Error = ();
+
+    fn is_unset(cvalue: &Self::CValue) -> bool {
+        *cvalue == CassConsistency::CASS_CONSISTENCY_UNKNOWN
+    }
+
+    fn from_set_c_value(cvalue: Self::CValue) -> Result<Self, Self::Error> {
+        match cvalue {
+            CassConsistency::CASS_CONSISTENCY_ANY => Ok(Consistency::Any),
+            CassConsistency::CASS_CONSISTENCY_ONE => Ok(Consistency::One),
+            CassConsistency::CASS_CONSISTENCY_TWO => Ok(Consistency::Two),
+            CassConsistency::CASS_CONSISTENCY_THREE => Ok(Consistency::Three),
+            CassConsistency::CASS_CONSISTENCY_QUORUM => Ok(Consistency::Quorum),
+            CassConsistency::CASS_CONSISTENCY_ALL => Ok(Consistency::All),
+            CassConsistency::CASS_CONSISTENCY_LOCAL_QUORUM => Ok(Consistency::LocalQuorum),
+            CassConsistency::CASS_CONSISTENCY_EACH_QUORUM => Ok(Consistency::EachQuorum),
+            CassConsistency::CASS_CONSISTENCY_LOCAL_ONE => Ok(Consistency::LocalOne),
+            CassConsistency::CASS_CONSISTENCY_LOCAL_SERIAL => Ok(Consistency::LocalSerial),
+            CassConsistency::CASS_CONSISTENCY_SERIAL => Ok(Consistency::Serial),
+            _ => Err(()),
+        }
+    }
+}
+
+impl MaybeUnsetConfigValue for Option<SerialConsistency> {
+    type CValue = CassConsistency;
+    type Error = ();
+
+    fn is_unset(cvalue: &Self::CValue) -> bool {
+        *cvalue == CassConsistency::CASS_CONSISTENCY_UNKNOWN
+    }
+
+    fn from_set_c_value(cvalue: Self::CValue) -> Result<Self, Self::Error> {
+        match cvalue {
+            CassConsistency::CASS_CONSISTENCY_ANY => {
+                // This is in line with the CPP Driver: if 0 is passed (which is Consistency::Any),
+                // then serial consistency is not set:
+                // ```c++
+                // if (callback->serial_consistency() != 0) {
+                //  flags |= CASS_QUERY_FLAG_SERIAL_CONSISTENCY;
+                // }
+                // ```
+                Ok(None)
+            }
+            CassConsistency::CASS_CONSISTENCY_LOCAL_SERIAL => {
+                Ok(Some(SerialConsistency::LocalSerial))
+            }
+            CassConsistency::CASS_CONSISTENCY_SERIAL => Ok(Some(SerialConsistency::Serial)),
+            _ => Err(()),
+        }
+    }
+}

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -13,7 +13,7 @@ use scylla::client::execution_profile::{
 use scylla::policies::load_balancing::LatencyAwarenessBuilder;
 use scylla::policies::retry::RetryPolicy;
 use scylla::policies::speculative_execution::SimpleSpeculativeExecutionPolicy;
-use scylla::statement::Consistency;
+use scylla::statement::{Consistency, SerialConsistency};
 
 use crate::argconv::{
     ArcFFI, BoxFFI, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr, CassOwnedExclusivePtr,
@@ -719,16 +719,35 @@ pub unsafe extern "C" fn cass_execution_profile_set_serial_consistency(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let maybe_serial_consistency =
-        if serial_consistency == CassConsistency::CASS_CONSISTENCY_UNKNOWN {
-            None
-        } else {
-            match serial_consistency.try_into() {
-                Ok(c) => Some(c),
-                Err(_) => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
-            }
-        };
-    profile_builder.modify_in_place(|builder| builder.serial_consistency(maybe_serial_consistency));
+    let Ok(maybe_set_serial_consistency) =
+        MaybeUnsetConfig::<Option<SerialConsistency>>::from_c_value(serial_consistency)
+    else {
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
+    match maybe_set_serial_consistency {
+        MaybeUnsetConfig::Unset => {
+            // CASS_CONSISTENCY_UNKNOWN
+            // TODO: implement semantics of this.
+            // A workaround is needed, because Rust Driver's ExecutionProfileBuilder
+            // does not expose API to unset serial consistency (enabling semantics:
+            // "ignore me and use the default profile's setting").
+            tracing::warn!(
+                "Passed `CASS_CONSISTENCY_UNKNOWN` to `cass_exec_profile_set_serial_consistency`. \
+                This is not supported by the CPP Rust Driver yet: once you set some consistency \
+                on an execution profile, you cannot unset it. This limitation will be fixed in the future. \
+                As a workaround, you can refrain from setting serial consistency on an execution profile, \
+                which will make the driver use the consistency set on cluster level."
+            );
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        MaybeUnsetConfig::Set(maybe_serial_consistency) => {
+            // CASS_CONSISTENCY_ANY -> None
+            // other consistency -> Some()
+            profile_builder
+                .modify_in_place(|builder| builder.serial_consistency(maybe_serial_consistency));
+        }
+    }
 
     CassError::CASS_OK
 }

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) mod cass_error;
 pub(crate) mod cass_types;
 pub(crate) mod cluster;
 pub(crate) mod collection;
+pub(crate) mod config_value;
 pub(crate) mod date_time;
 pub(crate) mod exec_profile;
 pub(crate) mod execution_error;

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -18,8 +18,7 @@ use scylla::serialize::value::SerializeValue;
 use scylla::serialize::writers::RowWriter;
 use scylla::statement::SerialConsistency;
 use scylla::statement::unprepared::Statement;
-use scylla::value::MaybeUnset;
-use scylla::value::MaybeUnset::{Set, Unset};
+use scylla::value::MaybeUnset::{self, Set, Unset};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::net::{IpAddr, SocketAddr};
@@ -664,38 +663,44 @@ pub unsafe extern "C" fn cass_statement_set_serial_consistency(
     // set serial consistency if a user passed correct value and set it to
     // None otherwise.
     // I think that failing explicitly is a better idea, so I decided to return
-    // and error
-    let consistency = match get_consistency_from_cass_consistency(serial_consistency) {
-        Some(Consistency::Serial) => SerialConsistency::Serial,
-        Some(Consistency::LocalSerial) => SerialConsistency::LocalSerial,
-        _ => return CassError::CASS_ERROR_LIB_BAD_PARAMS,
+    // an error.
+    let Ok(maybe_set_serial_consistency) =
+        MaybeUnsetConfig::<Option<SerialConsistency>>::from_c_value(serial_consistency)
+    else {
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    match &mut statement.statement {
-        BoundStatement::Simple(inner) => inner.query.set_serial_consistency(Some(consistency)),
-        BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
-            .statement
-            .set_serial_consistency(Some(consistency)),
-    }
+    match maybe_set_serial_consistency {
+        MaybeUnsetConfig::Unset => {
+            // The correct semantics for `CASS_CONSISTENCY_UNKNOWN` is to
+            // make statement not have any opinion at all about serial consistency.
+            // Then, the default from the cluster/execution profile should be used.
+            // Unfortunately, the Rust Driver does not support
+            // "unsetting" serial consistency from a statement at the moment.
+            //
+            // FIXME: Implement unsetting serial consistency in the Rust Driver.
+            // Then, fix this code.
+            //
+            // For now, we will throw an error in order to warn the user
+            // about this limitation.
+            tracing::warn!(
+                "Passed `CASS_CONSISTENCY_UNKNOWN` to `cass_statement_set_serial_consistency`. \
+                This is not supported by the CPP Rust Driver yet: once you set some serial consistency \
+                on a statement, you cannot unset it. This limitation will be fixed in the future. \
+                As a workaround, you can refrain from setting serial consistency on a statement, which \
+                will make the driver use the serial consistency set on execution profile or cluster level."
+            );
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        MaybeUnsetConfig::Set(serial_consistency) => match &mut statement.statement {
+            BoundStatement::Simple(inner) => inner.query.set_serial_consistency(serial_consistency),
+            BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
+                .statement
+                .set_serial_consistency(serial_consistency),
+        },
+    };
 
     CassError::CASS_OK
-}
-
-fn get_consistency_from_cass_consistency(consistency: CassConsistency) -> Option<Consistency> {
-    match consistency {
-        CassConsistency::CASS_CONSISTENCY_ANY => Some(Consistency::Any),
-        CassConsistency::CASS_CONSISTENCY_ONE => Some(Consistency::One),
-        CassConsistency::CASS_CONSISTENCY_TWO => Some(Consistency::Two),
-        CassConsistency::CASS_CONSISTENCY_THREE => Some(Consistency::Three),
-        CassConsistency::CASS_CONSISTENCY_QUORUM => Some(Consistency::Quorum),
-        CassConsistency::CASS_CONSISTENCY_ALL => Some(Consistency::All),
-        CassConsistency::CASS_CONSISTENCY_LOCAL_QUORUM => Some(Consistency::LocalQuorum),
-        CassConsistency::CASS_CONSISTENCY_EACH_QUORUM => Some(Consistency::EachQuorum),
-        CassConsistency::CASS_CONSISTENCY_SERIAL => Some(Consistency::Serial),
-        CassConsistency::CASS_CONSISTENCY_LOCAL_SERIAL => Some(Consistency::LocalSerial),
-        CassConsistency::CASS_CONSISTENCY_LOCAL_ONE => Some(Consistency::LocalOne),
-        _ => None,
-    }
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
_Generated with GPT-4o and manually (heavily) redacted_

## Problem overview

Serial consistency is handled incorrectly in both: 1) statement/batch, 2) exec profiles/cluster. The requirements that are not always met:
- `CASS_CONSISTENCY_ANY` shall result in **not setting any** serial consistency in the request frame;
- `CASS_CONSISTENCY_UNKNOWN` shall have the semantics of _"ignore me and use the default"_. CPP Driver allows it for statements/batches/exec profiles and forbids for cluster (because there would be no default to be used over cluster-level configuration).

## Solution

All changes are done to align with the CPP Driver behaviour.

The commits do the following:
1. **Support for serial consistency `ANY` in statements and batches**:
   Fixed the semantics in statements and batches (`cass_{statement,batch}_set_serial_consistency`):
   - `ANY` is allowed.
   - `UNKNOWN` is allowed and means that the execution profile's setting is used (or cluster's, if there's no execution profile set). Unfortunately, as the Rust driver misses corresponding option to unset consistency on statements, this is unsupported for now.

2. (Bonus) **Refactored consistency handling in statements and batches**:
  Similarly to what is done about serial consistency, the code is prepared for the Rust Driver's change introducing statements' API to unset consistency. 

3. **Fixes to serial consistency handling in execution profiles**:
  Fixed the semantics in execution profiles (`cass_execution_profile_set_serial_consistency`):
    - `ANY` is allowed.
   - `UNKNOWN` is allowed and means that the cluster's setting is used. This is unsupported for now and will be taken care in the follow-up.

4. **Fixes to serial consistency handling in cluster**:
   - Cluster forbids `CASS_CONSISTENCY_UNKNOWN`.

5. **Removal of `SerialConsistency` conversion**:
   - Eliminated the `impl TryFrom<CassConsistency> for SerialConsistency` implementation.
   - Addressed misuse risks due to differing semantics in conversion contexts (statements/batches/execution profiles vs cluster).

6. **No serial consistency as the default for the cluster**:
   - CPP Driver, as a default, sets **no serial consistency**.
   - The default is adjusted to conform.
   - **Note:** Rust driver purposefully set the default serial consistency to `LocalSerial` instead of `Any`. See the commit message for considerations. Let's discuss this.

### Discussion needed
The last commit: should we change the CPP-Driver's default of serial consistency from `Any` to `LocalSerial`?

### Summary:
These changes improve correctness of serial consistency handling, ensuring alignment with the CPP Driver's behavior.

### Testing

Coming soon, I'm working on an integration test for consistency/serial consistency set in all possible ways. This is going to be in a follow-up.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
