### PR TITLE
ci: remove old OSS Scyllas from workflows

### DIFF
--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -57,13 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        scylla-version:
-          [
-            ENTERPRISE-RELEASE,
-            ENTERPRISE-PRIOR-RELEASE,
-            OSS-RELEASE,
-            OSS-PRIOR-RELEASE,
-          ]
+        scylla-version: [ENTERPRISE-RELEASE, ENTERPRISE-PRIOR-RELEASE]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
The workflow that builds, lints, and tests the driver ran the tests against four Scylla versions:
- ENTERPRISE-RELEASE
- ENTERPRISE-PRIOR-RELEASE
- OSS-RELEASE
- OSS-PRIOR-RELEASE

The OSS versions are no longer supported, so we remove them from the workflow. It makes sense to keep the last two Scylla versions in the CI. Other versions will be tested by the matrix tests.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
