### PR TITLE
Expose public rust API & enable API lints

### DIFF
--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -60,6 +60,8 @@ strip = "none"
 
 [lints.rust]
 unsafe-op-in-unsafe-fn = "warn"
+unnameable_types = "warn"
+unreachable_pub = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(cpp_integration_testing)',
 ] }

--- a/scylla-rust-wrapper/src/api.rs
+++ b/scylla-rust-wrapper/src/api.rs
@@ -1,0 +1,881 @@
+//! This module re-exports the driver's C API functions.
+//! This has multiple goals:
+//! 1. Provide a single point of access to all C API functions.
+//!    Useful for in-Rust integration testing and intra-crate usage.
+//! 2. Have a complete list of the API, together with clearly marked
+//!    unimplemented functions.
+//! 3. Ensure that the API is `pub`, which happened to not be the case
+//!    because of accidental omission of `pub` in some cases.
+//!
+//! The submodules are ordered by the `cassandra.h` order.
+//! However, the order of the functions within each submodule is alphabetical,
+//! as opposed to the order in `cassandra.h`.
+
+pub mod execution_profile {
+    #[rustfmt::skip]
+    pub use crate::exec_profile::{
+        cass_execution_profile_free,
+        cass_execution_profile_new,
+        cass_execution_profile_set_blacklist_dc_filtering,
+        cass_execution_profile_set_blacklist_dc_filtering_n,
+        cass_execution_profile_set_blacklist_filtering,
+        cass_execution_profile_set_blacklist_filtering_n,
+        cass_execution_profile_set_consistency,
+        cass_execution_profile_set_constant_speculative_execution_policy,
+        cass_execution_profile_set_latency_aware_routing,
+        cass_execution_profile_set_latency_aware_routing_settings,
+        cass_execution_profile_set_load_balance_dc_aware,
+        cass_execution_profile_set_load_balance_dc_aware_n,
+        cass_execution_profile_set_load_balance_rack_aware,
+        cass_execution_profile_set_load_balance_rack_aware_n,
+        cass_execution_profile_set_load_balance_round_robin,
+        cass_execution_profile_set_no_speculative_execution_policy,
+        cass_execution_profile_set_request_timeout,
+        cass_execution_profile_set_retry_policy,
+        cass_execution_profile_set_serial_consistency,
+        cass_execution_profile_set_token_aware_routing,
+        cass_execution_profile_set_token_aware_routing_shuffle_replicas,
+        cass_execution_profile_set_whitelist_dc_filtering,
+        cass_execution_profile_set_whitelist_dc_filtering_n,
+        cass_execution_profile_set_whitelist_filtering,
+        cass_execution_profile_set_whitelist_filtering_n,
+    };
+}
+
+pub mod cluster {
+    #[rustfmt::skip]
+    pub use crate::cluster::{
+        cass_cluster_free,
+        cass_cluster_new,
+        cass_cluster_set_application_name,
+        cass_cluster_set_application_name_n,
+        cass_cluster_set_application_version,
+        cass_cluster_set_application_version_n,
+        // cass_cluster_set_authenticator_callbacks, UNIMPLEMENTED
+        cass_cluster_set_blacklist_dc_filtering,
+        cass_cluster_set_blacklist_dc_filtering_n,
+        cass_cluster_set_blacklist_filtering,
+        cass_cluster_set_blacklist_filtering_n,
+        cass_cluster_set_client_id,
+        // cass_cluster_set_cloud_secure_connection_bundle, UNIMPLEMENTED
+        cass_cluster_set_cloud_secure_connection_bundle_n, // FIXME: shouldn't this be unimplemented?
+        // cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init, UNIMPLEMENTED
+        // cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init_n, UNIMPLEMENTED
+        cass_cluster_set_coalesce_delay,
+        cass_cluster_set_compression,
+        cass_cluster_set_connect_timeout,
+        cass_cluster_set_connection_heartbeat_interval,
+        cass_cluster_set_connection_idle_timeout,
+        cass_cluster_set_consistency,
+        // cass_cluster_set_constant_reconnect, UNIMPLEMENTED
+        cass_cluster_set_contact_points,
+        cass_cluster_set_contact_points_n,
+        cass_cluster_set_constant_speculative_execution_policy,
+        cass_cluster_set_core_connections_per_host,
+        cass_cluster_set_core_connections_per_shard,
+        cass_cluster_set_credentials,
+        cass_cluster_set_credentials_n,
+        cass_cluster_set_execution_profile,
+        cass_cluster_set_execution_profile_n,
+        cass_cluster_set_exponential_reconnect, // FIXME: Should be unimplemented!
+        // cass_cluster_set_host_listener_callback, UNIMPLEMENTED
+        cass_cluster_set_latency_aware_routing,
+        cass_cluster_set_latency_aware_routing_settings,
+        cass_cluster_set_load_balance_round_robin,
+        cass_cluster_set_load_balance_dc_aware,
+        cass_cluster_set_load_balance_dc_aware_n,
+        cass_cluster_set_local_address,
+        cass_cluster_set_local_address_n,
+        cass_cluster_set_local_port_range,
+        cass_cluster_set_load_balance_rack_aware,
+        cass_cluster_set_load_balance_rack_aware_n,
+        // cass_cluster_set_max_concurrent_creation, UNIMPLEMENTED
+        // cass_cluster_set_max_concurrent_requests_threshold, UNIMPLEMENTED
+        // cass_cluster_set_max_connections_per_host, UNIMPLEMENTED
+        // cass_cluster_set_max_requests_per_flush, UNIMPLEMENTED
+        // cass_cluster_set_max_reusable_write_objects, UNIMPLEMENTED
+        // cass_cluster_set_monitor_reporting_interval, UNIMPLEMENTED
+        cass_cluster_set_max_schema_wait_time,
+        // cass_cluster_set_new_request_ratio, UNIMPLEMENTED
+        // cass_cluster_set_no_compact, UNIMPLEMENTED
+        cass_cluster_set_no_speculative_execution_policy,
+        // cass_cluster_set_num_threads_io, UNIMPLEMENTED
+        cass_cluster_set_port,
+        // cass_cluster_set_prepare_on_all_hosts, UNIMPLEMENTED
+        // cass_cluster_set_prepare_on_up_or_add_host, UNIMPLEMENTED
+        cass_cluster_set_protocol_version,
+        cass_cluster_set_queue_size_event,
+        // cass_cluster_set_queue_size_io, UNIMPLEMENTED
+        // cass_cluster_set_reconnect_wait_time, UNIMPLEMENTED
+        cass_cluster_set_request_timeout,
+        // cass_cluster_set_resolve_timeout, UNIMPLEMENTED
+        cass_cluster_set_retry_policy,
+        cass_cluster_set_schema_agreement_interval,
+        cass_cluster_set_serial_consistency,
+        cass_cluster_set_ssl,
+        cass_cluster_set_tcp_keepalive,
+        cass_cluster_set_tcp_nodelay,
+        cass_cluster_set_timestamp_gen,
+        cass_cluster_set_token_aware_routing,
+        cass_cluster_set_token_aware_routing_shuffle_replicas,
+        // cass_cluster_set_tracing_max_wait_time, UNIMPLEMENTED
+        // cass_cluster_set_tracing_retry_wait_time, UNIMPLEMENTED
+        // cass_cluster_set_tracing_consistency, UNIMPLEMENTED
+        cass_cluster_set_use_beta_protocol_version,
+        // cass_cluster_set_use_hostname_resolution, UNIMPLEMENTED
+        cass_cluster_set_use_randomized_contact_points, // FIXME: Should be unimplemented!
+        cass_cluster_set_use_schema,
+        cass_cluster_set_whitelist_dc_filtering,
+        cass_cluster_set_whitelist_dc_filtering_n,
+        cass_cluster_set_whitelist_filtering,
+        cass_cluster_set_whitelist_filtering_n,
+        // cass_cluster_set_write_bytes_high_water_mark, UNIMPLEMENTED
+        // cass_cluster_set_write_bytes_low_water_mark, UNIMPLEMENTED
+        // cass_cluster_set_pending_requests_high_water_mark, UNIMPLEMENTED
+        // cass_cluster_set_pending_requests_low_water_mark, UNIMPLEMENTED
+    };
+}
+
+pub mod session {
+    #[rustfmt::skip]
+    pub use crate::session::{
+        cass_session_close,
+        cass_session_connect,
+        cass_session_connect_keyspace,
+        cass_session_connect_keyspace_n,
+        cass_session_execute,
+        cass_session_execute_batch,
+        cass_session_free,
+        cass_session_get_client_id,
+        cass_session_get_metrics,
+        cass_session_get_schema_meta,
+        // cass_session_get_speculative_execution_metrics, UNIMPLEMENTED
+        cass_session_new,
+        cass_session_prepare,
+        cass_session_prepare_from_existing,
+        cass_session_prepare_n,
+    };
+}
+
+pub mod schema_meta {
+    #[rustfmt::skip]
+    pub use crate::metadata::{
+        cass_schema_meta_free,
+        // cass_schema_meta_snapshot_version, UNIMPLEMENTED
+        // cass_schema_meta_version, UNIMPLEMENTED
+        cass_schema_meta_keyspace_by_name,
+        cass_schema_meta_keyspace_by_name_n,
+    };
+}
+
+pub mod keyspace_meta {
+    #[rustfmt::skip]
+    pub use crate::metadata::{
+        // cass_keyspace_meta_aggregate_by_name, UNIMPLEMENTED
+        // cass_keyspace_meta_aggregate_by_name_n, UNIMPLEMENTED
+        // cass_keyspace_meta_field_by_name, UNIMPLEMENTED
+        // cass_keyspace_meta_field_by_name_n, UNIMPLEMENTED
+        // cass_keyspace_meta_function_by_name, UNIMPLEMENTED
+        // cass_keyspace_meta_function_by_name_n, UNIMPLEMENTED
+        // cass_keyspace_meta_is_virtual, UNIMPLEMENTED
+        cass_keyspace_meta_materialized_view_by_name,
+        cass_keyspace_meta_materialized_view_by_name_n,
+        cass_keyspace_meta_name,
+        cass_keyspace_meta_table_by_name,
+        cass_keyspace_meta_table_by_name_n,
+        cass_keyspace_meta_user_type_by_name,
+        cass_keyspace_meta_user_type_by_name_n,
+    };
+}
+
+pub mod table_meta {
+    #[rustfmt::skip]
+    pub use crate::metadata::{
+        cass_table_meta_clustering_key_count,
+        cass_table_meta_clustering_key,
+        // cass_table_meta_clustering_key_order, UNIMPLEMENTED
+        cass_table_meta_column,
+        cass_table_meta_column_by_name,
+        cass_table_meta_column_by_name_n,
+        cass_table_meta_column_count,
+        // cass_table_meta_field_by_name, UNIMPLEMENTED
+        // cass_table_meta_field_by_name_n, UNIMPLEMENTED
+        // cass_table_meta_index, UNIMPLEMENTED
+        // cass_table_meta_index_by_name, UNIMPLEMENTED
+        // cass_table_meta_index_by_name_n, UNIMPLEMENTED
+        // cass_table_meta_index_count, UNIMPLEMENTED
+        // cass_table_meta_is_virtual, UNIMPLEMENTED
+        cass_table_meta_materialized_view,
+        cass_table_meta_materialized_view_by_name,
+        cass_table_meta_materialized_view_by_name_n,
+        cass_table_meta_materialized_view_count,
+        cass_table_meta_name,
+        cass_table_meta_partition_key_count,
+        cass_table_meta_partition_key,
+    };
+}
+
+pub mod materialized_view_meta {
+    #[rustfmt::skip]
+    pub use crate::metadata::{
+        cass_materialized_view_meta_base_table,
+        cass_materialized_view_meta_column,
+        cass_materialized_view_meta_column_by_name,
+        cass_materialized_view_meta_column_by_name_n,
+        cass_materialized_view_meta_column_count,
+        cass_materialized_view_meta_name,
+        cass_materialized_view_meta_clustering_key,
+        cass_materialized_view_meta_clustering_key_count,
+        // cass_materialized_view_meta_clustering_key_order, UNIMPLEMENTED
+        // cass_materialized_view_meta_field_by_name, UNIMPLEMENTED
+        // cass_materialized_view_meta_field_by_name_n, UNIMPLEMENTED
+        cass_materialized_view_meta_partition_key,
+        cass_materialized_view_meta_partition_key_count,
+    };
+}
+
+pub mod column_meta {
+    #[rustfmt::skip]
+    pub use crate::metadata::{
+        cass_column_meta_data_type,
+        // cass_column_meta_field_by_name, UNIMPLEMENTED
+        // cass_column_meta_field_by_name_n, UNIMPLEMENTED
+        cass_column_meta_name,
+        cass_column_meta_type,
+    };
+}
+
+pub mod index_meta {
+    #[expect(unused_imports)]
+    #[rustfmt::skip]
+    pub use crate::metadata::{
+        // cass_index_meta_name, UNIMPLEMENTED
+        // cass_index_meta_field_by_name, UNIMPLEMENTED
+        // cass_index_meta_field_by_name_n, UNIMPLEMENTED
+        // cass_index_meta_options, UNIMPLEMENTED
+        // cass_index_meta_target, UNIMPLEMENTED
+        // cass_index_meta_type, UNIMPLEMENTED
+    };
+}
+
+pub mod function_meta {
+    #[expect(unused_imports)]
+    #[rustfmt::skip]
+    pub use crate::metadata::{
+        // cass_function_meta_argument_count, UNIMPLEMENTED
+        // cass_function_meta_argument, UNIMPLEMENTED
+        // cass_function_meta_argument_type_by_name, UNIMPLEMENTED
+        // cass_function_meta_argument_type_by_name_n, UNIMPLEMENTED
+        // cass_function_meta_body, UNIMPLEMENTED
+        // cass_function_meta_called_on_null_input, UNIMPLEMENTED
+        // cass_function_meta_field_by_name, UNIMPLEMENTED
+        // cass_function_meta_field_by_name_n, UNIMPLEMENTED
+        // cass_function_meta_full_name, UNIMPLEMENTED
+        // cass_function_meta_language, UNIMPLEMENTED
+        // cass_function_meta_name, UNIMPLEMENTED
+        // cass_function_meta_return_type, UNIMPLEMENTED
+    };
+}
+
+pub mod aggregate_meta {
+    #[expect(unused_imports)]
+    #[rustfmt::skip]
+    pub use crate::metadata::{
+        // cass_aggregate_meta_argument, UNIMPLEMENTED
+        // cass_aggregate_meta_argument_count, UNIMPLEMENTED
+        // cass_aggregate_meta_argument_type, UNIMPLEMENTED
+        // cass_aggregate_meta_field_by_name, UNIMPLEMENTED
+        // cass_aggregate_meta_field_by_name_n, UNIMPLEMENTED
+        // cass_aggregate_meta_final_func, UNIMPLEMENTED
+        // cass_aggregate_meta_full_name, UNIMPLEMENTED
+        // cass_aggregate_meta_init_cond, UNIMPLEMENTED
+        // cass_aggregate_meta_name, UNIMPLEMENTED
+        // cass_aggregate_meta_return_type, UNIMPLEMENTED
+        // cass_aggregate_meta_state_func, UNIMPLEMENTED
+        // cass_aggregate_meta_state_type, UNIMPLEMENTED
+    };
+}
+
+pub mod ssl {
+    #[rustfmt::skip]
+    pub use crate::ssl::{
+        cass_ssl_add_trusted_cert,
+        cass_ssl_add_trusted_cert_n,
+        cass_ssl_free,
+        cass_ssl_new,
+        cass_ssl_new_no_lib_init,
+        cass_ssl_set_cert,
+        cass_ssl_set_cert_n,
+        cass_ssl_set_private_key,
+        cass_ssl_set_private_key_n,
+        cass_ssl_set_verify_flags,
+    };
+}
+
+pub mod authenticator {
+    #[expect(unused_imports)]
+    #[rustfmt::skip]
+    pub use crate::{
+        // cass_authenticator_address, UNIMPLEMENTED
+        // cass_authenticator_hostname, UNIMPLEMENTED
+        // cass_authenticator_class_name, UNIMPLEMENTED
+        // cass_authenticator_exchange_data, UNIMPLEMENTED
+        // cass_authenticator_set_exchange_data, UNIMPLEMENTED
+        // cass_authenticator_response, UNIMPLEMENTED
+        // cass_authenticator_set_response, UNIMPLEMENTED
+        // cass_authenticator_set_error, UNIMPLEMENTED
+        // cass_authenticator_set_error_n, UNIMPLEMENTED
+    };
+}
+
+pub mod future {
+    #[rustfmt::skip]
+    pub use crate::future::{
+        cass_future_coordinator,
+        cass_future_error_code,
+        cass_future_error_message,
+        cass_future_get_error_result,
+        cass_future_free,
+        cass_future_get_prepared,
+        cass_future_get_result,
+        cass_future_ready,
+        cass_future_set_callback,
+        cass_future_tracing_id,
+        cass_future_wait,
+        cass_future_wait_timed,
+    };
+
+    #[rustfmt::skip]
+    pub use crate::cluster::{
+        cass_future_custom_payload_item,  // FIXME: Should be unimplemented!
+        cass_future_custom_payload_item_count,  // FIXME: Should be unimplemented!
+    };
+}
+
+pub mod statement {
+    #[rustfmt::skip]
+    pub use crate::statement::{
+        cass_statement_bind_bool,
+        cass_statement_bind_bool_by_name,
+        cass_statement_bind_bool_by_name_n,
+        cass_statement_bind_bytes,
+        cass_statement_bind_bytes_by_name,
+        cass_statement_bind_bytes_by_name_n,
+        // cass_statement_bind_custom, UNIMPLEMENTED
+        // cass_statement_bind_custom_by_name, UNIMPLEMENTED
+        // cass_statement_bind_custom_n, UNIMPLEMENTED
+        cass_statement_bind_collection,
+        cass_statement_bind_collection_by_name,
+        cass_statement_bind_collection_by_name_n,
+        cass_statement_bind_decimal,
+        cass_statement_bind_decimal_by_name,
+        cass_statement_bind_decimal_by_name_n,
+        cass_statement_bind_double,
+        cass_statement_bind_double_by_name,
+        cass_statement_bind_double_by_name_n,
+        cass_statement_bind_duration,
+        cass_statement_bind_duration_by_name,
+        cass_statement_bind_duration_by_name_n,
+        cass_statement_bind_float,
+        cass_statement_bind_float_by_name,
+        cass_statement_bind_float_by_name_n,
+        cass_statement_bind_inet,
+        cass_statement_bind_inet_by_name,
+        cass_statement_bind_inet_by_name_n,
+        cass_statement_bind_int8,
+        cass_statement_bind_int8_by_name,
+        cass_statement_bind_int8_by_name_n,
+        cass_statement_bind_int16,
+        cass_statement_bind_int16_by_name,
+        cass_statement_bind_int16_by_name_n,
+        cass_statement_bind_int32,
+        cass_statement_bind_int32_by_name,
+        cass_statement_bind_int32_by_name_n,
+        cass_statement_bind_int64,
+        cass_statement_bind_int64_by_name,
+        cass_statement_bind_int64_by_name_n,
+        cass_statement_bind_null,
+        cass_statement_bind_null_by_name,
+        cass_statement_bind_null_by_name_n,
+        cass_statement_bind_string,
+        cass_statement_bind_string_by_name,
+        cass_statement_bind_string_by_name_n,
+        cass_statement_bind_string_n,
+        cass_statement_bind_tuple,
+        cass_statement_bind_tuple_by_name,
+        cass_statement_bind_tuple_by_name_n,
+        cass_statement_bind_uint32,
+        cass_statement_bind_uint32_by_name,
+        cass_statement_bind_uint32_by_name_n,
+        cass_statement_bind_user_type,
+        cass_statement_bind_user_type_by_name,
+        cass_statement_bind_user_type_by_name_n,
+        cass_statement_bind_uuid,
+        cass_statement_bind_uuid_by_name,
+        cass_statement_bind_uuid_by_name_n,
+        // cass_statement_add_key_index, UNIMPLEMENTED
+        cass_statement_free,
+        cass_statement_new,
+        cass_statement_new_n,
+        cass_statement_reset_parameters,
+        cass_statement_set_consistency,
+        // cass_statement_set_custom_payload, UNIMPLEMENTED
+        // cass_statement_set_custom_payload_n, UNIMPLEMENTED
+        cass_statement_set_host,
+        cass_statement_set_host_inet,
+        cass_statement_set_host_n,
+        cass_statement_set_is_idempotent,
+        // cass_statement_set_keyspace, UNIMPLEMENTED
+        // cass_statement_set_keyspace_n, UNIMPLEMENTED
+        cass_statement_set_node,
+        cass_statement_set_paging_size,
+        cass_statement_set_paging_state,
+        cass_statement_set_paging_state_token,
+        cass_statement_set_request_timeout,
+        cass_statement_set_retry_policy,
+        cass_statement_set_serial_consistency,
+        cass_statement_set_timestamp,
+        cass_statement_set_tracing,
+    };
+
+    #[rustfmt::skip]
+    pub use crate::exec_profile::{
+        cass_statement_set_execution_profile,
+        cass_statement_set_execution_profile_n,
+    };
+}
+
+pub mod prepared {
+    #[rustfmt::skip]
+    pub use crate::prepared::{
+        cass_prepared_bind,
+        cass_prepared_free,
+        cass_prepared_parameter_data_type,
+        cass_prepared_parameter_data_type_by_name,
+        cass_prepared_parameter_data_type_by_name_n,
+        cass_prepared_parameter_name,
+    };
+}
+
+pub mod batch {
+    #[rustfmt::skip]
+    pub use crate::batch::{
+        cass_batch_add_statement,
+        cass_batch_free,
+        cass_batch_new,
+        cass_batch_set_consistency,
+        // cass_batch_set_custom_payload, UNIMPLEMENTED
+        // cass_batch_set_keyspace, UNIMPLEMENTED
+        // cass_batch_set_keyspace_n, UNIMPLEMENTED
+        cass_batch_set_serial_consistency,
+        cass_batch_set_request_timeout,
+        cass_batch_set_is_idempotent,
+        cass_batch_set_retry_policy,
+        cass_batch_set_timestamp,
+        cass_batch_set_tracing,
+    };
+
+    #[rustfmt::skip]
+    pub use crate::exec_profile::{
+        cass_batch_set_execution_profile,
+        cass_batch_set_execution_profile_n,
+    };
+}
+
+pub mod data_type {
+    #[rustfmt::skip]
+    pub use crate::cass_types::{
+        cass_data_sub_type_count,
+        cass_data_type_add_sub_type,
+        cass_data_type_add_sub_type_by_name,
+        cass_data_type_add_sub_type_by_name_n,
+        cass_data_type_add_sub_value_type,
+        cass_data_type_add_sub_value_type_by_name,
+        cass_data_type_add_sub_value_type_by_name_n,
+        cass_data_type_class_name,
+        cass_data_type_free,
+        cass_data_type_is_frozen,
+        cass_data_type_keyspace,
+        cass_data_type_new,
+        cass_data_type_new_from_existing,
+        cass_data_type_new_tuple,
+        cass_data_type_new_udt,
+        cass_data_type_set_class_name,
+        cass_data_type_set_class_name_n,
+        cass_data_type_set_keyspace,
+        cass_data_type_set_keyspace_n,
+        cass_data_type_set_type_name,
+        cass_data_type_set_type_name_n,
+        cass_data_type_sub_data_type,
+        cass_data_type_sub_data_type_by_name,
+        cass_data_type_sub_data_type_by_name_n,
+        cass_data_type_sub_type_count,
+        cass_data_type_sub_type_name,
+        cass_data_type_type,
+        cass_data_type_type_name,
+    };
+}
+
+pub mod collection {
+    #[rustfmt::skip]
+    pub use crate::collection::{
+        cass_collection_append_bool,
+        cass_collection_append_bytes,
+        cass_collection_append_collection,
+        // cass_collection_append_custom, UNIMPLEMENTED
+        // cass_collection_append_custom_n, UNIMPLEMENTED
+        cass_collection_append_decimal,
+        cass_collection_append_duration,
+        cass_collection_append_double,
+        cass_collection_append_float,
+        cass_collection_append_inet,
+        cass_collection_append_int8,
+        cass_collection_append_int16,
+        cass_collection_append_int32,
+        cass_collection_append_int64,
+        cass_collection_append_string,
+        cass_collection_append_string_n,
+        cass_collection_append_tuple,
+        cass_collection_append_uint32,
+        cass_collection_append_user_type,
+        cass_collection_append_uuid,
+        cass_collection_data_type,
+        cass_collection_free,
+        cass_collection_new,
+        cass_collection_new_from_data_type,
+    };
+}
+
+pub mod tuple {
+    #[rustfmt::skip]
+    pub use crate::tuple::{
+        cass_tuple_data_type,
+        cass_tuple_free,
+        cass_tuple_new,
+        cass_tuple_new_from_data_type,
+        cass_tuple_set_bool,
+        cass_tuple_set_bytes,
+        cass_tuple_set_collection,
+        // cass_tuple_set_custom, UNIMPLEMENTED
+        // cass_tuple_set_custom_n, UNIMPLEMENTED
+        cass_tuple_set_decimal,
+        cass_tuple_set_duration,
+        cass_tuple_set_double,
+        cass_tuple_set_float,
+        cass_tuple_set_inet,
+        cass_tuple_set_int8,
+        cass_tuple_set_int16,
+        cass_tuple_set_int32,
+        cass_tuple_set_int64,
+        cass_tuple_set_null,
+        cass_tuple_set_string,
+        cass_tuple_set_string_n,
+        cass_tuple_set_tuple,
+        cass_tuple_set_uint32,
+        cass_tuple_set_user_type,
+        cass_tuple_set_uuid,
+    };
+}
+
+pub mod user_type {
+    #[rustfmt::skip]
+    pub use crate::user_type::{
+        cass_user_type_data_type,
+        cass_user_type_free,
+        cass_user_type_new_from_data_type,
+        cass_user_type_set_bool,
+        cass_user_type_set_bool_by_name,
+        cass_user_type_set_bool_by_name_n,
+        cass_user_type_set_bytes,
+        cass_user_type_set_bytes_by_name,
+        cass_user_type_set_bytes_by_name_n,
+        cass_user_type_set_collection,
+        cass_user_type_set_collection_by_name,
+        cass_user_type_set_collection_by_name_n,
+        // cass_user_type_set_custom, UNIMPLEMENTED
+        // cass_user_type_set_custom_by_name, UNIMPLEMENTED
+        // cass_user_type_set_custom_by_name_n, UNIMPLEMENTED
+        // cass_user_type_set_custom_n, UNIMPLEMENTED
+        cass_user_type_set_decimal,
+        cass_user_type_set_decimal_by_name,
+        cass_user_type_set_decimal_by_name_n,
+        cass_user_type_set_duration,
+        cass_user_type_set_duration_by_name,
+        cass_user_type_set_duration_by_name_n,
+        cass_user_type_set_double,
+        cass_user_type_set_double_by_name,
+        cass_user_type_set_double_by_name_n,
+        cass_user_type_set_float,
+        cass_user_type_set_float_by_name,
+        cass_user_type_set_float_by_name_n,
+        cass_user_type_set_inet,
+        cass_user_type_set_inet_by_name,
+        cass_user_type_set_inet_by_name_n,
+        cass_user_type_set_int8,
+        cass_user_type_set_int8_by_name,
+        cass_user_type_set_int8_by_name_n,
+        cass_user_type_set_int16,
+        cass_user_type_set_int16_by_name,
+        cass_user_type_set_int16_by_name_n,
+        cass_user_type_set_int32,
+        cass_user_type_set_int32_by_name,
+        cass_user_type_set_int32_by_name_n,
+        cass_user_type_set_int64,
+        cass_user_type_set_int64_by_name,
+        cass_user_type_set_int64_by_name_n,
+        cass_user_type_set_null,
+        cass_user_type_set_null_by_name,
+        cass_user_type_set_null_by_name_n,
+        cass_user_type_set_string,
+        cass_user_type_set_string_by_name,
+        cass_user_type_set_string_by_name_n,
+        cass_user_type_set_string_n,
+        cass_user_type_set_tuple,
+        cass_user_type_set_tuple_by_name,
+        cass_user_type_set_tuple_by_name_n,
+        cass_user_type_set_uint32,
+        cass_user_type_set_uint32_by_name,
+        cass_user_type_set_uint32_by_name_n,
+        cass_user_type_set_user_type,
+        cass_user_type_set_user_type_by_name,
+        cass_user_type_set_user_type_by_name_n,
+        cass_user_type_set_uuid,
+        cass_user_type_set_uuid_by_name,
+        cass_user_type_set_uuid_by_name_n,
+    };
+}
+
+pub mod result {
+    #[rustfmt::skip]
+    pub use crate::query_result::{
+        cass_result_column_count,
+        cass_result_column_data_type,
+        cass_result_column_name,
+        cass_result_column_type,
+        cass_result_first_row,
+        cass_result_free,
+        cass_result_has_more_pages,
+        cass_result_paging_state_token,
+        cass_result_row_count,
+    };
+}
+
+pub mod error {
+    #[rustfmt::skip]
+    pub use crate::execution_error::{
+        cass_error_num_arg_types,
+        cass_error_result_arg_type,
+        cass_error_result_code,
+        cass_error_result_consistency,
+        cass_error_result_data_present,
+        cass_error_result_free,
+        cass_error_result_function,
+        cass_error_result_keyspace,
+        cass_error_result_num_failures,
+        cass_error_result_responses_received,
+        cass_error_result_responses_required,
+        cass_error_result_table,
+        cass_error_result_write_type,
+    };
+
+    #[rustfmt::skip]
+    pub use crate::external::{
+        cass_error_desc,
+    };
+}
+
+pub mod iterator {
+    #[rustfmt::skip]
+    pub use crate::iterator::{
+        cass_iterator_fields_from_user_type,
+        cass_iterator_free,
+        cass_iterator_from_collection,
+        cass_iterator_from_map,
+        cass_iterator_from_result,
+        cass_iterator_from_row,
+        cass_iterator_from_tuple,
+        // cass_iterator_aggregates_from_keyspace_meta, UNIMPLEMENTED
+        cass_iterator_columns_from_materialized_view_meta,
+        cass_iterator_columns_from_table_meta,
+        // cass_iterator_functions_from_keyspace_meta, UNIMPLEMENTED
+        // cass_iterator_fields_from_keyspace_meta, UNIMPLEMENTED
+        // cass_iterator_fields_from_table_meta, UNIMPLEMENTED
+        // cass_iterator_fields_from_materialized_view_meta, UNIMPLEMENTED
+        // cass_iterator_fields_from_column_meta, UNIMPLEMENTED
+        // cass_iterator_fields_from_index_meta, UNIMPLEMENTED
+        // cass_iterator_fields_from_function_meta, UNIMPLEMENTED
+        // cass_iterator_fields_from_aggregate_meta, UNIMPLEMENTED
+        // cass_iterator_get_aggregate_meta, UNIMPLEMENTED
+        cass_iterator_get_column,
+        cass_iterator_get_column_meta,
+        // cass_iterator_get_function_meta, UNIMPLEMENTED
+        // cass_iterator_get_index_meta, UNIMPLEMENTED
+        // cass_iterator_get_meta_field_name, UNIMPLEMENTED
+        cass_iterator_get_map_key,
+        cass_iterator_get_map_value,
+        cass_iterator_get_materialized_view_meta,
+        cass_iterator_get_user_type_field_name,
+        cass_iterator_get_user_type_field_value,
+        cass_iterator_get_keyspace_meta,
+        // cass_iterator_get_meta_field_value, UNIMPLEMENTED
+        cass_iterator_get_row,
+        cass_iterator_get_table_meta,
+        cass_iterator_get_value,
+        cass_iterator_get_user_type,
+        // cass_iterator_indexes_from_table_meta, UNIMPLEMENTED
+        cass_iterator_keyspaces_from_schema_meta,
+        cass_iterator_materialized_views_from_keyspace_meta,
+        cass_iterator_materialized_views_from_table_meta,
+        cass_iterator_next,
+        cass_iterator_tables_from_keyspace_meta,
+        cass_iterator_type,
+        cass_iterator_user_types_from_keyspace_meta,
+    };
+}
+
+pub mod row {
+    #[rustfmt::skip]
+    pub use crate::query_result::{
+        cass_row_get_column,
+        cass_row_get_column_by_name,
+        cass_row_get_column_by_name_n,
+    };
+}
+
+pub mod value {
+    #[rustfmt::skip]
+    pub use crate::query_result::{
+        cass_value_data_type,
+        cass_value_get_bool,
+        cass_value_get_bytes,
+        // cass_value_get_custom, UNIMPLEMENTED
+        cass_value_get_decimal,
+        cass_value_get_duration,
+        cass_value_get_double,
+        cass_value_get_float,
+        cass_value_get_inet,
+        cass_value_get_int8,
+        cass_value_get_int16,
+        cass_value_get_int32,
+        cass_value_get_int64,
+        cass_value_get_string,
+        cass_value_get_uint32,
+        cass_value_get_uuid,
+        cass_value_is_collection,
+        cass_value_is_duration,
+        cass_value_is_null,
+        cass_value_item_count,
+        cass_value_primary_sub_type,
+        cass_value_secondary_sub_type,
+        cass_value_type,
+    };
+}
+
+pub mod uuid_gen {
+    #[rustfmt::skip]
+    pub use crate::uuid::{
+        cass_uuid_gen_free,
+        cass_uuid_gen_from_time,
+        cass_uuid_gen_new,
+        cass_uuid_gen_new_with_node,
+        cass_uuid_gen_random,
+        cass_uuid_gen_time,
+    };
+}
+
+pub mod uuid {
+    #[rustfmt::skip]
+    pub use crate::uuid::{
+        cass_uuid_from_string,
+        cass_uuid_from_string_n,
+        cass_uuid_min_from_time,
+        cass_uuid_max_from_time,
+        cass_uuid_timestamp,
+        cass_uuid_string,
+        cass_uuid_version,
+    };
+}
+
+pub mod timestamp_gen {
+    #[rustfmt::skip]
+    pub use crate::timestamp_generator::{
+        cass_timestamp_gen_free,
+        cass_timestamp_gen_monotonic_new,
+        cass_timestamp_gen_monotonic_new_with_settings,
+        cass_timestamp_gen_server_side_new,
+    };
+}
+
+pub mod retry_policy {
+    #[rustfmt::skip]
+    pub use crate::retry_policy::{
+        cass_retry_policy_default_new,
+        cass_retry_policy_downgrading_consistency_new,
+        cass_retry_policy_fallthrough_new,
+        cass_retry_policy_free,
+        cass_retry_policy_logging_new,
+    };
+}
+
+pub mod custom_payload {
+    // cass_custom_payload_free, UNIMPLEMENTED
+    // cass_custom_payload_new, UNIMPLEMENTED
+    // cass_custom_payload_remove, UNIMPLEMENTED
+    // cass_custom_payload_remove_n, UNIMPLEMENTED
+    // cass_custom_payload_set, UNIMPLEMENTED
+    // cass_custom_payload_set_n, UNIMPLEMENTED
+    #[rustfmt::skip]
+    pub use crate::cluster::{
+        cass_custom_payload_new, // FIXME: Should be unimplemented!
+    };
+}
+
+pub mod consistency {
+    #[rustfmt::skip]
+    pub use crate::misc::{
+        cass_consistency_string
+    };
+}
+
+pub mod write_type {
+    #[rustfmt::skip]
+    pub use crate::misc::{
+        cass_write_type_string
+    };
+}
+
+pub mod log {
+    #[rustfmt::skip]
+    pub use crate::logging::{
+        cass_log_cleanup,
+        cass_log_get_callback_and_data,
+        cass_log_level_string,
+        cass_log_set_callback,
+        cass_log_set_level,
+        cass_log_set_queue_size,
+    };
+}
+
+pub mod inet {
+    #[rustfmt::skip]
+    pub use crate::inet::{
+        cass_inet_from_string,
+        cass_inet_from_string_n,
+        cass_inet_init_v4,
+        cass_inet_init_v6,
+        cass_inet_string,
+    };
+}
+
+pub mod date_time {
+    #[rustfmt::skip]
+    pub use crate::date_time::{
+        cass_date_from_epoch,
+        cass_date_time_to_epoch,
+        cass_time_from_epoch
+    };
+}
+
+pub mod alloc {
+    // cass_alloc_set_functions, UNIMPLEMENTED
+}

--- a/scylla-rust-wrapper/src/api.rs
+++ b/scylla-rust-wrapper/src/api.rs
@@ -14,6 +14,7 @@
 pub mod execution_profile {
     #[rustfmt::skip]
     pub use crate::exec_profile::{
+        CassExecProfile,
         cass_execution_profile_free,
         cass_execution_profile_new,
         cass_execution_profile_set_blacklist_dc_filtering,
@@ -45,6 +46,7 @@ pub mod execution_profile {
 pub mod cluster {
     #[rustfmt::skip]
     pub use crate::cluster::{
+        CassCluster,
         cass_cluster_free,
         cass_cluster_new,
         cass_cluster_set_application_name,
@@ -139,6 +141,7 @@ pub mod cluster {
 pub mod session {
     #[rustfmt::skip]
     pub use crate::session::{
+        CassSession,
         cass_session_close,
         cass_session_connect,
         cass_session_connect_keyspace,
@@ -160,6 +163,7 @@ pub mod session {
 pub mod schema_meta {
     #[rustfmt::skip]
     pub use crate::metadata::{
+        CassSchemaMeta,
         cass_schema_meta_free,
         // cass_schema_meta_snapshot_version, UNIMPLEMENTED
         // cass_schema_meta_version, UNIMPLEMENTED
@@ -171,6 +175,7 @@ pub mod schema_meta {
 pub mod keyspace_meta {
     #[rustfmt::skip]
     pub use crate::metadata::{
+        CassKeyspaceMeta,
         // cass_keyspace_meta_aggregate_by_name, UNIMPLEMENTED
         // cass_keyspace_meta_aggregate_by_name_n, UNIMPLEMENTED
         // cass_keyspace_meta_field_by_name, UNIMPLEMENTED
@@ -191,6 +196,7 @@ pub mod keyspace_meta {
 pub mod table_meta {
     #[rustfmt::skip]
     pub use crate::metadata::{
+        CassTableMeta,
         cass_table_meta_clustering_key_count,
         cass_table_meta_clustering_key,
         // cass_table_meta_clustering_key_order, UNIMPLEMENTED
@@ -218,6 +224,7 @@ pub mod table_meta {
 pub mod materialized_view_meta {
     #[rustfmt::skip]
     pub use crate::metadata::{
+        CassMaterializedViewMeta,
         cass_materialized_view_meta_base_table,
         cass_materialized_view_meta_column,
         cass_materialized_view_meta_column_by_name,
@@ -237,6 +244,7 @@ pub mod materialized_view_meta {
 pub mod column_meta {
     #[rustfmt::skip]
     pub use crate::metadata::{
+        CassColumnMeta,
         cass_column_meta_data_type,
         // cass_column_meta_field_by_name, UNIMPLEMENTED
         // cass_column_meta_field_by_name_n, UNIMPLEMENTED
@@ -249,6 +257,7 @@ pub mod index_meta {
     #[expect(unused_imports)]
     #[rustfmt::skip]
     pub use crate::metadata::{
+        // CassIndexMeta,
         // cass_index_meta_name, UNIMPLEMENTED
         // cass_index_meta_field_by_name, UNIMPLEMENTED
         // cass_index_meta_field_by_name_n, UNIMPLEMENTED
@@ -262,6 +271,7 @@ pub mod function_meta {
     #[expect(unused_imports)]
     #[rustfmt::skip]
     pub use crate::metadata::{
+        // CassFunctionMeta,
         // cass_function_meta_argument_count, UNIMPLEMENTED
         // cass_function_meta_argument, UNIMPLEMENTED
         // cass_function_meta_argument_type_by_name, UNIMPLEMENTED
@@ -281,6 +291,7 @@ pub mod aggregate_meta {
     #[expect(unused_imports)]
     #[rustfmt::skip]
     pub use crate::metadata::{
+        // CassAggregateMeta,
         // cass_aggregate_meta_argument, UNIMPLEMENTED
         // cass_aggregate_meta_argument_count, UNIMPLEMENTED
         // cass_aggregate_meta_argument_type, UNIMPLEMENTED
@@ -299,6 +310,7 @@ pub mod aggregate_meta {
 pub mod ssl {
     #[rustfmt::skip]
     pub use crate::ssl::{
+        CassSsl,
         cass_ssl_add_trusted_cert,
         cass_ssl_add_trusted_cert_n,
         cass_ssl_free,
@@ -316,6 +328,7 @@ pub mod authenticator {
     #[expect(unused_imports)]
     #[rustfmt::skip]
     pub use crate::{
+        // CassAuthenticator,
         // cass_authenticator_address, UNIMPLEMENTED
         // cass_authenticator_hostname, UNIMPLEMENTED
         // cass_authenticator_class_name, UNIMPLEMENTED
@@ -331,6 +344,8 @@ pub mod authenticator {
 pub mod future {
     #[rustfmt::skip]
     pub use crate::future::{
+        CassFuture,
+        CassFutureCallback,
         cass_future_coordinator,
         cass_future_error_code,
         cass_future_error_message,
@@ -350,11 +365,17 @@ pub mod future {
         cass_future_custom_payload_item,  // FIXME: Should be unimplemented!
         cass_future_custom_payload_item_count,  // FIXME: Should be unimplemented!
     };
+
+    #[rustfmt::skip]
+    pub use crate::query_result::{
+        CassNode, // `cass_future_coordinator()` returns a `CassNode`.
+    };
 }
 
 pub mod statement {
     #[rustfmt::skip]
     pub use crate::statement::{
+        CassStatement,
         cass_statement_bind_bool,
         cass_statement_bind_bool_by_name,
         cass_statement_bind_bool_by_name_n,
@@ -448,6 +469,7 @@ pub mod statement {
 pub mod prepared {
     #[rustfmt::skip]
     pub use crate::prepared::{
+        CassPrepared,
         cass_prepared_bind,
         cass_prepared_free,
         cass_prepared_parameter_data_type,
@@ -460,6 +482,8 @@ pub mod prepared {
 pub mod batch {
     #[rustfmt::skip]
     pub use crate::batch::{
+        CassBatch,
+        CassBatchType,
         cass_batch_add_statement,
         cass_batch_free,
         cass_batch_new,
@@ -485,6 +509,7 @@ pub mod batch {
 pub mod data_type {
     #[rustfmt::skip]
     pub use crate::cass_types::{
+        CassDataType,
         cass_data_sub_type_count,
         cass_data_type_add_sub_type,
         cass_data_type_add_sub_type_by_name,
@@ -519,6 +544,7 @@ pub mod data_type {
 pub mod collection {
     #[rustfmt::skip]
     pub use crate::collection::{
+        CassCollection,
         cass_collection_append_bool,
         cass_collection_append_bytes,
         cass_collection_append_collection,
@@ -549,6 +575,7 @@ pub mod collection {
 pub mod tuple {
     #[rustfmt::skip]
     pub use crate::tuple::{
+        CassTuple,
         cass_tuple_data_type,
         cass_tuple_free,
         cass_tuple_new,
@@ -580,6 +607,7 @@ pub mod tuple {
 pub mod user_type {
     #[rustfmt::skip]
     pub use crate::user_type::{
+        CassUserType,
         cass_user_type_data_type,
         cass_user_type_free,
         cass_user_type_new_from_data_type,
@@ -648,6 +676,7 @@ pub mod user_type {
 pub mod result {
     #[rustfmt::skip]
     pub use crate::query_result::{
+        CassResult,
         cass_result_column_count,
         cass_result_column_data_type,
         cass_result_column_name,
@@ -663,6 +692,9 @@ pub mod result {
 pub mod error {
     #[rustfmt::skip]
     pub use crate::execution_error::{
+        CassError,
+        CassErrorResult,
+        CassErrorSource,
         cass_error_num_arg_types,
         cass_error_result_arg_type,
         cass_error_result_code,
@@ -687,6 +719,7 @@ pub mod error {
 pub mod iterator {
     #[rustfmt::skip]
     pub use crate::iterator::{
+        CassIterator,
         cass_iterator_fields_from_user_type,
         cass_iterator_free,
         cass_iterator_from_collection,
@@ -736,6 +769,7 @@ pub mod iterator {
 pub mod row {
     #[rustfmt::skip]
     pub use crate::query_result::{
+        CassRow,
         cass_row_get_column,
         cass_row_get_column_by_name,
         cass_row_get_column_by_name_n,
@@ -745,6 +779,8 @@ pub mod row {
 pub mod value {
     #[rustfmt::skip]
     pub use crate::query_result::{
+        CassValue,
+        CassValueType,
         cass_value_data_type,
         cass_value_get_bool,
         cass_value_get_bytes,
@@ -774,6 +810,7 @@ pub mod value {
 pub mod uuid_gen {
     #[rustfmt::skip]
     pub use crate::uuid::{
+        CassUuidGen,
         cass_uuid_gen_free,
         cass_uuid_gen_from_time,
         cass_uuid_gen_new,
@@ -799,6 +836,7 @@ pub mod uuid {
 pub mod timestamp_gen {
     #[rustfmt::skip]
     pub use crate::timestamp_generator::{
+        CassTimestampGen,
         cass_timestamp_gen_free,
         cass_timestamp_gen_monotonic_new,
         cass_timestamp_gen_monotonic_new_with_settings,
@@ -809,6 +847,7 @@ pub mod timestamp_gen {
 pub mod retry_policy {
     #[rustfmt::skip]
     pub use crate::retry_policy::{
+        CassRetryPolicy,
         cass_retry_policy_default_new,
         cass_retry_policy_downgrading_consistency_new,
         cass_retry_policy_fallthrough_new,
@@ -826,6 +865,7 @@ pub mod custom_payload {
     // cass_custom_payload_set_n, UNIMPLEMENTED
     #[rustfmt::skip]
     pub use crate::cluster::{
+        CassCustomPayload, // FIXME: Should be unimplemented!
         cass_custom_payload_new, // FIXME: Should be unimplemented!
     };
 }
@@ -833,6 +873,7 @@ pub mod custom_payload {
 pub mod consistency {
     #[rustfmt::skip]
     pub use crate::misc::{
+        CassConsistency,
         cass_consistency_string
     };
 }
@@ -840,6 +881,7 @@ pub mod consistency {
 pub mod write_type {
     #[rustfmt::skip]
     pub use crate::misc::{
+        CassWriteType,
         cass_write_type_string
     };
 }
@@ -847,6 +889,7 @@ pub mod write_type {
 pub mod log {
     #[rustfmt::skip]
     pub use crate::logging::{
+        CassLogCallback,
         cass_log_cleanup,
         cass_log_get_callback_and_data,
         cass_log_level_string,
@@ -859,6 +902,7 @@ pub mod log {
 pub mod inet {
     #[rustfmt::skip]
     pub use crate::inet::{
+        CassInet,
         cass_inet_from_string,
         cass_inet_from_string_n,
         cass_inet_init_v4,

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -76,6 +76,9 @@ macro_rules! make_c_str {
 pub(crate) use make_c_str;
 
 mod sealed {
+    // This is a sealed trait - its whole purpose is to be unnameable.
+    // This means we need to disable the check.
+    #[expect(unnameable_types)]
     pub trait Sealed {}
 }
 
@@ -330,8 +333,19 @@ impl<T: Sized> CassPtr<'_, T, (Exclusive, CMut)> {
 }
 
 mod origin_sealed {
+    // This is a sealed trait - its whole purpose is to be unnameable.
+    // This means we need to disable the check.
+    #[expect(unnameable_types)]
     pub trait FromBoxSealed {}
+
+    // This is a sealed trait - its whole purpose is to be unnameable.
+    // This means we need to disable the check.
+    #[expect(unnameable_types)]
     pub trait FromArcSealed {}
+
+    // This is a sealed trait - its whole purpose is to be unnameable.
+    // This means we need to disable the check.
+    #[expect(unnameable_types)]
     pub trait FromRefSealed {}
 }
 

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -414,7 +414,7 @@ pub trait BoxFFI: Sized + origin_sealed::FromBoxSealed {
 /// The data should be allocated via [`Arc::new`], and then returned to the user as a pointer.
 /// The user is responsible for freeing the memory associated
 /// with the pointer using corresponding driver's API function.
-pub(crate) trait ArcFFI: Sized + origin_sealed::FromArcSealed {
+pub trait ArcFFI: Sized + origin_sealed::FromArcSealed {
     /// Creates a pointer from a valid reference to Arc-allocated data.
     /// Holder of the pointer borrows the pointee.
     #[allow(clippy::needless_lifetimes)]

--- a/scylla-rust-wrapper/src/batch.rs
+++ b/scylla-rust-wrapper/src/batch.rs
@@ -3,7 +3,8 @@ use crate::argconv::{
     FFI, FromBox,
 };
 use crate::cass_error::CassError;
-use crate::cass_types::{CassBatchType, CassConsistency, make_batch_type};
+pub use crate::cass_types::CassBatchType;
+use crate::cass_types::{CassConsistency, make_batch_type};
 use crate::config_value::MaybeUnsetConfig;
 use crate::exec_profile::PerStatementExecProfile;
 use crate::retry_policy::CassRetryPolicy;

--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -1,7 +1,7 @@
 use scylla::errors::*;
 
 // Re-export error types.
-pub(crate) use crate::cass_error_types::{CassError, CassErrorSource};
+pub use crate::cass_error_types::{CassError, CassErrorSource};
 use crate::execution_error::CassErrorResult;
 use crate::statement::UnknownNamedParameterError;
 

--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -8,9 +8,9 @@ use std::cell::UnsafeCell;
 use std::os::raw::c_char;
 use std::sync::Arc;
 
-pub(crate) use crate::cass_batch_types::CassBatchType;
-pub(crate) use crate::cass_consistency_types::CassConsistency;
-pub(crate) use crate::cass_data_types::CassValueType;
+pub use crate::cass_batch_types::CassBatchType;
+pub use crate::cass_consistency_types::CassConsistency;
+pub use crate::cass_data_types::CassValueType;
 
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]

--- a/scylla-rust-wrapper/src/collection.rs
+++ b/scylla-rust-wrapper/src/collection.rs
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn cass_collection_new(
 }
 
 #[unsafe(no_mangle)]
-unsafe extern "C" fn cass_collection_new_from_data_type(
+pub unsafe extern "C" fn cass_collection_new_from_data_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
     item_count: size_t,
 ) -> CassOwnedExclusivePtr<CassCollection, CMut> {
@@ -185,7 +185,7 @@ unsafe extern "C" fn cass_collection_new_from_data_type(
 }
 
 #[unsafe(no_mangle)]
-unsafe extern "C" fn cass_collection_data_type(
+pub unsafe extern "C" fn cass_collection_data_type(
     collection: CassBorrowedSharedPtr<CassCollection, CConst>,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
     let Some(collection_ref) = BoxFFI::as_ref(collection) else {

--- a/scylla-rust-wrapper/src/execution_error.rs
+++ b/scylla-rust-wrapper/src/execution_error.rs
@@ -1,5 +1,6 @@
 use crate::argconv::*;
 use crate::cass_error::*;
+pub use crate::cass_error::{CassError, CassErrorSource};
 use crate::cass_error_types::CassWriteType;
 use crate::cass_types::CassConsistency;
 use crate::types::*;

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -17,7 +17,7 @@ use tokio::task::JoinHandle;
 use tokio::time::Duration;
 
 #[derive(Debug)]
-pub enum CassResultValue {
+pub(crate) enum CassResultValue {
     Empty,
     QueryResult(Arc<CassResult>),
     QueryError(Arc<CassErrorResult>),
@@ -26,7 +26,7 @@ pub enum CassResultValue {
 
 type CassFutureError = (CassError, String);
 
-pub type CassFutureResult = Result<CassResultValue, CassFutureError>;
+pub(crate) type CassFutureResult = Result<CassResultValue, CassFutureError>;
 
 pub type CassFutureCallback = Option<
     unsafe extern "C" fn(future: CassBorrowedSharedPtr<CassFuture, CMut>, data: *mut c_void),

--- a/scylla-rust-wrapper/src/inet.rs
+++ b/scylla-rust-wrapper/src/inet.rs
@@ -14,7 +14,7 @@ pub(crate) use crate::cass_inet_types::CassInet;
 #[repr(u8)] // address_length field in CassInet is cass_uint8_t
 #[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone)]
-pub enum CassInetLength {
+pub(crate) enum CassInetLength {
     CASS_INET_V4 = 4,
     CASS_INET_V6 = 16,
 }

--- a/scylla-rust-wrapper/src/inet.rs
+++ b/scylla-rust-wrapper/src/inet.rs
@@ -9,7 +9,7 @@ use std::os::raw::c_char;
 use std::slice::from_raw_parts;
 use std::str::FromStr;
 
-pub(crate) use crate::cass_inet_types::CassInet;
+pub use crate::cass_inet_types::CassInet;
 
 #[repr(u8)] // address_length field in CassInet is cass_uint8_t
 #[allow(non_camel_case_types)]

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -54,7 +54,7 @@ macro_rules! include_bindgen_generated {
 }
 
 /// All numeric types are defined here.
-pub(crate) mod types {
+pub mod types {
     #![allow(non_camel_case_types)]
     // for `cass_false` and `cass_true` globals.
     #![allow(non_upper_case_globals)]

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -59,6 +59,7 @@ pub mod types {
     // for `cass_false` and `cass_true` globals.
     #![allow(non_upper_case_globals)]
     #![allow(unused)]
+    #![allow(unreachable_pub, unnameable_types)]
 
     // Definition for size_t (and possibly other types in the future)
     include_bindgen_generated!("basic_types.rs");
@@ -67,36 +68,48 @@ pub mod types {
 /// CassError, CassErrorSource, CassWriteType
 pub(crate) mod cass_error_types {
     #![allow(unused)]
+    #![allow(unreachable_pub, unnameable_types)]
+
     include_bindgen_generated!("cppdriver_error_types.rs");
 }
 
 /// CassValueType
 pub(crate) mod cass_data_types {
     #![allow(unused)]
+    #![allow(unreachable_pub, unnameable_types)]
+
     include_bindgen_generated!("cppdriver_data_types.rs");
 }
 
 /// CassConsistency
 pub(crate) mod cass_consistency_types {
     #![allow(unused)]
+    #![allow(unreachable_pub, unnameable_types)]
+
     include_bindgen_generated!("cppdriver_consistency_types.rs");
 }
 
 /// CassBatchType
 pub(crate) mod cass_batch_types {
     #![allow(unused)]
+    #![allow(unreachable_pub, unnameable_types)]
+
     include_bindgen_generated!("cppdriver_batch_types.rs");
 }
 
 /// CassCompressionType
 pub(crate) mod cass_compression_types {
     #![allow(unused)]
+    #![allow(unreachable_pub, unnameable_types)]
+
     include_bindgen_generated!("cppdriver_compression_types.rs");
 }
 
 /// CassCollectionType
 pub(crate) mod cass_collection_types {
     #![allow(unused)]
+    #![allow(unreachable_pub, unnameable_types)]
+
     include_bindgen_generated!("cppdriver_collection_types.rs");
 }
 
@@ -104,6 +117,7 @@ pub(crate) mod cass_collection_types {
 pub(crate) mod cass_inet_types {
     #![allow(unused)]
     #![allow(non_camel_case_types, non_snake_case)]
+    #![allow(unreachable_pub, unnameable_types)]
 
     include_bindgen_generated!("cppdriver_inet_types.rs");
 }
@@ -112,6 +126,7 @@ pub(crate) mod cass_inet_types {
 pub(crate) mod cass_log_types {
     #![allow(unused)]
     #![allow(non_camel_case_types, non_snake_case)]
+    #![allow(unreachable_pub, unnameable_types)]
 
     include_bindgen_generated!("cppdriver_log_types.rs");
 }
@@ -119,6 +134,7 @@ pub(crate) mod cass_log_types {
 /// CassColumnType
 pub(crate) mod cass_column_types {
     #![allow(unused)]
+    #![allow(unreachable_pub, unnameable_types)]
 
     include_bindgen_generated!("cppdriver_column_type.rs");
 }
@@ -127,6 +143,7 @@ pub(crate) mod cass_column_types {
 pub(crate) mod cass_uuid_types {
     #![allow(unused)]
     #![allow(non_camel_case_types, non_snake_case)]
+    #![allow(unreachable_pub, unnameable_types)]
 
     include_bindgen_generated!("cppdriver_uuid_types.rs");
 }
@@ -134,6 +151,7 @@ pub(crate) mod cass_uuid_types {
 /// CassIteratorType
 pub(crate) mod cass_iterator_types {
     #![allow(unused)]
+    #![allow(unreachable_pub, unnameable_types)]
 
     include_bindgen_generated!("cppdriver_iterator_types.rs");
 }
@@ -142,6 +160,7 @@ pub(crate) mod cass_iterator_types {
 pub(crate) mod cass_metrics_types {
     #![allow(unused)]
     #![allow(non_camel_case_types, non_snake_case)]
+    #![allow(unreachable_pub, unnameable_types)]
 
     include_bindgen_generated!("cppdriver_metrics_types.rs");
 }

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -8,6 +8,7 @@ use tokio::runtime::Runtime;
 
 #[macro_use]
 mod binding;
+pub mod api;
 // pub, because doctests defined in `argconv` module need to access it.
 pub mod argconv;
 pub(crate) mod batch;

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -73,7 +73,7 @@ impl TryFrom<CassLogLevel> for Level {
 
 pub(crate) const CASS_LOG_MAX_MESSAGE_SIZE: usize = 1024;
 
-pub unsafe extern "C" fn stderr_log_callback(
+pub(crate) unsafe extern "C" fn stderr_log_callback(
     message: CassBorrowedSharedPtr<CassLogMessage, CConst>,
     _data: *mut c_void,
 ) {

--- a/scylla-rust-wrapper/src/misc.rs
+++ b/scylla-rust-wrapper/src/misc.rs
@@ -1,6 +1,6 @@
 use std::ffi::{CStr, c_char};
 
-use crate::{cass_error_types::CassWriteType, cass_types::CassConsistency};
+pub use crate::{cass_error_types::CassWriteType, cass_types::CassConsistency};
 
 impl CassConsistency {
     pub(crate) fn as_cstr(&self) -> &'static CStr {

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -1,8 +1,9 @@
 use crate::argconv::*;
 use crate::cass_error::{CassError, ToCassError};
+pub use crate::cass_types::CassValueType;
 use crate::cass_types::{
-    CassColumnSpec, CassDataType, CassDataTypeInner, CassValueType, MapDataType,
-    cass_data_type_type, get_column_type,
+    CassColumnSpec, CassDataType, CassDataTypeInner, MapDataType, cass_data_type_type,
+    get_column_type,
 };
 use crate::execution_error::CassErrorResult;
 use crate::inet::CassInet;

--- a/scylla-rust-wrapper/src/retry_policy.rs
+++ b/scylla-rust-wrapper/src/retry_policy.rs
@@ -6,8 +6,13 @@ use std::sync::Arc;
 
 use crate::argconv::{ArcFFI, CMut, CassBorrowedSharedPtr, CassOwnedSharedPtr, FFI, FromArc};
 
+// Technically, we should not allow this struct to be public,
+// but this would require a lot of changes in the codebase:
+// CassRetryPolicy would need to be a newtype wrapper around
+// an additional inner enum.
+#[expect(unnameable_types)]
 #[derive(Debug)]
-pub(crate) struct CassLoggingRetryPolicy {
+pub struct CassLoggingRetryPolicy {
     child_policy: Arc<CassRetryPolicy>,
 }
 

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 
-pub(crate) struct CassSessionInner {
+pub struct CassSessionInner {
     session: Session,
     exec_profile_map: HashMap<ExecProfileName, ExecutionProfileHandle>,
     client_id: uuid::Uuid,

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -32,6 +32,11 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 
+// Technically, we should not allow this struct to be public,
+// but this would require a lot of changes in the codebase:
+// CassSession would need to be a newtype wrapper around this struct
+// instead of a type alias.
+#[expect(unnameable_types)]
 pub struct CassSessionInner {
     session: Session,
     exec_profile_map: HashMap<ExecProfileName, ExecutionProfileHandle>,

--- a/scylla-rust-wrapper/src/statement.rs
+++ b/scylla-rust-wrapper/src/statement.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Clone)]
-pub enum BoundStatement {
+pub(crate) enum BoundStatement {
     Simple(BoundSimpleStatement),
     Prepared(BoundPreparedStatement),
 }

--- a/scylla-rust-wrapper/src/tuple.rs
+++ b/scylla-rust-wrapper/src/tuple.rs
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn cass_tuple_new(
 }
 
 #[unsafe(no_mangle)]
-unsafe extern "C" fn cass_tuple_new_from_data_type(
+pub unsafe extern "C" fn cass_tuple_new_from_data_type(
     data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassOwnedExclusivePtr<CassTuple, CMut> {
     let Some(data_type) = ArcFFI::cloned_from_ptr(data_type) else {
@@ -94,12 +94,12 @@ unsafe extern "C" fn cass_tuple_new_from_data_type(
 }
 
 #[unsafe(no_mangle)]
-unsafe extern "C" fn cass_tuple_free(tuple: CassOwnedExclusivePtr<CassTuple, CMut>) {
+pub unsafe extern "C" fn cass_tuple_free(tuple: CassOwnedExclusivePtr<CassTuple, CMut>) {
     BoxFFI::free(tuple);
 }
 
 #[unsafe(no_mangle)]
-unsafe extern "C" fn cass_tuple_data_type(
+pub unsafe extern "C" fn cass_tuple_data_type(
     tuple: CassBorrowedSharedPtr<CassTuple, CConst>,
 ) -> CassBorrowedSharedPtr<CassDataType, CConst> {
     let Some(tuple) = BoxFFI::as_ref(tuple) else {


### PR DESCRIPTION
Ref: #319

Stacked on: #330
Start review from 3368e28 - `collection,tuple: expose missed functions`.

_Generated with GPT-4o and manually (heavily) redacted_

## Problem Overview

The Scylla Rust wrapper aims to be a drop-in replacement for the CPP Driver, but several areas required improvement to ensure better alignment with the CPP Driver's public API and usability in Rust. These include:
- missing public API functions
  - some functions are unimplemented,
  - some implemented functions are just stubs and they do nothing,
  - some correctly implemented functions are not `pub`.
- inconsistent module organization,
- accessibility issues for integration testing.

Additionally, some types and functions were erroneously exposed or restricted.

## Solution

### Big Picture

A new module - `api` - is introduced to re-export public Rust (`extern "C"`) API of the driver.
Thanks to that, we can enable new lints: `unnameable_types` and `unreachable_pub`, which are a good measure to safeguard against regressions in spirit of #319. On the way, a number of misconfiguration cases were found and fixed. 

### Per-commit

The per-commit changes are as follows:

1. **Privatize remaining types**:
   - Cleans up the codebase by privatizing types that were mistakenly exposed, ensuring a more consistent and maintainable API.

1. **Expose missed functions**:
   - Functions such as `cass_collection_data_type`, `cass_tuple_data_type`, and others were erroneously module-private, preventing their use outside their modules. This commit ensures these functions are publicly accessible, aligning with the CPP Driver's API.

1. **Hide the `CassIterator` enum from the public API**:    
   - The variants of the `CassIterator` should not be exposed to the public API, as they are an implementation detail of the Scylla Rust wrapper. A wrapper type is added to achieve this.

1. **Pubify `ArcFFI` trait**:
   - It's going to be useful for integration tests.

1. **Add `expect(unnameable_types)` in sealed traits**:
   - Like the Rust driver did. This particular use case depends on type unnameability.

1. **Group all public C API in one module**:
    - Introduces a new `api` module that re-exports all public C API functions from `cassandra.h`, grouped by their order in the header file. This improves visibility into implemented and missing functions, facilitates integration testing, and ensures the Rust wrapper is a drop-in replacement for the CPP Driver.
   - Incorrectly implemented functions are appropriately commented.
   - Unimplemented functions are commented out.

1. **Include public types in the API**:
   - Re-exports public types alongside public functions in the `api` module. This change ensures that public API functions can be used seamlessly in Rust, particularly for integration testing and other use cases.

1. **Enable `unnameable_types` and `unreachable_pub` lints**:
   - This has successfully caught some issues in the codebase.

## Discussion Needed

Is the format I chose for `api` module clear enough? Does it make unimplemented/incorrectly implemented functions discoverable enough?


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
