### PR TITLE
`cass_session_free` waits for session close

### DIFF
--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -314,7 +314,7 @@ impl CassFuture {
         CassError::CASS_OK
     }
 
-    fn into_raw(self: Arc<Self>) -> CassOwnedSharedPtr<Self, CMut> {
+    pub(crate) fn into_raw(self: Arc<Self>) -> CassOwnedSharedPtr<Self, CMut> {
         ArcFFI::into_ptr(self)
     }
 

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -105,7 +105,7 @@ impl CassSessionInner {
     }
 
     async fn connect_fut(
-        session_opt: Arc<RwLock<Option<CassSessionInner>>>,
+        session_opt: Arc<RwLock<Option<Self>>>,
         session_builder_fut: impl Future<Output = SessionBuilder>,
         exec_profile_builder_map: HashMap<ExecProfileName, CassExecProfile>,
         host_filter: Arc<dyn HostFilter>,
@@ -162,6 +162,26 @@ impl CassSessionInner {
             client_id,
         });
         Ok(CassResultValue::Empty)
+    }
+
+    fn close_fut(session_opt: Arc<RwLock<Option<Self>>>) -> Arc<CassFuture> {
+        CassFuture::new_from_future(
+            async move {
+                let mut session_guard = session_opt.write().await;
+                if session_guard.is_none() {
+                    return Err((
+                        CassError::CASS_ERROR_LIB_UNABLE_TO_CLOSE,
+                        "Already closing or closed".msg(),
+                    ));
+                }
+
+                *session_guard = None;
+
+                Ok(CassResultValue::Empty)
+            },
+            #[cfg(cpp_integration_testing)]
+            None,
+        )
     }
 }
 
@@ -587,23 +607,7 @@ pub unsafe extern "C" fn cass_session_close(
         return ArcFFI::null();
     };
 
-    CassFuture::make_raw(
-        async move {
-            let mut session_guard = session_opt.write().await;
-            if session_guard.is_none() {
-                return Err((
-                    CassError::CASS_ERROR_LIB_UNABLE_TO_CLOSE,
-                    "Already closing or closed".msg(),
-                ));
-            }
-
-            *session_guard = None;
-
-            Ok(CassResultValue::Empty)
-        },
-        #[cfg(cpp_integration_testing)]
-        None,
-    )
+    CassSessionInner::close_fut(session_opt).into_raw()
 }
 
 #[unsafe(no_mangle)]

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -352,13 +352,12 @@ pub unsafe extern "C" fn cass_session_execute(
 
     let future = async move {
         let session_guard = session_opt.read().await;
-        if session_guard.is_none() {
+        let Some(cass_session_inner) = session_guard.as_ref() else {
             return Err((
                 CassError::CASS_ERROR_LIB_NO_HOSTS_AVAILABLE,
                 "Session is not connected".msg(),
             ));
-        }
-        let cass_session_inner = session_guard.as_ref().unwrap();
+        };
         let session = &cass_session_inner.session;
 
         let handle = cass_session_inner


### PR DESCRIPTION
This is an extracted prefix of #328 that I have no doubts about. It makes `cass_session_free` block until the session is closed, i.e., all running requests are completed. This is what `cassandra.h`, as well as the `AsyncClose` test, specify.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
