### PR TITLE
Release 0.5.1

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-cpp-driver-rust"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "assert_matches",
  "bindgen",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cpp-driver-rust"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"
 repository = "https://github.com/scylladb/scylla-rust-driver"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB CPP Rust Driver 0.5.1, an API-compatible rewrite of https://github.com/scylladb/cpp-driver as a wrapper for the Rust driver. It will fully replace the CPP driver, which is already reaching its End of Life.

The driver version shall be considered **Beta**.

Some minor features still need to be included. See [_Limitations_](https://github.com/scylladb/cpp-rust-driver/?tab=readme-ov-file#limitations) and [_Unimplemented functions from cassandra.h_](https://github.com/scylladb/cpp-rust-driver/?tab=readme-ov-file#unimplemented-functions-from-cassandrah) sections in README.md.

The underlying Rust driver used version: [1.3.0](https://github.com/scylladb/scylla-rust-driver/releases/tag/v1.3.0).

## Changes

**New features / enhancements**
- Bumped Rust driver dependency to 1.3.0 ([#339](https://github.com/scylladb/cpp-rust-driver/pull/339)).

**Bug fixes:**
- Fixed panic upon `cass_session_get_client_id()` on disconnected sessions ([#327](https://github.com/scylladb/cpp-rust-driver/pull/327)).
- Fixed semantics of session closing. Now, `cass_session_close` waits for all in-flight requests to complete ([#328](https://github.com/scylladb/cpp-rust-driver/pull/328)).
- Fixed serial consistency handling ([#330](https://github.com/scylladb/cpp-rust-driver/pull/330)).
- Fixed bug that a wrong fixed consistency (`ONE`) was set for prepared statements ([#331](https://github.com/scylladb/cpp-rust-driver/pull/331)).
- Fixed driver defaults - in cluster and execution profiles ([#332](https://github.com/scylladb/cpp-rust-driver/pull/332)).
- Fixed `cass_session_free` so that it waits for session close before freeing it ([#338](https://github.com/scylladb/cpp-rust-driver/pull/338)).
- Fixed panic upon calling future-related functions in callbacks ([#337](https://github.com/scylladb/cpp-rust-driver/pull/337)).
- Fixed statement/batch request timeouts ([#341](https://github.com/scylladb/cpp-rust-driver/pull/341)).
- Deleted unimplemented function stubs, so there are linker errors instead of runtime errors when such function is called by application code ([#342](https://github.com/scylladb/cpp-rust-driver/pull/342)).
- Fixed CQL TEXT and VARCHAR mapping ([#344](https://github.com/scylladb/cpp-rust-driver/pull/344)).

**CI / developer tool improvements:**
- Enabled more integration tests from CPP Driver ([#325](https://github.com/scylladb/cpp-rust-driver/pull/325)).
- Introduced an integration test for consistency ([#343](https://github.com/scylladb/cpp-rust-driver/pull/343)).

**Documentation**:
- Some fixes to README and API docs regarding (un)implemented functions ([#347](https://github.com/scylladb/cpp-rust-driver/pull/347)).

**Others:**
- Exposed public rust API & enabled API lints ([#333](https://github.com/scylladb/cpp-rust-driver/pull/333)).
- Fixed lints in integration testing API ([#340](https://github.com/scylladb/cpp-rust-driver/pull/340)).
- Done a bunch of minor refactors for type safety, readability and robustness ([#345](https://github.com/scylladb/cpp-rust-driver/pull/345)).


Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/cpp-rust-driver/](https://github.com/scylladb/cpp-rust-driver/)
Contributions are most welcome!

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:
| commits | author              |
|---------|---------------------|
| 89      | Wojciech Przytuła   |
|  1      | dependabot[bot]     |
