### PR TITLE
Fix lints in integration testing API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ _update-rust-tooling:
 
 check-cargo: install-cargo-if-missing _update-rust-tooling
 	@echo "Running \"cargo check\" in ./scylla-rust-wrapper"
-	@cd ${CURRENT_DIR}/scylla-rust-wrapper; cargo check
+	@cd ${CURRENT_DIR}/scylla-rust-wrapper; cargo check --all-targets
 
 fix-cargo:
 	@echo "Running \"cargo fix --verbose --all\" in ./scylla-rust-wrapper"

--- a/scylla-rust-wrapper/build.rs
+++ b/scylla-rust-wrapper/build.rs
@@ -81,7 +81,7 @@ fn prepare_cppdriver_data(outfile: &str, allowed_types: &[&str], out_path: &Path
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed={}", RELATIVE_PATH_TO_CASSANDRA_H);
+    println!("cargo:rerun-if-changed={RELATIVE_PATH_TO_CASSANDRA_H}");
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     prepare_full_bindings(&out_path);
     prepare_basic_types(&out_path);

--- a/scylla-rust-wrapper/src/api.rs
+++ b/scylla-rust-wrapper/src/api.rs
@@ -923,3 +923,21 @@ pub mod date_time {
 pub mod alloc {
     // cass_alloc_set_functions, UNIMPLEMENTED
 }
+
+#[cfg(cpp_integration_testing)]
+pub mod integration_testing {
+    #[rustfmt::skip]
+    pub use crate::integration_testing::{
+        IgnoringRetryPolicy,
+        testing_batch_set_sleeping_history_listener,
+        testing_cluster_get_connect_timeout,
+        testing_cluster_get_contact_points,
+        testing_cluster_get_port,
+        testing_free_cstring,
+        testing_future_get_attempted_hosts,
+        testing_future_get_host,
+        testing_retry_policy_ignoring_new,
+        testing_statement_set_recording_history_listener,
+        testing_statement_set_sleeping_history_listener,
+    };
+}

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -332,7 +332,7 @@ fn test_future_get_attempted_hosts() {
 ///
 /// Useful for testing purposes.
 #[derive(Debug)]
-pub(crate) struct IgnoringRetryPolicy;
+pub struct IgnoringRetryPolicy;
 
 #[derive(Debug)]
 struct IgnoringRetrySession;

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -272,7 +272,7 @@ pub unsafe extern "C" fn testing_future_get_attempted_hosts(
         // Convert the SocketAddr to a string.
         // Delimit address strings with '\n' to enable easy parsing in C.
 
-        write!(&mut acc, "{}\n", host.ip()).unwrap();
+        writeln!(&mut acc, "{}", host.ip()).unwrap();
         acc
     });
 

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -100,9 +100,9 @@ pub(crate) struct PrintlnVisitor {
 impl tracing::field::Visit for PrintlnVisitor {
     fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
         if self.log_message.is_empty() {
-            write!(self.log_message, "{}: {:?}", field, value).unwrap();
+            write!(self.log_message, "{field}: {value:?}").unwrap();
         } else {
-            write!(self.log_message, ", {}: {:?}", field, value).unwrap();
+            write!(self.log_message, ", {field}: {value:?}").unwrap();
         }
     }
 }

--- a/scylla-rust-wrapper/src/prepared.rs
+++ b/scylla-rust-wrapper/src/prepared.rs
@@ -65,8 +65,7 @@ impl CassPrepared {
             // col specs, and we found an index with a corresponding name, we should
             // find a CassDataType at given index.
             None => panic!(
-                "Cannot find a data type of parameter with given name: {}. This is a driver bug!",
-                name
+                "Cannot find a data type of parameter with given name: {name}. This is a driver bug!",
             ),
         }
     }


### PR DESCRIPTION
## Problem description

When I introduced the `api` module and turned on optional lints about the (non-)`pub` types, I forgot to expose `pub` functions from the `integration_testing` module. This was not spotted by the CI, because the checks were run without `--cfg cpp_integration_testing` in `RUSTFLAGS`.

## What's done

1. clippy is appeased after the recent update of rust toolchain.
2. the `integration_testing` module is made pass the optional lints.
3. `cargo check` is now run with the `--all-targets` flag, so that it checks tests, too (not only the lib crate).
4. `cargo clippy` is now run with the `cpp_integration_testing` option in `RUSTFLAGS` to make the integration testing code covered by the linter.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
