### PR TITLE
Fix driver defaults - cluster & exec profiles

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -1614,7 +1614,7 @@ cass_cluster_set_local_address_n(CassCluster* cluster,
  * used when establishing the shard-aware connections. This is
  * applicable when the routing of connection to shard is based on
  * the client-side port number.
- * 
+ *
  * When application connects to multiple CassCluster-s it is advised
  * to assign mutually non-overlapping port intervals to each. It is assumed
  * that the supplied range is allowed by the OS (e.g. it fits inside
@@ -1803,7 +1803,7 @@ cass_cluster_set_core_connections_per_host(CassCluster* cluster,
  * Sets the number of connections opened by the driver to each shard.
  *
  * Cassandra nodes are treated as if they have one shard.
- * 
+ *
  * This will override the `cass_cluster_set_core_connections_per_host`, if set.
  *
  * <b>Default:</b> 1
@@ -1908,11 +1908,11 @@ cass_cluster_set_exponential_reconnect(CassCluster* cluster,
  * request's roundtrip time. Larger values should be used for throughput
  * bound workloads and lower values should be used for latency bound
  * workloads.
- * 
+ *
  * Notice that underlying Rust tokio timer has a granularity of millisecond.
  * Thus, the sub-millisecond delays are implemented in a non-deterministic way
  * by yielding the current tokio task.
- * 
+ *
  * The semantics of mapping the provided number microseconds to the delay
  * on rust-driver side:
  * - 0us -> no delay, i.e. the delay is disabled
@@ -11108,8 +11108,6 @@ cass_uuid_from_string_n(const char* str,
  * Creates a new server-side timestamp generator. This generator allows Cassandra
  * to assign timestamps server-side.
  *
- * <b>Note:</b> This is the default timestamp generator.
- *
  * @cassandra{2.1+}
  *
  * @public @memberof CassTimestampGen
@@ -11136,6 +11134,8 @@ cass_timestamp_gen_server_side_new();
  * the clock skew is resolved. These settings can be changed by using
  * `cass_timestamp_gen_monotonic_new_with_settings()` to create the generator
  * instance.
+ *
+ * <b>Note:</b> This is the default timestamp generator.
  *
  * <b>Note:</b> This generator is thread-safe and can be shared by multiple
  * sessions.
@@ -11488,7 +11488,7 @@ cass_log_set_callback(CassLogCallback callback,
 
 /**
  * Analogous getter - useful for restoring logger to previous values.
- * 
+ *
  * @param[out] callback_out Current logging callback. Must point to a valid memory area.
  * @param[out] data_out Current Logger instance. Must point to a valid memory area.
  */

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -240,14 +240,14 @@ impl<'a, T: Sized, P: Properties> CassPtr<'a, T, P> {
 
 /// Pointer constructors.
 impl<T: Sized, P: Properties> CassPtr<'_, T, P> {
-    fn null() -> Self {
+    pub fn null() -> Self {
         CassPtr {
             ptr: None,
             _phantom: PhantomData,
         }
     }
 
-    pub(crate) fn is_null(&self) -> bool {
+    pub fn is_null(&self) -> bool {
         self.ptr.is_none()
     }
 
@@ -274,7 +274,7 @@ impl<T: Sized, P: Properties> CassPtr<'_, T, P> {
 
 /// Constructors for to exclusive pointers.
 impl<T: Sized> CassPtr<'_, T, (Exclusive, CMut)> {
-    fn null_mut() -> Self {
+    pub(crate) fn null_mut() -> Self {
         CassPtr {
             ptr: None,
             _phantom: PhantomData,

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -69,33 +69,16 @@ pub unsafe extern "C" fn cass_batch_set_consistency(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
+    let batch = &mut Arc::make_mut(&mut batch.state).batch;
     match maybe_set_consistency {
         MaybeUnsetConfig::Unset => {
             // The correct semantics for `CASS_CONSISTENCY_UNKNOWN` is to
             // make batch not have any opinion at all about consistency.
             // Then, the default from the cluster/execution profile should be used.
-            // Unfortunately, the Rust Driver does not support
-            // "unsetting" consistency from a batch at the moment.
-            //
-            // FIXME: Implement unsetting consistency in the Rust Driver.
-            // Then, fix this code.
-            //
-            // For now, we will throw an error in order to warn the user
-            // about this limitation.
-            tracing::warn!(
-                "Passed `CASS_CONSISTENCY_UNKNOWN` to `cass_batch_set_consistency`. \
-                This is not supported by the CPP Rust Driver yet: once you set some consistency \
-                on a batch, you cannot unset it. This limitation will be fixed in the future. \
-                As a workaround, you can refrain from setting consistency on a batch, which \
-                will make the driver use the consistency set on execution profile or cluster level."
-            );
-
-            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            batch.unset_consistency();
         }
         MaybeUnsetConfig::Set(consistency) => {
-            Arc::make_mut(&mut batch.state)
-                .batch
-                .set_consistency(consistency);
+            batch.set_consistency(consistency);
         }
     };
     CassError::CASS_OK
@@ -125,32 +108,16 @@ pub unsafe extern "C" fn cass_batch_set_serial_consistency(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
+    let batch = &mut Arc::make_mut(&mut batch.state).batch;
     match maybe_set_serial_consistency {
         MaybeUnsetConfig::Unset => {
             // The correct semantics for `CASS_CONSISTENCY_UNKNOWN` is to
             // make batch not have any opinion at all about serial consistency.
             // Then, the default from the cluster/execution profile should be used.
-            // Unfortunately, the Rust Driver does not support
-            // "unsetting" serial consistency from a batch at the moment.
-            //
-            // FIXME: Implement unsetting serial consistency in the Rust Driver.
-            // Then, fix this code.
-            //
-            // For now, we will throw an error in order to warn the user
-            // about this limitation.
-            tracing::warn!(
-                "Passed `CASS_CONSISTENCY_UNKNOWN` to `cass_batch_set_serial_consistency`. \
-                This is not supported by the CPP Rust Driver yet: once you set some serial consistency \
-                on a batch, you cannot unset it. This limitation will be fixed in the future. \
-                As a workaround, you can refrain from setting serial consistency on a batch, which \
-                will make the driver use the serial consistency set on execution profile or cluster level."
-            );
-            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            batch.unset_serial_consistency();
         }
         MaybeUnsetConfig::Set(serial_consistency) => {
-            Arc::make_mut(&mut batch.state)
-                .batch
-                .set_serial_consistency(serial_consistency);
+            batch.set_serial_consistency(serial_consistency);
         }
     };
 

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn cass_batch_set_consistency(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let Ok(maybe_set_consistency) = MaybeUnsetConfig::<Consistency>::from_c_value(consistency)
+    let Ok(maybe_set_consistency) = MaybeUnsetConfig::<_, Consistency>::from_c_value(consistency)
     else {
         // Invalid consistency value provided.
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn cass_batch_set_consistency(
 
     let batch = &mut Arc::make_mut(&mut batch.state).batch;
     match maybe_set_consistency {
-        MaybeUnsetConfig::Unset => {
+        MaybeUnsetConfig::Unset(_) => {
             // The correct semantics for `CASS_CONSISTENCY_UNKNOWN` is to
             // make batch not have any opinion at all about consistency.
             // Then, the default from the cluster/execution profile should be used.
@@ -103,14 +103,14 @@ pub unsafe extern "C" fn cass_batch_set_serial_consistency(
     // I think that failing explicitly is a better idea, so I decided to return
     // an error.
     let Ok(maybe_set_serial_consistency) =
-        MaybeUnsetConfig::<Option<SerialConsistency>>::from_c_value(serial_consistency)
+        MaybeUnsetConfig::<_, Option<SerialConsistency>>::from_c_value(serial_consistency)
     else {
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
     let batch = &mut Arc::make_mut(&mut batch.state).batch;
     match maybe_set_serial_consistency {
-        MaybeUnsetConfig::Unset => {
+        MaybeUnsetConfig::Unset(_) => {
             // The correct semantics for `CASS_CONSISTENCY_UNKNOWN` is to
             // make batch not have any opinion at all about serial consistency.
             // Then, the default from the cluster/execution profile should be used.
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn cass_batch_set_request_timeout(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
     let maybe_unset_timeout =
-        MaybeUnsetConfig::<RequestTimeout>::from_c_value_infallible(timeout_ms);
+        MaybeUnsetConfig::<_, RequestTimeout>::from_c_value_infallible(timeout_ms);
 
     // `Batch::set_request_timeout` expects an Option<Duration> with unusual semantics:
     // - `None` means "ignore me and use the default timeout from the cluster/execution profile" - this is
@@ -189,7 +189,7 @@ pub unsafe extern "C" fn cass_batch_set_request_timeout(
     // - `Some(timeout)` means "use timeout of given value".
     // Therefore, to acquire "no timeout" semantics, we need to emulate it with an extremely long timeout.
     let timeout = match maybe_unset_timeout {
-        MaybeUnsetConfig::Unset => None,
+        MaybeUnsetConfig::Unset(_) => None,
         MaybeUnsetConfig::Set(RequestTimeout(timeout)) => {
             Some(timeout.unwrap_or(RequestTimeout::INFINITE))
         }

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -20,7 +20,7 @@ use scylla::client::{PoolSize, SelfIdentity, WriteCoalescingDelay};
 use scylla::frame::Compression;
 use scylla::policies::host_filter::HostFilter;
 use scylla::policies::load_balancing::LatencyAwarenessBuilder;
-use scylla::policies::retry::RetryPolicy;
+use scylla::policies::retry::{DefaultRetryPolicy, RetryPolicy};
 use scylla::policies::speculative_execution::SimpleSpeculativeExecutionPolicy;
 use scylla::policies::timestamp_generator::{MonotonicTimestampGenerator, TimestampGenerator};
 use scylla::routing::ShardAwarePortRange;
@@ -185,7 +185,9 @@ pub unsafe extern "C" fn cass_cluster_new() -> CassOwnedExclusivePtr<CassCluster
     let default_execution_profile_builder = ExecutionProfileBuilder::default()
         .consistency(DEFAULT_CONSISTENCY)
         .serial_consistency(DEFAULT_SERIAL_CONSISTENCY)
-        .request_timeout(Some(DEFAULT_REQUEST_TIMEOUT));
+        .request_timeout(Some(DEFAULT_REQUEST_TIMEOUT))
+        .retry_policy(Arc::new(DefaultRetryPolicy::new()))
+        .speculative_execution_policy(None);
 
     /* Default config options - according to `cassandra.h`:
      * ```c++

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -66,6 +66,13 @@ const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_millis(5000);
 const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
 // - keepalive timeout is 60 secs
 const DEFAULT_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(60);
+// - TCP keepalive interval (actually: delay before the first keepalive
+//   probe is sent) is 0 sec in the CPP Driver. However, libuv started
+//   to reject such configuration on purpose since 1.49, so let's follow
+//   its reasoning and set it to more.
+//   1 sec could make sense, but Rust driver warns if it's not greater
+//   than 1 sec (for performance reasons), so let's set 2 secs..
+const DEFAULT_TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(2);
 // - default local ip address is arbitrary
 const DEFAULT_LOCAL_IP_ADDRESS: Option<IpAddr> = None;
 // - default shard aware local port range is ephemeral range
@@ -284,6 +291,7 @@ pub unsafe extern "C" fn cass_cluster_new() -> CassOwnedExclusivePtr<CassCluster
             .schema_agreement_timeout(DEFAULT_MAX_SCHEMA_WAIT_TIME)
             .schema_agreement_interval(DEFAULT_SCHEMA_AGREEMENT_INTERVAL)
             .tcp_nodelay(DEFAULT_SET_TCP_NO_DELAY)
+            .tcp_keepalive_interval(DEFAULT_TCP_KEEPALIVE_INTERVAL)
             .connection_timeout(DEFAULT_CONNECT_TIMEOUT)
             .pool_size(DEFAULT_CONNECTION_POOL_SIZE)
             .write_coalescing(DEFAULT_ENABLE_WRITE_COALESCING)

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -188,6 +188,12 @@ pub unsafe extern "C" fn cass_cluster_new() -> CassOwnedExclusivePtr<CassCluster
         .request_timeout(Some(DEFAULT_REQUEST_TIMEOUT))
         .retry_policy(Arc::new(DefaultRetryPolicy::new()))
         .speculative_execution_policy(None);
+    // Load balancing is set in LoadBalancingConfig::build().
+    // The default load balancing policy is DCAware in CPP Driver.
+    // NOTE: CPP Driver initializes the local DC to the first node the client
+    // connects to. This is tricky, a possible footgun, and hard to be done with
+    // the current Rust driver implementation, which is why do don't use DC awareness
+    // by default.
 
     /* Default config options - according to `cassandra.h`:
      * ```c++

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -1524,14 +1524,14 @@ pub unsafe extern "C" fn cass_cluster_set_consistency(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let Ok(maybe_set_consistency) = MaybeUnsetConfig::<Consistency>::from_c_value(consistency)
+    let Ok(maybe_set_consistency) = MaybeUnsetConfig::<_, Consistency>::from_c_value(consistency)
     else {
         // Invalid consistency value provided.
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
     match maybe_set_consistency {
-        MaybeUnsetConfig::Unset => {
+        MaybeUnsetConfig::Unset(_) => {
             // `CASS_CONSISTENCY_UNKNOWN` is not supported in the cluster settings.
             return CassError::CASS_ERROR_LIB_BAD_PARAMS;
         }
@@ -1557,14 +1557,14 @@ pub unsafe extern "C" fn cass_cluster_set_serial_consistency(
     };
 
     let Ok(maybe_set_serial_consistency) =
-        MaybeUnsetConfig::<Option<SerialConsistency>>::from_c_value(serial_consistency)
+        MaybeUnsetConfig::<_, Option<SerialConsistency>>::from_c_value(serial_consistency)
     else {
         // Invalid serial consistency value provided.
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
     match maybe_set_serial_consistency {
-        MaybeUnsetConfig::Unset => {
+        MaybeUnsetConfig::Unset(_) => {
             // `CASS_CONSISTENCY_UNKNOWN` is not supported in the cluster settings.
             return CassError::CASS_ERROR_LIB_BAD_PARAMS;
         }

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -22,7 +22,7 @@ use scylla::policies::host_filter::HostFilter;
 use scylla::policies::load_balancing::LatencyAwarenessBuilder;
 use scylla::policies::retry::RetryPolicy;
 use scylla::policies::speculative_execution::SimpleSpeculativeExecutionPolicy;
-use scylla::policies::timestamp_generator::TimestampGenerator;
+use scylla::policies::timestamp_generator::{MonotonicTimestampGenerator, TimestampGenerator};
 use scylla::routing::ShardAwarePortRange;
 use scylla::statement::{Consistency, SerialConsistency};
 use std::collections::HashMap;
@@ -292,6 +292,7 @@ pub unsafe extern "C" fn cass_cluster_new() -> CassOwnedExclusivePtr<CassCluster
             .keepalive_timeout(DEFAULT_KEEPALIVE_TIMEOUT)
             .local_ip_address(DEFAULT_LOCAL_IP_ADDRESS)
             .shard_aware_local_port_range(DEFAULT_SHARD_AWARE_LOCAL_PORT_RANGE)
+            .timestamp_generator(Arc::new(MonotonicTimestampGenerator::new()))
     };
 
     BoxFFI::into_ptr(Box::new(CassCluster {

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -39,7 +39,7 @@ use crate::cass_compression_types::CassCompressionType;
 
 // According to `cassandra.h` the defaults for
 // - consistency for statements is LOCAL_ONE,
-const DEFAULT_CONSISTENCY: Consistency = Consistency::LocalOne;
+pub(crate) const DEFAULT_CONSISTENCY: Consistency = Consistency::LocalOne;
 // - serial consistency for statements is ANY, which corresponds to None in Rust Driver.
 const DEFAULT_SERIAL_CONSISTENCY: Option<SerialConsistency> = None;
 // - request client timeout is 12000 millis,

--- a/scylla-rust-wrapper/src/config_value.rs
+++ b/scylla-rust-wrapper/src/config_value.rs
@@ -7,26 +7,25 @@ use crate::{cass_types::CassConsistency, types::cass_uint64_t};
 /// Represents a configuration value that may or may not be set.
 /// If a configuration value is unset, it means that the default value
 /// should be used.
-pub(crate) enum MaybeUnsetConfig<T> {
-    Unset,
+pub(crate) enum MaybeUnsetConfig<CValue, T> {
+    Unset(std::marker::PhantomData<CValue>),
     Set(T),
 }
 
 /// Represents types that can be converted from a C value have the special unset value.
 /// This is used to handle cases where a configuration value may not be set,
 /// allowing the driver to clearly distinguish between an unset value and a set value.
-pub(crate) trait MaybeUnsetConfigValue: Sized {
-    type CValue;
+pub(crate) trait MaybeUnsetConfigValue<CValue>: Sized {
     type Error;
 
     /// Checks if the given C value is considered unset.
-    fn is_unset(cvalue: &Self::CValue) -> bool;
+    fn is_unset(cvalue: &CValue) -> bool;
 
     /// Converts a maybe unset C value to a Rust value, returning an error if the value
     /// is invalid.
-    fn from_c_value(cvalue: Self::CValue) -> Result<MaybeUnsetConfig<Self>, Self::Error> {
+    fn from_c_value(cvalue: CValue) -> Result<MaybeUnsetConfig<CValue, Self>, Self::Error> {
         if Self::is_unset(&cvalue) {
-            Ok(MaybeUnsetConfig::Unset)
+            Ok(MaybeUnsetConfig::Unset(std::marker::PhantomData))
         } else {
             let rust_value = Self::from_set_c_value(cvalue)?;
             Ok(MaybeUnsetConfig::Set(rust_value))
@@ -35,34 +34,33 @@ pub(crate) trait MaybeUnsetConfigValue: Sized {
 
     /// Converts a **set** C value to a Rust value, returning an error if the value
     /// is invalid or if the value is unset.
-    fn from_set_c_value(cvalue: Self::CValue) -> Result<Self, Self::Error>;
+    fn from_set_c_value(cvalue: CValue) -> Result<Self, Self::Error>;
 }
 
-impl<T: MaybeUnsetConfigValue> MaybeUnsetConfig<T> {
+impl<CValue, T: MaybeUnsetConfigValue<CValue>> MaybeUnsetConfig<CValue, T> {
     /// Converts a maybe unset C value to a Rust value, returning an error if the value
     /// is invalid.
-    pub(crate) fn from_c_value(cvalue: T::CValue) -> Result<Self, T::Error> {
-        <T as MaybeUnsetConfigValue>::from_c_value(cvalue)
+    pub(crate) fn from_c_value(cvalue: CValue) -> Result<Self, T::Error> {
+        <T as MaybeUnsetConfigValue<CValue>>::from_c_value(cvalue)
     }
 }
 
-impl<T: MaybeUnsetConfigValue<Error = Infallible>> MaybeUnsetConfig<T> {
+impl<CValue, T: MaybeUnsetConfigValue<CValue, Error = Infallible>> MaybeUnsetConfig<CValue, T> {
     /// Converts a maybe unset C value to a Rust value. Available for C values that are guaranteed
     /// to be valid and thus never return an error.
-    pub(crate) fn from_c_value_infallible(cvalue: T::CValue) -> Self {
+    pub(crate) fn from_c_value_infallible(cvalue: CValue) -> Self {
         Self::from_c_value(cvalue).unwrap_or_else(|never| match never {})
     }
 }
 
-impl MaybeUnsetConfigValue for Consistency {
-    type CValue = CassConsistency;
+impl MaybeUnsetConfigValue<CassConsistency> for Consistency {
     type Error = ();
 
-    fn is_unset(cvalue: &Self::CValue) -> bool {
+    fn is_unset(cvalue: &CassConsistency) -> bool {
         *cvalue == CassConsistency::CASS_CONSISTENCY_UNKNOWN
     }
 
-    fn from_set_c_value(cvalue: Self::CValue) -> Result<Self, Self::Error> {
+    fn from_set_c_value(cvalue: CassConsistency) -> Result<Self, Self::Error> {
         match cvalue {
             CassConsistency::CASS_CONSISTENCY_ANY => Ok(Consistency::Any),
             CassConsistency::CASS_CONSISTENCY_ONE => Ok(Consistency::One),
@@ -80,15 +78,14 @@ impl MaybeUnsetConfigValue for Consistency {
     }
 }
 
-impl MaybeUnsetConfigValue for Option<SerialConsistency> {
-    type CValue = CassConsistency;
+impl MaybeUnsetConfigValue<CassConsistency> for Option<SerialConsistency> {
     type Error = ();
 
-    fn is_unset(cvalue: &Self::CValue) -> bool {
+    fn is_unset(cvalue: &CassConsistency) -> bool {
         *cvalue == CassConsistency::CASS_CONSISTENCY_UNKNOWN
     }
 
-    fn from_set_c_value(cvalue: Self::CValue) -> Result<Self, Self::Error> {
+    fn from_set_c_value(cvalue: CassConsistency) -> Result<Self, Self::Error> {
         match cvalue {
             CassConsistency::CASS_CONSISTENCY_ANY => {
                 // This is in line with the CPP Driver: if 0 is passed (which is Consistency::Any),
@@ -116,15 +113,14 @@ impl RequestTimeout {
     pub(crate) const INFINITE: Duration = Duration::MAX;
 }
 
-impl MaybeUnsetConfigValue for RequestTimeout {
-    type CValue = cass_uint64_t;
+impl MaybeUnsetConfigValue<cass_uint64_t> for RequestTimeout {
     type Error = Infallible;
 
-    fn is_unset(cvalue: &Self::CValue) -> bool {
+    fn is_unset(cvalue: &cass_uint64_t) -> bool {
         *cvalue == cass_uint64_t::MAX
     }
 
-    fn from_set_c_value(cvalue: Self::CValue) -> Result<Self, Self::Error> {
+    fn from_set_c_value(cvalue: cass_uint64_t) -> Result<Self, Self::Error> {
         Ok(RequestTimeout(
             (cvalue != 0).then(|| Duration::from_millis(cvalue)),
         ))

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -56,15 +56,15 @@ impl CassExecProfile {
         self,
         cluster_default_profile: &ExecutionProfile,
     ) -> ExecutionProfile {
-        let load_balacing = if self.load_balancing_config.load_balancing_kind.is_some() {
+        let load_balancing = if self.load_balancing_config.load_balancing_kind.is_some() {
             self.load_balancing_config.build().await
         } else {
             // If load balancing config does not have LB kind defined,
             // we make use of cluster's LBP.
-            cluster_default_profile.get_load_balancing_policy().clone()
+            Arc::clone(cluster_default_profile.get_load_balancing_policy())
         };
 
-        self.inner.load_balancing_policy(load_balacing).build()
+        self.inner.load_balancing_policy(load_balancing).build()
     }
 }
 

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -341,14 +341,14 @@ pub unsafe extern "C" fn cass_execution_profile_set_consistency(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let Ok(maybe_set_consistency) = MaybeUnsetConfig::<Consistency>::from_c_value(consistency)
+    let Ok(maybe_set_consistency) = MaybeUnsetConfig::<_, Consistency>::from_c_value(consistency)
     else {
         // Invalid consistency value provided.
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
     match maybe_set_consistency {
-        MaybeUnsetConfig::Unset => {
+        MaybeUnsetConfig::Unset(_) => {
             // This will make the profile inherit the consistency from the cluster's default profile.
             // This works around the problem that the Rust Driver's API does not allow
             // unsetting the consistency in the execution profile.
@@ -732,8 +732,8 @@ pub unsafe extern "C" fn cass_execution_profile_set_request_timeout(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    match MaybeUnsetConfig::<RequestTimeout>::from_c_value_infallible(timeout_ms) {
-        MaybeUnsetConfig::Unset => {
+    match MaybeUnsetConfig::<_, RequestTimeout>::from_c_value_infallible(timeout_ms) {
+        MaybeUnsetConfig::Unset(_) => {
             // CASS_UINT64_MAX
             // This will make the profile inherit the request timeout from the cluster's default profile.
             profile_builder.overrides.request_timeout = false;
@@ -799,13 +799,13 @@ pub unsafe extern "C" fn cass_execution_profile_set_serial_consistency(
     };
 
     let Ok(maybe_set_serial_consistency) =
-        MaybeUnsetConfig::<Option<SerialConsistency>>::from_c_value(serial_consistency)
+        MaybeUnsetConfig::<_, Option<SerialConsistency>>::from_c_value(serial_consistency)
     else {
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
     match maybe_set_serial_consistency {
-        MaybeUnsetConfig::Unset => {
+        MaybeUnsetConfig::Unset(_) => {
             // CASS_CONSISTENCY_UNKNOWN
             // This will make the profile inherit the serial consistency from the cluster's default profile.
             // This works around the problem that the Rust Driver's API does not allow
@@ -1392,10 +1392,10 @@ mod tests {
 
                 assert_eq!(
                     built_profile.get_consistency(),
-                    match MaybeUnsetConfig::<Consistency>::from_c_value(custom_cass_consistency)
+                    match MaybeUnsetConfig::<_, Consistency>::from_c_value(custom_cass_consistency)
                         .unwrap()
                     {
-                        MaybeUnsetConfig::Unset => panic!(
+                        MaybeUnsetConfig::Unset(_) => panic!(
                             "Unexpected Unset, which should only happen for CASS_CONSISTENCY_UNKNOWN"
                         ),
                         MaybeUnsetConfig::Set(c) => c,
@@ -1404,12 +1404,12 @@ mod tests {
 
                 assert_eq!(
                     built_profile.get_serial_consistency(),
-                    match MaybeUnsetConfig::<Option<SerialConsistency>>::from_c_value(
+                    match MaybeUnsetConfig::<_, Option<SerialConsistency>>::from_c_value(
                         custom_serial_cass_consistency
                     )
                     .unwrap()
                     {
-                        MaybeUnsetConfig::Unset => panic!(
+                        MaybeUnsetConfig::Unset(_) => panic!(
                             "Unexpected Unset, which should only happen for CASS_CONSISTENCY_UNKNOWN"
                         ),
                         MaybeUnsetConfig::Set(sc) => sc,

--- a/scylla-rust-wrapper/src/load_balancing.rs
+++ b/scylla-rust-wrapper/src/load_balancing.rs
@@ -145,7 +145,12 @@ impl LoadBalancingConfig {
     pub(crate) async fn build(self) -> Arc<dyn LoadBalancingPolicy> {
         let load_balancing_kind = self
             .load_balancing_kind
-            // Round robin is chosen by default for cluster wide LBP.
+            // Round robin is chosen by default for cluster wide LBP, while
+            // in CPP Driver the default load balancing policy is DCAware!
+            // Rationale: CPP Driver initializes the local DC to the first node the client
+            // connects to. This is tricky, a possible footgun, and hard to be done with
+            // the current Rust driver implementation, which is why do don't use DC awareness
+            // by default.
             .unwrap_or(LoadBalancingKind::RoundRobin);
 
         let mut builder = DefaultPolicyBuilder::new().token_aware(self.token_awareness_enabled);

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -5,7 +5,6 @@ use crate::cass_error::*;
 use crate::cass_metrics_types::CassMetrics;
 use crate::cass_types::get_column_type;
 use crate::cluster::CassCluster;
-use crate::cluster::build_session_builder;
 use crate::exec_profile::{CassExecProfile, ExecProfileName, PerStatementExecProfile};
 use crate::future::{CassFuture, CassFutureResult, CassResultValue};
 use crate::metadata::create_table_metadata;
@@ -75,7 +74,7 @@ impl CassConnectedSession {
         cluster: &CassCluster,
         keyspace: Option<String>,
     ) -> CassOwnedSharedPtr<CassFuture, CMut> {
-        let session_builder = build_session_builder(cluster);
+        let session_builder = cluster.build_session_builder();
         let exec_profile_map = cluster.execution_profile_map().clone();
         let host_filter = cluster.build_host_filter();
 

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -332,14 +332,14 @@ pub unsafe extern "C" fn cass_statement_set_consistency(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let Ok(maybe_set_consistency) = MaybeUnsetConfig::<Consistency>::from_c_value(consistency)
+    let Ok(maybe_set_consistency) = MaybeUnsetConfig::<_, Consistency>::from_c_value(consistency)
     else {
         // Invalid consistency value provided.
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
     match maybe_set_consistency {
-        MaybeUnsetConfig::Unset => {
+        MaybeUnsetConfig::Unset(_) => {
             // The correct semantics for `CASS_CONSISTENCY_UNKNOWN` is to
             // make statement not have any opinion at all about consistency.
             // Then, the default from the cluster/execution profile should be used.
@@ -652,13 +652,13 @@ pub unsafe extern "C" fn cass_statement_set_serial_consistency(
     // I think that failing explicitly is a better idea, so I decided to return
     // an error.
     let Ok(maybe_set_serial_consistency) =
-        MaybeUnsetConfig::<Option<SerialConsistency>>::from_c_value(serial_consistency)
+        MaybeUnsetConfig::<_, Option<SerialConsistency>>::from_c_value(serial_consistency)
     else {
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
     match maybe_set_serial_consistency {
-        MaybeUnsetConfig::Unset => {
+        MaybeUnsetConfig::Unset(_) => {
             // The correct semantics for `CASS_CONSISTENCY_UNKNOWN` is to
             // make statement not have any opinion at all about serial consistency.
             // Then, the default from the cluster/execution profile should be used.
@@ -711,7 +711,7 @@ pub unsafe extern "C" fn cass_statement_set_request_timeout(
     };
 
     let maybe_unset_timeout =
-        MaybeUnsetConfig::<RequestTimeout>::from_c_value_infallible(timeout_ms);
+        MaybeUnsetConfig::<_, RequestTimeout>::from_c_value_infallible(timeout_ms);
 
     // `Statement::set_request_timeout` expects an Option<Duration> with unusual semantics:
     // - `None` means "ignore me and use the default timeout from the cluster/execution profile" - this is
@@ -720,7 +720,7 @@ pub unsafe extern "C" fn cass_statement_set_request_timeout(
     // - `Some(timeout)` means "use timeout of given value".
     // Therefore, to acquire "no timeout" semantics, we need to emulate it with an extremely long timeout.
     let timeout = match maybe_unset_timeout {
-        MaybeUnsetConfig::Unset => None,
+        MaybeUnsetConfig::Unset(_) => None,
         MaybeUnsetConfig::Set(RequestTimeout(timeout)) => {
             Some(timeout.unwrap_or(RequestTimeout::INFINITE))
         }

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -343,23 +343,12 @@ pub unsafe extern "C" fn cass_statement_set_consistency(
             // The correct semantics for `CASS_CONSISTENCY_UNKNOWN` is to
             // make statement not have any opinion at all about consistency.
             // Then, the default from the cluster/execution profile should be used.
-            // Unfortunately, the Rust Driver does not support
-            // "unsetting" consistency from a statement at the moment.
-            //
-            // FIXME: Implement unsetting consistency in the Rust Driver.
-            // Then, fix this code.
-            //
-            // For now, we will throw an error in order to warn the user
-            // about this limitation.
-            tracing::warn!(
-                "Passed `CASS_CONSISTENCY_UNKNOWN` to `cass_statement_set_consistency`. \
-                This is not supported by the CPP Rust Driver yet: once you set some consistency \
-                on a statement, you cannot unset it. This limitation will be fixed in the future. \
-                As a workaround, you can refrain from setting consistency on a statement, which \
-                will make the driver use the consistency set on execution profile or cluster level."
-            );
-
-            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            match &mut statement.statement {
+                BoundStatement::Simple(inner) => inner.query.unset_consistency(),
+                BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
+                    .statement
+                    .unset_consistency(),
+            }
         }
         MaybeUnsetConfig::Set(consistency) => match &mut statement.statement {
             BoundStatement::Simple(inner) => inner.query.set_consistency(consistency),
@@ -673,22 +662,12 @@ pub unsafe extern "C" fn cass_statement_set_serial_consistency(
             // The correct semantics for `CASS_CONSISTENCY_UNKNOWN` is to
             // make statement not have any opinion at all about serial consistency.
             // Then, the default from the cluster/execution profile should be used.
-            // Unfortunately, the Rust Driver does not support
-            // "unsetting" serial consistency from a statement at the moment.
-            //
-            // FIXME: Implement unsetting serial consistency in the Rust Driver.
-            // Then, fix this code.
-            //
-            // For now, we will throw an error in order to warn the user
-            // about this limitation.
-            tracing::warn!(
-                "Passed `CASS_CONSISTENCY_UNKNOWN` to `cass_statement_set_serial_consistency`. \
-                This is not supported by the CPP Rust Driver yet: once you set some serial consistency \
-                on a statement, you cannot unset it. This limitation will be fixed in the future. \
-                As a workaround, you can refrain from setting serial consistency on a statement, which \
-                will make the driver use the serial consistency set on execution profile or cluster level."
-            );
-            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            match &mut statement.statement {
+                BoundStatement::Simple(inner) => inner.query.unset_serial_consistency(),
+                BoundStatement::Prepared(inner) => Arc::make_mut(&mut inner.statement)
+                    .statement
+                    .unset_serial_consistency(),
+            }
         }
         MaybeUnsetConfig::Set(serial_consistency) => match &mut statement.statement {
             BoundStatement::Simple(inner) => inner.query.set_serial_consistency(serial_consistency),


### PR DESCRIPTION
_Generated with GPT-4o and manually (heavily) redacted_

Stacked on #341 (first 3 commits).

## Problem Overview

The Rust wrapper diverges from the CPP Driver in several areas of configuration, including:
1. default settings,
2. request timeouts,
3. execution profile behavior, and
4. load balancing policies.

These inconsistencies can lead to confusion for users migrating from the CPP Driver or relying on its documented behavior. Additionally, certain code patterns in the Rust wrapper could benefit from refactoring for improved clarity and maintainability.

## Solution

All changes are made to align the Scylla Rust wrapper with the CPP Driver's behavior while improving code organization and defensive programming practices.

The commits do the following:


1. **Style and typo fixes**:
   - Fixes minor style and typographical issues in `exec_profile.rs`.

1. **Paste CPP Driver defaults in a comment**:
   - Adds comments listing the CPP Driver's default settings and configuration code to ensure no defaults are accidentally omitted in the Rust wrapper.

1. **Use MonotonicTimestampGenerator by default**:
   - Ensures the default timestamp generator matches the CPP Driver's behavior, as well as most of the drivers'.

1. **Enable TCP keepalive by default**:
   - Aligns with the CPP Driver, but sets the keepalive interval to 2 seconds instead of 0 seconds due to libuv's rejection of 0-second configurations (and Rust driver's complaints that 1 sec is too short, whatever).

1. **Refactor `build_session_builder` as a method**:
   - Moves `build_session_builder` to be a method of `CassCluster`, as it perfectly makes sense.

1. **Set default policies explicitly**:
   - Explicitly sets default retry and speculative execution policies in the default execution profile builder to prevent future changes from breaking functionality.

1. **Describe load balancing policy divergence**:
   - Adds comments explaining the divergence in load balancing policy behaviour between the CPP Driver and the Rust wrapper. The Rust wrapper defaults to RoundRobin, requiring explicit local DC configuration for DC-aware policies.

1. **Use cluster defaults for unset settings in execution profiles**:
   - Modifies `CassExecProfile` to use the cluster's default profile for settings not explicitly set in the execution profile, ensuring consistency with the CPP Driver.

1. **Allow unsetting retry policy in execution profile**:
   - Passing null pointer as a retry policy to `cass_execution_profile_retry_policy` shall unset the retry policy, making the driver use the retry policy set in the cluster. This commit makes it true.

1. **Crate-expose `CassPtr::null(_mut)` constructors**:
   - For use in tests.

1.  **Unit test fetching unset settings from cluster**:
   - Verifies that settings that are unset on execution profile are fetched from the cluster.

**The remaining commits are not described here. I decided it's enough to read the commit messages.**

## Discussion Needed

Point 7: Should we reconsider the default load balancing policy to match the CPP Driver's behavior (DCAware with automatic local DC initialization)? While the current approach avoids potential pitfalls, it diverges from the CPP Driver's default.

## Summary

These changes improve the correctness, maintainability, and alignment of the Scylla Rust wrapper with the CPP Driver's behavior. They also enhance code clarity and defensive programming practices.

## Testing

I included one unit test for the execution profiles. The test verifies that each setting is inherited from the cluster iff it's unset in the execution profile.

Integration tests for consistency and serial consistency settings are planned as a follow-up.

## Pre-review Checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~