### PR TITLE
Introduce an IT for consistency

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -523,6 +523,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1125,7 +1134,7 @@ dependencies = [
  "futures",
  "hashbrown 0.15.2",
  "histogram",
- "itertools",
+ "itertools 0.14.0",
  "openssl",
  "rand 0.9.0",
  "rand_pcg",
@@ -1148,6 +1157,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "itertools 0.10.5",
  "libc",
  "machine-uid",
  "ntest",
@@ -1158,6 +1168,7 @@ dependencies = [
  "rand 0.8.5",
  "rusty-fork",
  "scylla",
+ "scylla-cql",
  "scylla-proxy",
  "thiserror 1.0.69",
  "tokio",
@@ -1175,7 +1186,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "itertools",
+ "itertools 0.14.0",
  "lz4_flex",
  "scylla-macros",
  "snap",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -35,11 +35,13 @@ chrono = "0.4.20"
 
 [dev-dependencies]
 scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.3.0" }
+scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.3.0" }
 bytes = "1.10.0"
-
+itertools = "0.10.3"
 assert_matches = "1.5.0"
 ntest = "0.9.3"
 rusty-fork = "0.3.0"
+
 [lib]
 name = "scylla_cpp_driver"
 crate-type = ["cdylib", "staticlib", "lib"]

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -6,11 +6,11 @@ use std::os::raw::c_char;
 use std::ptr::NonNull;
 use std::sync::{Arc, Weak};
 
-pub(crate) unsafe fn ptr_to_cstr(ptr: *const c_char) -> Option<&'static str> {
+pub unsafe fn ptr_to_cstr(ptr: *const c_char) -> Option<&'static str> {
     unsafe { CStr::from_ptr(ptr) }.to_str().ok()
 }
 
-pub(crate) unsafe fn ptr_to_cstr_n(ptr: *const c_char, size: size_t) -> Option<&'static str> {
+pub unsafe fn ptr_to_cstr_n(ptr: *const c_char, size: size_t) -> Option<&'static str> {
     if ptr.is_null() {
         return None;
     }
@@ -228,9 +228,8 @@ pub type CassBorrowedExclusivePtr<'a, T, CM> = CassPtr<'a, T, (Exclusive, CM)>;
 
 /// Utility method for tests. Useful when some method returns `T*`,
 /// and then another method accepts `const T*`.
-#[cfg(test)]
 impl<'a, T: Sized, P: Properties> CassPtr<'a, T, P> {
-    pub(crate) fn into_c_const(self) -> CassPtr<'a, T, (P::Onwership, CConst)> {
+    pub fn into_c_const(self) -> CassPtr<'a, T, (P::Onwership, CConst)> {
         CassPtr {
             ptr: self.ptr,
             _phantom: PhantomData,
@@ -309,7 +308,7 @@ impl<T: Sized, P: Properties> CassPtr<'_, T, P> {
     /// Resulting pointer inherits the lifetime from the immutable borrow
     /// of original pointer.
     #[allow(clippy::needless_lifetimes)]
-    pub(crate) fn borrow<'a>(&'a self) -> CassPtr<'a, T, (Shared, P::CMutability)> {
+    pub fn borrow<'a>(&'a self) -> CassPtr<'a, T, (Shared, P::CMutability)> {
         CassPtr {
             ptr: self.ptr,
             _phantom: PhantomData,
@@ -323,8 +322,7 @@ impl<T: Sized> CassPtr<'_, T, (Exclusive, CMut)> {
     /// of original pointer. Since the method accepts a mutable reference
     /// to the original pointer, we enforce aliasing ^ mutability principle at compile time.
     #[allow(clippy::needless_lifetimes)]
-    #[cfg_attr(not(test), expect(unused))]
-    pub(crate) fn borrow_mut<'a>(&'a mut self) -> CassPtr<'a, T, (Exclusive, CMut)> {
+    pub fn borrow_mut<'a>(&'a mut self) -> CassPtr<'a, T, (Exclusive, CMut)> {
         CassPtr {
             ptr: self.ptr,
             _phantom: PhantomData,

--- a/scylla-rust-wrapper/tests/integration/consistency.rs
+++ b/scylla-rust-wrapper/tests/integration/consistency.rs
@@ -1,0 +1,682 @@
+use itertools::Itertools as _;
+use libc::c_char;
+use scylla::frame::types::Consistency;
+use scylla::statement::SerialConsistency;
+use scylla::statement::batch::BatchType;
+use scylla_cpp_driver::api::batch::{
+    CassBatch, CassBatchType, cass_batch_add_statement, cass_batch_new, cass_batch_set_consistency,
+    cass_batch_set_execution_profile, cass_batch_set_serial_consistency,
+};
+use scylla_cpp_driver::api::cluster::{
+    cass_cluster_free, cass_cluster_new, cass_cluster_set_connection_heartbeat_interval,
+    cass_cluster_set_consistency, cass_cluster_set_contact_points,
+    cass_cluster_set_execution_profile, cass_cluster_set_retry_policy,
+    cass_cluster_set_serial_consistency,
+};
+use scylla_cpp_driver::api::consistency::CassConsistency;
+use scylla_cpp_driver::api::error::CassError;
+use scylla_cpp_driver::api::execution_profile::{
+    cass_execution_profile_free, cass_execution_profile_new,
+    cass_execution_profile_set_consistency, cass_execution_profile_set_serial_consistency,
+};
+use scylla_cpp_driver::api::future::{cass_future_error_code, cass_future_get_prepared};
+use scylla_cpp_driver::api::prepared::{cass_prepared_bind, cass_prepared_free};
+use scylla_cpp_driver::api::retry_policy::{
+    cass_retry_policy_fallthrough_new, cass_retry_policy_free,
+};
+use scylla_cpp_driver::api::session::{
+    CassSession, cass_session_close, cass_session_connect, cass_session_execute,
+    cass_session_execute_batch, cass_session_free, cass_session_new, cass_session_prepare,
+    cass_session_prepare_from_existing,
+};
+use scylla_cpp_driver::api::statement::{
+    CassStatement, cass_statement_new, cass_statement_set_consistency,
+    cass_statement_set_execution_profile, cass_statement_set_serial_consistency,
+};
+use scylla_cpp_driver::argconv::{CConst, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr};
+use scylla_proxy::ShardAwareness;
+use scylla_proxy::{
+    Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
+    TargetShard, WorkerError,
+};
+use std::ffi::CStr;
+use std::sync::Arc;
+use tokio::sync::mpsc::{self, UnboundedReceiver};
+
+use crate::utils::{
+    assert_cass_error_eq, cass_future_result_wait_expect_server_error_and_free,
+    cass_future_wait_check_and_free, drop_metadata_queries_rules, forge_prepare_response,
+    handshake_rules, proxy_uris_to_contact_points, setup_tracing,
+    test_with_3_node_dry_mode_cluster,
+};
+
+fn consistencies() -> impl Iterator<Item = Consistency> {
+    [
+        Consistency::All,
+        Consistency::Any,
+        Consistency::EachQuorum,
+        Consistency::LocalOne,
+        Consistency::LocalQuorum,
+        Consistency::One,
+        Consistency::Quorum,
+        Consistency::Three,
+        Consistency::Two,
+        Consistency::Serial,
+        Consistency::LocalSerial,
+    ]
+    .into_iter()
+}
+
+fn serial_consistencies() -> impl Iterator<Item = SerialConsistency> {
+    [SerialConsistency::Serial, SerialConsistency::LocalSerial].into_iter()
+}
+
+// Every consistency and every serial consistency is yielded at least once.
+// These are NOT all combinations of those.
+fn pairs_of_all_consistencies() -> impl Iterator<Item = (Consistency, Option<SerialConsistency>)> {
+    let consistencies = consistencies();
+    let serial_consistencies = serial_consistencies()
+        // This is because we have a conversion function from Consistency to CassConsistency.
+        .map(Some)
+        .chain(std::iter::repeat(None));
+    consistencies.zip(serial_consistencies)
+}
+
+const STATEMENT_CSTR: *const i8 = c"INSERT INTO consistency_tests VALUES (42)" as *const CStr as _;
+
+fn execute_and_check_statement(
+    cass_session: CassBorrowedSharedPtr<'_, CassSession, CMut>,
+    cass_statement: CassBorrowedSharedPtr<'_, CassStatement, CConst>,
+) {
+    unsafe {
+        let request_fut = cass_session_execute(cass_session, cass_statement);
+        cass_future_result_wait_expect_server_error_and_free(request_fut);
+    }
+}
+
+fn execute_and_check_batch(
+    cass_session: CassBorrowedSharedPtr<'_, CassSession, CMut>,
+    cass_batch: CassBorrowedSharedPtr<'_, CassBatch, CConst>,
+) {
+    unsafe {
+        let request_fut = cass_session_execute_batch(cass_session, cass_batch);
+        cass_future_result_wait_expect_server_error_and_free(request_fut);
+    }
+}
+
+// The following functions perform a request with consistencies set directly on a statement.
+fn statement_consistency_set_directly(
+    cass_session: CassBorrowedSharedPtr<'_, CassSession, CMut>,
+    mut cass_statement: CassBorrowedExclusivePtr<'_, CassStatement, CMut>,
+    c: CassConsistency,
+    sc: CassConsistency,
+) {
+    unsafe {
+        assert_cass_error_eq(
+            cass_statement_set_consistency(cass_statement.borrow_mut(), c),
+            CassError::CASS_OK,
+        );
+        assert_cass_error_eq(
+            cass_statement_set_serial_consistency(cass_statement.borrow_mut(), sc),
+            CassError::CASS_OK,
+        );
+        execute_and_check_statement(cass_session, cass_statement.borrow().into_c_const());
+        assert_cass_error_eq(
+            cass_statement_set_consistency(
+                cass_statement.borrow_mut(),
+                CassConsistency::CASS_CONSISTENCY_UNKNOWN,
+            ),
+            CassError::CASS_OK,
+        );
+        assert_cass_error_eq(
+            cass_statement_set_serial_consistency(
+                cass_statement.borrow_mut(),
+                CassConsistency::CASS_CONSISTENCY_UNKNOWN,
+            ),
+            CassError::CASS_OK,
+        );
+    }
+}
+
+fn batch_consistency_set_directly(
+    cass_session: CassBorrowedSharedPtr<'_, CassSession, CMut>,
+    mut cass_batch: CassBorrowedExclusivePtr<'_, CassBatch, CMut>,
+    c: CassConsistency,
+    sc: CassConsistency,
+) {
+    unsafe {
+        assert_cass_error_eq(
+            cass_batch_set_consistency(cass_batch.borrow_mut(), c),
+            CassError::CASS_OK,
+        );
+        assert_cass_error_eq(
+            cass_batch_set_serial_consistency(cass_batch.borrow_mut(), sc),
+            CassError::CASS_OK,
+        );
+        execute_and_check_batch(cass_session, cass_batch.borrow().into_c_const());
+        assert_cass_error_eq(
+            cass_batch_set_consistency(
+                cass_batch.borrow_mut(),
+                CassConsistency::CASS_CONSISTENCY_UNKNOWN,
+            ),
+            CassError::CASS_OK,
+        );
+        assert_cass_error_eq(
+            cass_batch_set_serial_consistency(
+                cass_batch.borrow_mut(),
+                CassConsistency::CASS_CONSISTENCY_UNKNOWN,
+            ),
+            CassError::CASS_OK,
+        );
+    }
+}
+
+/// Verifies that the last request was sent with the expected consistency and serial consistency.
+#[track_caller]
+fn check_consistencies(
+    consistency: Consistency,
+    serial_consistency: Option<SerialConsistency>,
+    mut request_rx: UnboundedReceiver<(RequestFrame, Option<TargetShard>)>,
+) -> UnboundedReceiver<(RequestFrame, Option<TargetShard>)> {
+    let (request_frame, _shard) = request_rx.blocking_recv().unwrap();
+    let deserialized_request = request_frame.deserialize().unwrap();
+    assert_eq!(deserialized_request.get_consistency().unwrap(), consistency);
+    assert_eq!(
+        deserialized_request.get_serial_consistency().unwrap(),
+        serial_consistency
+    );
+    request_rx
+}
+
+/// For all consistencies (as defined by `pairs_of_all_consistencies()`) and every method of setting consistencies
+/// (directly on statement, on per-statement exec profile, on default per-session exec profile)
+/// performs a request and calls `check_consistencies()` asserting function with `rx`.
+fn check_for_all_consistencies_and_setting_options(
+    mut rx: UnboundedReceiver<(RequestFrame, Option<TargetShard>)>,
+    proxy_uris: [String; 3],
+) {
+    let contact_points = proxy_uris_to_contact_points(proxy_uris);
+
+    unsafe {
+        let mut cass_cluster = cass_cluster_new();
+        assert_cass_error_eq(
+            cass_cluster_set_contact_points(cass_cluster.borrow_mut(), contact_points.as_ptr()),
+            CassError::CASS_OK,
+        );
+
+        // Not to interfere with the test, we set a long heartbeat interval.
+        cass_cluster_set_connection_heartbeat_interval(cass_cluster.borrow_mut(), 10000);
+
+        {
+            // Set the retry policy to fallthrough, so that retries do not interfere with the test.
+            let cass_retry_policy = cass_retry_policy_fallthrough_new();
+            cass_cluster_set_retry_policy(cass_cluster.borrow_mut(), cass_retry_policy.borrow());
+            cass_retry_policy_free(cass_retry_policy);
+        }
+
+        let cass_session = cass_session_new();
+        let mut cass_exec_profile = cass_execution_profile_new();
+        let exec_profile_name = c"test_profile".as_ptr();
+
+        {
+            // Connect the session to the cluster. Use default consistency and serial consistency.
+            let connect_fut =
+                cass_session_connect(cass_session.borrow(), cass_cluster.borrow().into_c_const());
+            cass_future_wait_check_and_free(connect_fut);
+        }
+
+        // Prepare statements that we will be using.
+        let mut cass_statement_unprepared = cass_statement_new(STATEMENT_CSTR, 0);
+
+        let mut cass_statement_prepared = {
+            let prepare_fut = cass_session_prepare(cass_session.borrow(), STATEMENT_CSTR);
+            assert_cass_error_eq(
+                cass_future_error_code(prepare_fut.borrow()),
+                CassError::CASS_OK,
+            );
+            let cass_prepared = cass_future_get_prepared(prepare_fut);
+            let cass_statement_prepared = cass_prepared_bind(cass_prepared.borrow());
+            cass_prepared_free(cass_prepared);
+            cass_statement_prepared
+        };
+
+        let mut cass_statement_prepared_from_existing = {
+            let prepare_fut = cass_session_prepare_from_existing(
+                cass_session.borrow(),
+                cass_statement_unprepared.borrow(),
+            );
+            assert_cass_error_eq(
+                cass_future_error_code(prepare_fut.borrow()),
+                CassError::CASS_OK,
+            );
+            let cass_prepared_from_existing = cass_future_get_prepared(prepare_fut);
+            let cass_statement_prepared_from_existing =
+                cass_prepared_bind(cass_prepared_from_existing.borrow());
+            cass_prepared_free(cass_prepared_from_existing);
+            cass_statement_prepared_from_existing
+        };
+
+        let mut cass_batch = {
+            let mut cass_batch = cass_batch_new(std::mem::transmute::<u32, CassBatchType>(
+                BatchType::Logged as u32,
+            ));
+            assert_cass_error_eq(
+                cass_batch_add_statement(
+                    cass_batch.borrow_mut(),
+                    cass_statement_unprepared.borrow(),
+                ),
+                CassError::CASS_OK,
+            );
+
+            cass_batch
+        };
+
+        {
+            // Verify that the consistencies are set to default values.
+
+            // As per CPP Driver code:
+            // ```c++
+            // #define CASS_DEFAULT_CONSISTENCY CASS_CONSISTENCY_LOCAL_ONE
+            // #define CASS_DEFAULT_REQUEST_TIMEOUT_MS 12000u
+            // #define CASS_DEFAULT_SERIAL_CONSISTENCY CASS_CONSISTENCY_ANY
+            // ```
+            const DEFAULT_CONSISTENCY: Consistency = Consistency::LocalOne;
+            // This is the CPP Driver default, but Rust Driver's default (LocalSerial) is arguably more reasonable.
+            // TODO: consider changing the default in CPP-Rust Driver to LocalSerial.
+            const DEFAULT_SERIAL_CONSISTENCY: Option<SerialConsistency> = None;
+
+            {
+                // Unprepared statement.
+                execute_and_check_statement(
+                    cass_session.borrow(),
+                    cass_statement_unprepared.borrow().into_c_const(),
+                );
+                rx = check_consistencies(DEFAULT_CONSISTENCY, DEFAULT_SERIAL_CONSISTENCY, rx);
+            }
+
+            {
+                // Prepared statement.
+                execute_and_check_statement(
+                    cass_session.borrow(),
+                    cass_statement_prepared.borrow().into_c_const(),
+                );
+                rx = check_consistencies(DEFAULT_CONSISTENCY, DEFAULT_SERIAL_CONSISTENCY, rx);
+            }
+
+            {
+                // Statement prepared from existing.
+                execute_and_check_statement(
+                    cass_session.borrow(),
+                    cass_statement_prepared_from_existing
+                        .borrow()
+                        .into_c_const(),
+                );
+                rx = check_consistencies(DEFAULT_CONSISTENCY, DEFAULT_SERIAL_CONSISTENCY, rx);
+            }
+
+            {
+                // Batch.
+                execute_and_check_batch(cass_session.borrow(), cass_batch.borrow().into_c_const());
+                rx = check_consistencies(DEFAULT_CONSISTENCY, DEFAULT_SERIAL_CONSISTENCY, rx);
+            }
+        }
+
+        {
+            // Close the session. This is because the following tests will connect to the same session.
+            let close_fut = cass_session_close(cass_session.borrow());
+            cass_future_wait_check_and_free(close_fut);
+        }
+
+        /* Outline:
+         * 1. Generate two distinct pairs of <consistency, serial_consistency>.
+         * 2. Configure the cluster with the first pair of consistencies.
+         * 2. Configure the execution profile with the second pair of consistencies.
+         * 3. Introduce the profile to the cluster.
+         * 4. Connect the session to the cluster.
+         * 5. Verify that correct consistencies are taken from the cluster.
+         * 6. Use the execution profile for statements and batches.
+         *    Verify that correct consistencies are taken from the execution profile.
+         * 7. Set the first pair of consistencies directly on statements and batches.
+         *    Verify that correct consistencies are taken from the statements and batches.
+         * 8. Close the session, so that the next test can connect to the same session.
+         */
+        for ((c_cluster, sc_cluster), (c_exec_profile, sc_exec_profile)) in
+            pairs_of_all_consistencies().zip_eq(
+                pairs_of_all_consistencies()
+                    .skip(1)
+                    .chain(pairs_of_all_consistencies().take(1)),
+            )
+        {
+            let [cass_c_cluster, cass_c_exec_profile] =
+                [c_cluster, c_exec_profile].map(CassConsistency::from);
+            let [cass_sc_cluster, cass_sc_exec_profile] = [sc_cluster, sc_exec_profile].map(|sc| {
+                CassConsistency::from(match sc {
+                    Some(SerialConsistency::Serial) => Consistency::Serial,
+                    Some(SerialConsistency::LocalSerial) => Consistency::LocalSerial,
+                    None => Consistency::Any,
+                })
+            });
+
+            {
+                // Configure the execution profile with the consistencies.
+                // Introduce the profile to the cluster.
+                assert_cass_error_eq(
+                    cass_execution_profile_set_consistency(
+                        cass_exec_profile.borrow_mut(),
+                        cass_c_exec_profile,
+                    ),
+                    CassError::CASS_OK,
+                );
+                assert_cass_error_eq(
+                    cass_execution_profile_set_serial_consistency(
+                        cass_exec_profile.borrow_mut(),
+                        cass_sc_exec_profile,
+                    ),
+                    CassError::CASS_OK,
+                );
+                assert_cass_error_eq(
+                    cass_cluster_set_execution_profile(
+                        cass_cluster.borrow_mut(),
+                        exec_profile_name,
+                        cass_exec_profile.borrow_mut(),
+                    ),
+                    CassError::CASS_OK,
+                );
+            }
+
+            {
+                // Configure provided consistency and serial consistency in the cluster.
+                assert_cass_error_eq(
+                    cass_cluster_set_consistency(cass_cluster.borrow_mut(), cass_c_cluster),
+                    CassError::CASS_OK,
+                );
+
+                assert_cass_error_eq(
+                    cass_cluster_set_serial_consistency(cass_cluster.borrow_mut(), cass_sc_cluster),
+                    CassError::CASS_OK,
+                );
+
+                // Connect the session to the cluster.
+                let connect_fut = cass_session_connect(
+                    cass_session.borrow(),
+                    cass_cluster.borrow().into_c_const(),
+                );
+                cass_future_wait_check_and_free(connect_fut);
+            }
+
+            {
+                // Verify that consistencies are correctly taken from the cluster.
+
+                // Unprepared statement.
+                execute_and_check_statement(
+                    cass_session.borrow(),
+                    cass_statement_unprepared.borrow().into_c_const(),
+                );
+                rx = check_consistencies(c_cluster, sc_cluster, rx);
+
+                // Prepared statement.
+                execute_and_check_statement(
+                    cass_session.borrow(),
+                    cass_statement_prepared.borrow().into_c_const(),
+                );
+                rx = check_consistencies(c_cluster, sc_cluster, rx);
+
+                // Statement prepared from existing.
+                execute_and_check_statement(
+                    cass_session.borrow(),
+                    cass_statement_prepared_from_existing
+                        .borrow()
+                        .into_c_const(),
+                );
+                rx = check_consistencies(c_cluster, sc_cluster, rx);
+
+                // Batch.
+                execute_and_check_batch(cass_session.borrow(), cass_batch.borrow().into_c_const());
+                rx = check_consistencies(c_cluster, sc_cluster, rx);
+            }
+
+            {
+                // Verify that consistencies are correctly taken from the execution profile.
+
+                // Unprepared statement.
+                {
+                    // Set execution profile on the statement.
+                    assert_cass_error_eq(
+                        cass_statement_set_execution_profile(
+                            cass_statement_unprepared.borrow_mut(),
+                            exec_profile_name,
+                        ),
+                        CassError::CASS_OK,
+                    );
+
+                    execute_and_check_statement(
+                        cass_session.borrow(),
+                        cass_statement_unprepared.borrow().into_c_const(),
+                    );
+                    rx = check_consistencies(c_exec_profile, sc_exec_profile, rx);
+                }
+
+                // Prepared statement.
+                {
+                    // Set execution profile on the statement.
+                    assert_cass_error_eq(
+                        cass_statement_set_execution_profile(
+                            cass_statement_prepared.borrow_mut(),
+                            exec_profile_name,
+                        ),
+                        CassError::CASS_OK,
+                    );
+
+                    execute_and_check_statement(
+                        cass_session.borrow(),
+                        cass_statement_prepared.borrow().into_c_const(),
+                    );
+                    rx = check_consistencies(c_exec_profile, sc_exec_profile, rx);
+                }
+
+                // Statement prepared from existing.
+                {
+                    // Set execution profile on the statement.
+                    assert_cass_error_eq(
+                        cass_statement_set_execution_profile(
+                            cass_statement_prepared_from_existing.borrow_mut(),
+                            exec_profile_name,
+                        ),
+                        CassError::CASS_OK,
+                    );
+
+                    execute_and_check_statement(
+                        cass_session.borrow(),
+                        cass_statement_prepared_from_existing
+                            .borrow()
+                            .into_c_const(),
+                    );
+                    rx = check_consistencies(c_exec_profile, sc_exec_profile, rx);
+                }
+
+                // Batch.
+                {
+                    // Set execution profile on the batch.
+                    assert_cass_error_eq(
+                        cass_batch_set_execution_profile(
+                            cass_batch.borrow_mut(),
+                            exec_profile_name,
+                        ),
+                        CassError::CASS_OK,
+                    );
+
+                    execute_and_check_batch(
+                        cass_session.borrow(),
+                        cass_batch.borrow().into_c_const(),
+                    );
+                    rx = check_consistencies(c_exec_profile, sc_exec_profile, rx);
+                }
+            }
+
+            {
+                // Verify that consistencies are correctly set directly on statements and batches.
+
+                // Unprepared statement.
+                statement_consistency_set_directly(
+                    cass_session.borrow(),
+                    cass_statement_unprepared.borrow_mut(),
+                    cass_c_cluster,
+                    cass_sc_cluster,
+                );
+                rx = check_consistencies(c_cluster, sc_cluster, rx);
+
+                // Prepared statement.
+                statement_consistency_set_directly(
+                    cass_session.borrow(),
+                    cass_statement_prepared.borrow_mut(),
+                    cass_c_cluster,
+                    cass_sc_cluster,
+                );
+                rx = check_consistencies(c_cluster, sc_cluster, rx);
+
+                // Statement prepared from existing.
+                statement_consistency_set_directly(
+                    cass_session.borrow(),
+                    cass_statement_prepared_from_existing.borrow_mut(),
+                    cass_c_cluster,
+                    cass_sc_cluster,
+                );
+                rx = check_consistencies(c_cluster, sc_cluster, rx);
+
+                batch_consistency_set_directly(
+                    cass_session.borrow(),
+                    cass_batch.borrow_mut(),
+                    cass_c_cluster,
+                    cass_sc_cluster,
+                );
+                rx = check_consistencies(c_cluster, sc_cluster, rx);
+            }
+
+            // Cleanup exec profile settings on statements.
+            {
+                // Unset execution profile on the statement.
+                assert_cass_error_eq(
+                    cass_statement_set_execution_profile(
+                        cass_statement_unprepared.borrow_mut(),
+                        std::ptr::null::<c_char>(),
+                    ),
+                    CassError::CASS_OK,
+                );
+
+                // Unset execution profile on the statement.
+                assert_cass_error_eq(
+                    cass_statement_set_execution_profile(
+                        cass_statement_prepared.borrow_mut(),
+                        std::ptr::null::<c_char>(),
+                    ),
+                    CassError::CASS_OK,
+                );
+
+                // Unset execution profile on the statement.
+                assert_cass_error_eq(
+                    cass_statement_set_execution_profile(
+                        cass_statement_prepared_from_existing.borrow_mut(),
+                        std::ptr::null::<c_char>(),
+                    ),
+                    CassError::CASS_OK,
+                );
+
+                // Unset execution profile on the batch.
+                assert_cass_error_eq(
+                    cass_batch_set_execution_profile(
+                        cass_batch.borrow_mut(),
+                        std::ptr::null::<c_char>(),
+                    ),
+                    CassError::CASS_OK,
+                );
+            }
+
+            {
+                // Close the session. This is because the following tests will connect to the same session.
+                let close_fut = cass_session_close(cass_session.borrow());
+                cass_future_wait_check_and_free(close_fut);
+            }
+        }
+        cass_execution_profile_free(cass_exec_profile);
+        cass_session_free(cass_session);
+        cass_cluster_free(cass_cluster);
+    }
+}
+
+// Checks that the expected consistency and serial_consistency are set
+// in the CQL request frame.
+#[tokio::test]
+#[ntest::timeout(60000)]
+async fn consistency_is_correctly_set_in_cql_requests() {
+    setup_tracing();
+    let res = test_with_3_node_dry_mode_cluster(
+        ShardAwareness::QueryNode,
+        |proxy_uris, mut running_proxy| async move {
+            let request_rules = |tx| {
+                handshake_rules()
+                    .into_iter()
+                    .chain(drop_metadata_queries_rules())
+                    .chain([
+                        RequestRule(
+                            Condition::and(
+                                Condition::not(Condition::ConnectionRegisteredAnyEvent),
+                                Condition::RequestOpcode(RequestOpcode::Prepare),
+                            ),
+                            // Respond to a PREPARE request with a prepared statement ID.
+                            // This assumes 0 bind variables and 0 returned columns.
+                            RequestReaction::forge_response(Arc::new(forge_prepare_response)),
+                        ),
+                        RequestRule(
+                            Condition::and(
+                                Condition::not(Condition::ConnectionRegisteredAnyEvent),
+                                Condition::or(
+                                    Condition::RequestOpcode(RequestOpcode::Execute),
+                                    Condition::or(
+                                        Condition::RequestOpcode(RequestOpcode::Batch),
+                                        Condition::and(
+                                            Condition::RequestOpcode(RequestOpcode::Query),
+                                            Condition::BodyContainsCaseSensitive(Box::new(
+                                                *b"INTO consistency_tests",
+                                            )),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            RequestReaction::forge()
+                                .server_error()
+                                .with_feedback_when_performed(tx),
+                        ),
+                    ])
+                    .collect::<Vec<_>>()
+            };
+
+            // Set the rules for the requests.
+            // This has the following effect:
+            // 1. PREPARE requests will be answered with a forged response.
+            // 2. EXECUTE, BATCH and QUERY requests will be replied with a forged error response,
+            //    but additionally will send a feedback to the channel `tx`, which will be used
+            //    to verify the consistency and serial consistency set in the request.
+            let (request_tx, request_rx) = mpsc::unbounded_channel();
+            for running_node in running_proxy.running_nodes.iter_mut() {
+                running_node.change_request_rules(Some(request_rules(request_tx.clone())));
+            }
+
+            // The test must be executed in a blocking context, because otherwise the tokio runtime
+            // will panic on blocking operations that C API performs.
+            tokio::task::spawn_blocking(move || {
+                check_for_all_consistencies_and_setting_options(request_rx, proxy_uris)
+            })
+            .await
+            .unwrap();
+
+            running_proxy
+        },
+    )
+    .await;
+
+    match res {
+        Ok(()) => (),
+        Err(ProxyError::Worker(WorkerError::DriverDisconnected(_))) => (),
+        Err(err) => panic!("{}", err),
+    }
+}

--- a/scylla-rust-wrapper/tests/integration/main.rs
+++ b/scylla-rust-wrapper/tests/integration/main.rs
@@ -1,0 +1,2 @@
+mod consistency;
+mod utils;

--- a/scylla-rust-wrapper/tests/integration/utils.rs
+++ b/scylla-rust-wrapper/tests/integration/utils.rs
@@ -1,0 +1,203 @@
+use bytes::BytesMut;
+use futures::Future;
+use libc::c_char;
+use scylla_cpp_driver::api::error::{CassError, cass_error_desc};
+use scylla_cpp_driver::api::future::{
+    CassFuture, cass_future_error_code, cass_future_error_message, cass_future_free,
+    cass_future_wait,
+};
+use scylla_cpp_driver::argconv::{CMut, CassOwnedSharedPtr, ptr_to_cstr, ptr_to_cstr_n};
+use scylla_cpp_driver::types::size_t;
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use scylla_proxy::{
+    Condition, Node, Proxy, ProxyError, Reaction as _, RequestFrame, RequestOpcode,
+    RequestReaction, RequestRule, ResponseFrame, RunningProxy, ShardAwareness,
+};
+
+pub(crate) fn setup_tracing() {
+    let _ = tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(tracing_subscriber::fmt::TestWriter::new())
+        .try_init();
+}
+
+pub(crate) async fn test_with_3_node_dry_mode_cluster<F, Fut>(
+    shard_awareness: ShardAwareness,
+    test: F,
+) -> Result<(), ProxyError>
+where
+    F: FnOnce([String; 3], RunningProxy) -> Fut,
+    Fut: Future<Output = RunningProxy>,
+{
+    let proxy1_uri = format!("{}:9042", scylla_proxy::get_exclusive_local_address());
+    let proxy2_uri = format!("{}:9042", scylla_proxy::get_exclusive_local_address());
+    let proxy3_uri = format!("{}:9042", scylla_proxy::get_exclusive_local_address());
+
+    let proxy1_addr = SocketAddr::from_str(proxy1_uri.as_str()).unwrap();
+    let proxy2_addr = SocketAddr::from_str(proxy2_uri.as_str()).unwrap();
+    let proxy3_addr = SocketAddr::from_str(proxy3_uri.as_str()).unwrap();
+
+    let proxy = Proxy::new([proxy1_addr, proxy2_addr, proxy3_addr].map(|proxy_addr| {
+        Node::builder()
+            .proxy_address(proxy_addr)
+            .shard_awareness(shard_awareness)
+            .build_dry_mode()
+    }));
+
+    let running_proxy = proxy.run().await.unwrap();
+
+    let running_proxy = test([proxy1_uri, proxy2_uri, proxy3_uri], running_proxy).await;
+
+    running_proxy.finish().await
+}
+
+pub(crate) fn assert_cass_error_eq(errcode1: CassError, errcode2: CassError) {
+    unsafe {
+        assert_eq!(
+            errcode1,
+            errcode2,
+            "expected \"{}\", instead got \"{}\"",
+            ptr_to_cstr(cass_error_desc(errcode1)).unwrap(),
+            ptr_to_cstr(cass_error_desc(errcode2)).unwrap()
+        );
+    }
+}
+
+#[track_caller]
+pub(crate) unsafe fn cass_future_wait_check_and_free(fut: CassOwnedSharedPtr<CassFuture, CMut>) {
+    unsafe { cass_future_wait(fut.borrow()) };
+    let errcode = unsafe { cass_future_error_code(fut.borrow()) };
+    if errcode != CassError::CASS_OK {
+        let mut message: *const c_char = std::ptr::null();
+        let mut message_len: size_t = 0;
+        unsafe { cass_future_error_message(fut.borrow(), &mut message, &mut message_len) };
+        panic!(
+            "Expected CASS_OK, got an error: <{:?}>, with message: {:?}",
+            unsafe { ptr_to_cstr(cass_error_desc(errcode)) },
+            unsafe { ptr_to_cstr_n(message, message_len) },
+        );
+    }
+
+    unsafe { cass_future_free(fut) };
+}
+
+#[track_caller]
+pub(crate) unsafe fn cass_future_result_wait_expect_server_error_and_free(
+    fut: CassOwnedSharedPtr<CassFuture, CMut>,
+) {
+    unsafe { cass_future_wait(fut.borrow()) };
+    // We expect a server error, so we check for that.
+    let errcode = unsafe { cass_future_error_code(fut.borrow()) };
+    if errcode != CassError::CASS_ERROR_SERVER_SERVER_ERROR {
+        if errcode == CassError::CASS_OK {
+            panic!("Expected CASS_ERROR_SERVER_SERVER_ERROR, got CASS_OK");
+        } else {
+            let mut message: *const c_char = std::ptr::null();
+            let mut message_len: size_t = 0;
+            unsafe { cass_future_error_message(fut.borrow(), &mut message, &mut message_len) };
+            panic!(
+                "Expected CASS_ERROR_SERVER_SERVER_ERROR, got a different error: <{:?}>, with message: {:?}",
+                unsafe { ptr_to_cstr(cass_error_desc(errcode)) },
+                unsafe { ptr_to_cstr_n(message, message_len) },
+            );
+        }
+    }
+    unsafe { cass_future_free(fut) };
+}
+
+pub(crate) fn handshake_rules() -> impl IntoIterator<Item = RequestRule> {
+    [
+        RequestRule(
+            Condition::RequestOpcode(RequestOpcode::Options),
+            RequestReaction::forge_response(Arc::new(move |frame: RequestFrame| {
+                ResponseFrame::forged_supported(frame.params, &HashMap::new()).unwrap()
+            })),
+        ),
+        RequestRule(
+            Condition::RequestOpcode(RequestOpcode::Startup)
+                .or(Condition::RequestOpcode(RequestOpcode::Register)),
+            RequestReaction::forge_response(Arc::new(move |frame: RequestFrame| {
+                ResponseFrame::forged_ready(frame.params)
+            })),
+        ),
+    ]
+}
+
+pub(crate) fn drop_metadata_queries_rules() -> impl IntoIterator<Item = RequestRule> {
+    [RequestRule(
+        Condition::ConnectionRegisteredAnyEvent.and(Condition::or(
+            Condition::RequestOpcode(RequestOpcode::Query),
+            Condition::or(
+                Condition::RequestOpcode(RequestOpcode::Prepare),
+                Condition::RequestOpcode(RequestOpcode::Execute),
+            ),
+        )),
+        RequestReaction::forge().server_error(),
+    )]
+}
+
+pub(crate) fn proxy_uris_to_contact_points(proxy_uris: [String; 3]) -> CString {
+    let contact_points = proxy_uris
+        .iter()
+        .map(|s| s.as_str().split_once(':').unwrap().0)
+        .collect::<Vec<_>>()
+        .join(",");
+    CString::new(contact_points).expect("Failed to create CString from contact points")
+}
+
+/// This assumes 0 bind variables and 0 returned columns.
+pub(crate) fn forge_prepare_response(request_frame: RequestFrame) -> ResponseFrame {
+    ResponseFrame {
+        params: request_frame.params.for_response(),
+        opcode: scylla_proxy::ResponseOpcode::Result,
+        body: {
+            let mut body = BytesMut::new();
+
+            // Write result kind for prepared statement.
+            const RESULT_KIND_PREPARED: i32 = 0x0004;
+            scylla_cql::frame::types::write_int(RESULT_KIND_PREPARED, &mut body);
+
+            // Write prepared metadata.
+            {
+                // Write the prepared statement ID length.
+                scylla_cql::frame::types::write_short(1, &mut body);
+
+                // Write the prepared statement ID (1 byte long).
+                body.extend_from_slice(&42_i8.to_be_bytes());
+
+                // Write flags
+                let flags = 0; // No GLOBAL_TABLES_SPEC
+                scylla_cql::frame::types::write_int(flags, &mut body);
+
+                // Write col count
+                scylla_cql::frame::types::write_int(0, &mut body);
+
+                // Write pk count
+                scylla_cql::frame::types::write_int(0, &mut body);
+
+                // No pk indices.
+
+                // No column specs.
+            }
+
+            // Write result metadata.
+            {
+                // Write flags
+                let flags = 0; // Neither of: GLOBAL_TABLES_SPEC, HAS_MORE_PAGES, NO_METADATA.
+                scylla_cql::frame::types::write_int(flags, &mut body);
+
+                // Write col count
+                scylla_cql::frame::types::write_int(0, &mut body);
+
+                // No column specs.
+            }
+
+            body.freeze()
+        },
+    }
+}


### PR DESCRIPTION
This PR introduces the first integration test for the CPP-Rust Driver that is written in Rust.

The test is based on an analogous one that is present in the Rust Driver. It finally convinces me that the consistencies are handled correctly.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[] I added appropriate `Fixes:` annotations to PR description.~~
