### PR TITLE
Fix statement/batch request timeouts

### DIFF
--- a/scylla-rust-wrapper/src/config_value.rs
+++ b/scylla-rust-wrapper/src/config_value.rs
@@ -1,6 +1,8 @@
+use std::{convert::Infallible, time::Duration};
+
 use scylla::statement::{Consistency, SerialConsistency};
 
-use crate::cass_types::CassConsistency;
+use crate::{cass_types::CassConsistency, types::cass_uint64_t};
 
 /// Represents a configuration value that may or may not be set.
 /// If a configuration value is unset, it means that the default value
@@ -41,6 +43,14 @@ impl<T: MaybeUnsetConfigValue> MaybeUnsetConfig<T> {
     /// is invalid.
     pub(crate) fn from_c_value(cvalue: T::CValue) -> Result<Self, T::Error> {
         <T as MaybeUnsetConfigValue>::from_c_value(cvalue)
+    }
+}
+
+impl<T: MaybeUnsetConfigValue<Error = Infallible>> MaybeUnsetConfig<T> {
+    /// Converts a maybe unset C value to a Rust value. Available for C values that are guaranteed
+    /// to be valid and thus never return an error.
+    pub(crate) fn from_c_value_infallible(cvalue: T::CValue) -> Self {
+        Self::from_c_value(cvalue).unwrap_or_else(|never| match never {})
     }
 }
 
@@ -96,5 +106,23 @@ impl MaybeUnsetConfigValue for Option<SerialConsistency> {
             CassConsistency::CASS_CONSISTENCY_SERIAL => Ok(Some(SerialConsistency::Serial)),
             _ => Err(()),
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RequestTimeout(pub(crate) Option<Duration>);
+
+impl MaybeUnsetConfigValue for RequestTimeout {
+    type CValue = cass_uint64_t;
+    type Error = Infallible;
+
+    fn is_unset(cvalue: &Self::CValue) -> bool {
+        *cvalue == cass_uint64_t::MAX
+    }
+
+    fn from_set_c_value(cvalue: Self::CValue) -> Result<Self, Self::Error> {
+        Ok(RequestTimeout(
+            (cvalue != 0).then(|| Duration::from_millis(cvalue)),
+        ))
     }
 }

--- a/scylla-rust-wrapper/src/config_value.rs
+++ b/scylla-rust-wrapper/src/config_value.rs
@@ -112,6 +112,10 @@ impl MaybeUnsetConfigValue for Option<SerialConsistency> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct RequestTimeout(pub(crate) Option<Duration>);
 
+impl RequestTimeout {
+    pub(crate) const INFINITE: Duration = Duration::MAX;
+}
+
 impl MaybeUnsetConfigValue for RequestTimeout {
     type CValue = cass_uint64_t;
     type Error = Infallible;

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -13,7 +13,7 @@ use crate::metadata::{CassKeyspaceMeta, CassMaterializedViewMeta, CassSchemaMeta
 use crate::prepared::CassPrepared;
 use crate::query_result::{CassResult, CassResultKind, CassResultMetadata};
 use crate::statement::{BoundStatement, CassStatement, SimpleQueryRowSerializer};
-use crate::types::{cass_uint64_t, size_t};
+use crate::types::size_t;
 use crate::uuid::CassUuid;
 use scylla::client::execution_profile::ExecutionProfileHandle;
 use scylla::client::session::Session;
@@ -30,7 +30,6 @@ use std::future::Future;
 use std::ops::Deref;
 use std::os::raw::c_char;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::{OwnedRwLockWriteGuard, RwLock};
 
 pub(crate) struct CassConnectedSession {
@@ -271,7 +270,6 @@ pub unsafe extern "C" fn cass_session_execute_batch(
     };
 
     let mut state = batch_from_raw.state.clone();
-    let request_timeout_ms = batch_from_raw.batch_request_timeout_ms;
 
     // DO NOT refer to `batch_from_raw` inside the async block, as I've done just to face a segfault.
     let batch_exec_profile = batch_from_raw.exec_profile.clone();
@@ -310,30 +308,11 @@ pub unsafe extern "C" fn cass_session_execute_batch(
         }
     };
 
-    match request_timeout_ms {
-        Some(timeout_ms) => CassFuture::make_raw(
-            async move { request_with_timeout(timeout_ms, future).await },
-            #[cfg(cpp_integration_testing)]
-            None,
-        ),
-        None => CassFuture::make_raw(
-            future,
-            #[cfg(cpp_integration_testing)]
-            None,
-        ),
-    }
-}
-
-async fn request_with_timeout(
-    request_timeout_ms: cass_uint64_t,
-    future: impl Future<Output = Result<CassResultValue, (CassError, String)>>,
-) -> Result<CassResultValue, (CassError, String)> {
-    match tokio::time::timeout(Duration::from_millis(request_timeout_ms), future).await {
-        Ok(result) => result,
-        Err(_timeout_err) => Ok(CassResultValue::QueryError(Arc::new(
-            ExecutionError::RequestTimeout(Duration::from_millis(request_timeout_ms)).into(),
-        ))),
-    }
+    CassFuture::make_raw(
+        future,
+        #[cfg(cpp_integration_testing)]
+        None,
+    )
 }
 
 #[unsafe(no_mangle)]

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -354,8 +354,6 @@ pub unsafe extern "C" fn cass_session_execute(
 
     let paging_state = statement_opt.paging_state.clone();
     let paging_enabled = statement_opt.paging_enabled;
-    let request_timeout_ms = statement_opt.request_timeout_ms;
-
     let mut statement = statement_opt.statement.clone();
 
     #[cfg(cpp_integration_testing)]
@@ -491,18 +489,11 @@ pub unsafe extern "C" fn cass_session_execute(
         }
     };
 
-    match request_timeout_ms {
-        Some(timeout_ms) => CassFuture::make_raw(
-            async move { request_with_timeout(timeout_ms, future).await },
-            #[cfg(cpp_integration_testing)]
-            recording_listener,
-        ),
-        None => CassFuture::make_raw(
-            future,
-            #[cfg(cpp_integration_testing)]
-            recording_listener,
-        ),
-    }
+    CassFuture::make_raw(
+        future,
+        #[cfg(cpp_integration_testing)]
+        recording_listener,
+    )
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
## Problem statement

The implementation of request timeouts set on statement/batch is hand-crafted and independent from the Rust Driver-provided request timeouts set on cluster/execution profile. This is obviously incorrect, as a longer request timeout on statement/batch would not override a shorter timeout set on cluster/execution profile.

## Solution

This PR leverages the `MaybeUnsetConfig` framework to work with request timeouts, and fixes statements and batches to use the Rust Driver's built-in request timeout capabilities.
Care is taken to support the semantics correctly:
- `timeout = 0` means that there should be no timeout. As the Rust driver does not allow for such setting on the statement/batch level, it is emulated using an extremely long timeout.
- `timeout = u64::MAX` means that the timeout should be unset (and the execution profile's/cluster's setting should be used instead). This corresponds to passing `None` to the Rust Driver's `{Statement,Batch}::set_request_timeout`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
