### PR TITLE
add API to specify metadata request timeout

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -3124,6 +3124,27 @@ CASS_EXPORT void
 cass_cluster_set_compression(CassCluster* cluster,
                              CassCompressionType compression_type);
 
+/**
+ * Sets the server-side timeout for metadata queries.
+ *
+ * It means that all metadata queries will be set the given timeout
+ * no matter what timeout is set as a cluster default.
+ * This prevents timeouts of schema queries when the schema is large
+ * and the default timeout is configured as tight.
+ *
+ * <b>Default:</b> 2 seconds.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] timeout_ms Request timeout in milliseconds. Pass 0 to use cluster default timeout.
+ */
+CASS_EXPORT void
+cass_cluster_set_metadata_request_serverside_timeout(CassCluster* cluster,
+                             cass_duration_t timeout_ms);
+
+
+
 /***********************************************************************************
  *
  * Session

--- a/scylla-rust-wrapper/src/api.rs
+++ b/scylla-rust-wrapper/src/api.rs
@@ -98,8 +98,9 @@ pub mod cluster {
         // cass_cluster_set_max_connections_per_host, UNIMPLEMENTED
         // cass_cluster_set_max_requests_per_flush, UNIMPLEMENTED
         // cass_cluster_set_max_reusable_write_objects, UNIMPLEMENTED
-        // cass_cluster_set_monitor_reporting_interval, UNIMPLEMENTED
         cass_cluster_set_max_schema_wait_time,
+        cass_cluster_set_metadata_request_serverside_timeout,
+        // cass_cluster_set_monitor_reporting_interval, UNIMPLEMENTED
         // cass_cluster_set_new_request_ratio, UNIMPLEMENTED
         // cass_cluster_set_no_compact, UNIMPLEMENTED
         cass_cluster_set_no_speculative_execution_policy,

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -1570,6 +1570,26 @@ pub unsafe extern "C" fn cass_cluster_set_num_threads_io(
     CassError::CASS_OK
 }
 
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cass_cluster_set_metadata_request_serverside_timeout(
+    cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
+    timeout_ms: cass_duration_t,
+) {
+    let Some(cluster_from_raw) = BoxFFI::as_mut_ref(cluster) else {
+        tracing::error!(
+            "Provided null cluster pointer to cass_cluster_set_metadata_request_serverside_timeout!"
+        );
+        return;
+    };
+
+    let metadata_request_timeout = (timeout_ms > 0).then(|| Duration::from_millis(timeout_ms));
+
+    cluster_from_raw
+        .session_builder
+        .config
+        .metadata_request_serverside_timeout = metadata_request_timeout;
+}
+
 #[cfg(test)]
 mod tests {
     use crate::testing::{assert_cass_error_eq, setup_tracing};


### PR DESCRIPTION
This adds a new API function to the driver: `cass_cluster_set_metadata_request_serverside_timeout`. This function allows users to set a server-side timeout for metadata queries, which is particularly useful for large schemas where the default timeout may be too tight. The default timeout is set to 2 seconds (as in Rust Driver), and users can pass 0 to use the cluster's default timeout. This simply exposes the existing Rust Driver's API.

Fixes: #172

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.

Closes [DRIVER-196](https://scylladb.atlassian.net/browse/DRIVER-196)


[DRIVER-196]: https://scylladb.atlassian.net/browse/DRIVER-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ