### PR TITLE
Bump Rust driver dependency to 1.3.0

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy 0.7.35",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,11 +255,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -305,6 +300,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -450,16 +451,17 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "histogram"
@@ -874,7 +876,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -945,7 +947,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1112,8 +1114,8 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "1.2.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.2.0#bc6b24da1b17aa4d33df6a0f0283f08937ff1a19"
+version = "1.3.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.3.0#c9ca852b7dd476886f033d3797790d2d0206987f"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1121,7 +1123,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "futures",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "histogram",
  "itertools",
  "openssl",
@@ -1162,13 +1164,13 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "yoke 0.8.0",
+ "yoke",
 ]
 
 [[package]]
 name = "scylla-cql"
-version = "1.2.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.2.0#bc6b24da1b17aa4d33df6a0f0283f08937ff1a19"
+version = "1.3.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.3.0#c9ca852b7dd476886f033d3797790d2d0206987f"
 dependencies = [
  "byteorder",
  "bytes",
@@ -1181,13 +1183,13 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "uuid",
- "yoke 0.7.5",
+ "yoke",
 ]
 
 [[package]]
 name = "scylla-macros"
-version = "1.2.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.2.0#bc6b24da1b17aa4d33df6a0f0283f08937ff1a19"
+version = "1.3.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.3.0#c9ca852b7dd476886f033d3797790d2d0206987f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1198,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "scylla-proxy"
 version = "0.0.4"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.2.0#bc6b24da1b17aa4d33df6a0f0283f08937ff1a19"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.3.0#c9ca852b7dd476886f033d3797790d2d0206987f"
 dependencies = [
  "bigdecimal",
  "byteorder",
@@ -1559,12 +1561,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,38 +1846,14 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive 0.7.5",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
- "yoke-derive 0.8.0",
+ "yoke-derive",
  "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "synstructure",
 ]
 
 [[package]]
@@ -1898,31 +1870,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.24",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["database"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.2.0", features = [
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.3.0", features = [
     "openssl-010",
     "metrics",
 ] }
@@ -34,7 +34,7 @@ bindgen = "0.65"
 chrono = "0.4.20"
 
 [dev-dependencies]
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.2.0" }
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.3.0" }
 bytes = "1.10.0"
 
 assert_matches = "1.5.0"


### PR DESCRIPTION
This will let us use the newly introduced APIs: https://github.com/scylladb/scylla-rust-driver/pull/1391 and https://github.com/scylladb/scylla-rust-driver/pull/1385, allowing bug fixes that require them.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
