### PR TITLE
types: fix CQL TEXT and VARCHAR mapping

### DIFF
--- a/scylla-rust-wrapper/src/cass_types.rs
+++ b/scylla-rust-wrapper/src/cass_types.rs
@@ -270,7 +270,13 @@ fn native_type_to_cass_value_type(native_type: &NativeType) -> CassValueType {
         Float => CassValueType::CASS_VALUE_TYPE_FLOAT,
         Int => CassValueType::CASS_VALUE_TYPE_INT,
         BigInt => CassValueType::CASS_VALUE_TYPE_BIGINT,
-        Text => CassValueType::CASS_VALUE_TYPE_TEXT,
+        // Rust Driver unifies both VARCHAR and TEXT into NativeType::Text.
+        // CPP Driver, in accordance to the CQL protocol, has separate types for VARCHAR and TEXT.
+        // Even worse, Rust Driver even does not handle CQL TEXT correctly! It errors out on TEXT
+        // type...
+        // As the DBs (Cassandra and ScyllaDB) seem to send the VARCHAR type in the protocol,
+        // we will assume that the NativeType::Text is actually a VARCHAR type.
+        Text => CassValueType::CASS_VALUE_TYPE_VARCHAR,
         Timestamp => CassValueType::CASS_VALUE_TYPE_TIMESTAMP,
         Inet => CassValueType::CASS_VALUE_TYPE_INET,
         SmallInt => CassValueType::CASS_VALUE_TYPE_SMALL_INT,

--- a/tests/src/integration/tests/test_schema_metadata.cpp
+++ b/tests/src/integration/tests/test_schema_metadata.cpp
@@ -22,7 +22,7 @@
 
 class SchemaMetadataTest : public Integration {
 public:
-  SchemaMetadataTest() { 
+  SchemaMetadataTest() {
     is_schema_metadata_ = true;
     // Materialized views do not work with tablets.
     disable_tablets_ = true;
@@ -181,11 +181,11 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, VirtualMetadata) {
 
   column_meta = cass_table_meta_column_by_name(table_meta.get(), "keyspace_name");
   ASSERT_TRUE(column_meta);
-  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_VARCHAR);
 
   column_meta = cass_table_meta_column_by_name(table_meta.get(), "table_name");
   ASSERT_TRUE(column_meta);
-  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_VARCHAR);
 
   column_meta = cass_table_meta_column_by_name(table_meta.get(), "task_id");
   ASSERT_TRUE(column_meta);
@@ -193,7 +193,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, VirtualMetadata) {
 
   column_meta = cass_table_meta_column_by_name(table_meta.get(), "kind");
   ASSERT_TRUE(column_meta);
-  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_VARCHAR);
 
   column_meta = cass_table_meta_column_by_name(table_meta.get(), "progress");
   ASSERT_TRUE(column_meta);
@@ -205,7 +205,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, VirtualMetadata) {
 
   column_meta = cass_table_meta_column_by_name(table_meta.get(), "unit");
   ASSERT_TRUE(column_meta);
-  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_VARCHAR);
 }
 
 CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, KeyspaceMetadata) {
@@ -231,10 +231,10 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, KeyspaceMetadata) {
   ASSERT_EQ(user_type_meta_name, "address");
 
   const CassDataType* user_type_field1 = cass_data_type_sub_data_type_by_name(user_type_meta, "street");
-  ASSERT_EQ(cass_data_type_type(user_type_field1), CASS_VALUE_TYPE_TEXT);
+  ASSERT_EQ(cass_data_type_type(user_type_field1), CASS_VALUE_TYPE_VARCHAR);
 
   const CassDataType* user_type_field2 = cass_data_type_sub_data_type_by_name(user_type_meta, "city");
-  ASSERT_EQ(cass_data_type_type(user_type_field2), CASS_VALUE_TYPE_TEXT);
+  ASSERT_EQ(cass_data_type_type(user_type_field2), CASS_VALUE_TYPE_VARCHAR);
 
   // Table Metadata
   const CassTableMeta* table_meta = cass_keyspace_meta_table_by_name(keyspace_meta, table_name_.c_str());
@@ -249,7 +249,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, KeyspaceMetadata) {
   const CassColumnMeta* column_meta;
   column_meta = cass_table_meta_column_by_name(table_meta, "key");
   ASSERT_TRUE(column_meta);
-  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+  EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_VARCHAR);
 
   column_meta = cass_table_meta_column_by_name(table_meta, "value");
   ASSERT_TRUE(column_meta);
@@ -330,10 +330,10 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, MetadataIterator) {
   ASSERT_EQ(user_type_meta_name, "address");
 
   const CassDataType* user_type_field1 = cass_data_type_sub_data_type_by_name(user_type_meta, "street");
-  ASSERT_EQ(cass_data_type_type(user_type_field1), CASS_VALUE_TYPE_TEXT);
+  ASSERT_EQ(cass_data_type_type(user_type_field1), CASS_VALUE_TYPE_VARCHAR);
 
   const CassDataType* user_type_field2 = cass_data_type_sub_data_type_by_name(user_type_meta, "city");
-  ASSERT_EQ(cass_data_type_type(user_type_field2), CASS_VALUE_TYPE_TEXT);
+  ASSERT_EQ(cass_data_type_type(user_type_field2), CASS_VALUE_TYPE_VARCHAR);
 
   ASSERT_FALSE(cass_iterator_next(keyspace_user_types_iterator));
 
@@ -367,7 +367,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, MetadataIterator) {
   std::string column1_name(column_meta_name, column_meta_name_length);
 
   if (column1_name == "key") {
-    EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+    EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_VARCHAR);
   } else if (column1_name == "value") {
     EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_BIGINT);
   }
@@ -379,7 +379,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaMetadataTest, MetadataIterator) {
   std::string column2_name(column_meta_name, column_meta_name_length);
 
   if (column2_name == "key") {
-    EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_TEXT);
+    EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_VARCHAR);
   } else if (column2_name == "value") {
     EXPECT_EQ(cass_data_type_type(cass_column_meta_data_type(column_meta)), CASS_VALUE_TYPE_BIGINT);
   }

--- a/tests/src/integration/values/varchar.hpp
+++ b/tests/src/integration/values/varchar.hpp
@@ -89,7 +89,7 @@ public:
 
   ValueType value() const { return varchar_; }
 
-  CassValueType value_type() const { return CASS_VALUE_TYPE_TEXT; }
+  CassValueType value_type() const { return CASS_VALUE_TYPE_VARCHAR; }
 
 protected:
   /**
@@ -111,7 +111,7 @@ public:
   std::string cql_type() const { return "text"; }
 
   CassValueType value_type() const {
-    return CASS_VALUE_TYPE_TEXT; // Text (alias is returned as varchar from server)
+    return CASS_VALUE_TYPE_VARCHAR; // Text (alias is returned as varchar from server)
   }
 };
 


### PR DESCRIPTION
Rust Driver unifies both VARCHAR and TEXT CQL types into `NativeType::Text`. CPP Driver, in accordance to the CQL protocol, has separate types for VARCHAR and TEXT. Even worse, Rust Driver even does not handle CQL TEXT correctly! It errors out on TEXT type...

As the DBs (Cassandra and ScyllaDB) seem to send the VARCHAR type in the protocol, we will assume that the `NativeType::Text` is actually a VARCHAR type.

The issue was discovered while running the examples, which were expecting VARCHAR type, but were getting TEXT type instead.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
