### PR TITLE
implement `cass_cluster_set_num_threads_io`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ SCYLLA_EXAMPLES_TO_RUN := \
 	# execution_profiles <- unimplemented `cass_statement_set_keyspace()`
 	# host_listener <- unimplemented `cass_cluster_set_host_listener_callback()`
 	# logging <- unimplemented `cass_cluster_set_host_listener_callback()`
-	# perf <- unimplemented `cass_cluster_set_num_threads_io()`, `cass_cluster_set_queue_size_io()`
+	# perf <- unimplemented `cass_cluster_set_queue_size_io()`
 	# schema_meta <- unimplemented multiple schema-related functions
 	# cloud <- out of interest for us, not related to ScyllaDB
 endif

--- a/README.md
+++ b/README.md
@@ -263,7 +263,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
 - cass_cluster_set_monitor_reporting_interval
 - cass_cluster_set_new_request_ratio
 - cass_cluster_set_no_compact
-- cass_cluster_set_num_threads_io
 - cass_cluster_set_pending_requests_high_water_mark
 - cass_cluster_set_pending_requests_low_water_mark
 - cass_cluster_set_prepare_on_all_hosts

--- a/examples/perf/perf.c
+++ b/examples/perf/perf.c
@@ -137,7 +137,7 @@ CassCluster* create_cluster(const char* hosts) {
   cass_cluster_set_credentials(cluster, "cassandra", "cassandra");
   cass_cluster_set_num_threads_io(cluster, NUM_IO_WORKER_THREADS);
   cass_cluster_set_queue_size_io(cluster, 10000);
-  cass_cluster_set_core_connections_per_host(cluster, 1);
+  cass_cluster_set_core_connections_per_shard(cluster, 1);
   return cluster;
 }
 

--- a/scylla-rust-wrapper/src/api.rs
+++ b/scylla-rust-wrapper/src/api.rs
@@ -103,7 +103,7 @@ pub mod cluster {
         // cass_cluster_set_new_request_ratio, UNIMPLEMENTED
         // cass_cluster_set_no_compact, UNIMPLEMENTED
         cass_cluster_set_no_speculative_execution_policy,
-        // cass_cluster_set_num_threads_io, UNIMPLEMENTED
+        cass_cluster_set_num_threads_io,
         cass_cluster_set_port,
         // cass_cluster_set_pending_requests_high_water_mark, UNIMPLEMENTED
         // cass_cluster_set_pending_requests_low_water_mark, UNIMPLEMENTED
@@ -984,7 +984,6 @@ pub mod integration_testing {
         cass_cluster_set_authenticator_callbacks,
         cass_cluster_set_cloud_secure_connection_bundle,
         cass_cluster_set_host_listener_callback,
-        cass_cluster_set_num_threads_io,
         cass_cluster_set_queue_size_io,
         cass_cluster_set_cloud_secure_connection_bundle_n,
         cass_cluster_set_exponential_reconnect,

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -81,7 +81,6 @@ const DEFAULT_SHARD_AWARE_LOCAL_PORT_RANGE: ShardAwarePortRange =
 const DRIVER_NAME: &str = "ScyllaDB Cpp-Rust Driver";
 const DRIVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(Clone)]
 pub struct CassCluster {
     runtime: Arc<tokio::runtime::Runtime>,
 

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -49,15 +49,28 @@ impl BoundCallback {
 
 #[derive(Default)]
 struct CassFutureState {
+    /// Optional callback to be executed when the future is resolved.
     callback: Option<BoundCallback>,
+
+    /// Join handle of the tokio task that resolves the future.
     join_handle: Option<JoinHandle<()>>,
 }
 
 pub struct CassFuture {
+    /// Mutable state of the future that requires synchronized exclusive access
+    /// in order to ensure thread safety of the future execution.
     state: Mutex<CassFutureState>,
+
+    /// Result of the future once it is resolved.
     result: OnceLock<CassFutureResult>,
+
+    /// Required as a place to allocate the stringified error message.
+    /// This is needed to support `cass_future_error_message`.
     err_string: OnceLock<String>,
+
+    /// Used to notify threads waiting for the future's result.
     wait_for_value: Condvar,
+
     #[cfg(cpp_integration_testing)]
     recording_listener: Option<Arc<crate::integration_testing::RecordingHistoryListener>>,
 }

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -552,13 +552,13 @@ pub unsafe extern "C" fn cass_future_error_message(
     };
 
     let value = future.waited_result();
-    let msg = future.err_string.get_or_init(|| match value {
-        Ok(CassResultValue::QueryError(err)) => err.msg(),
-        Err((_, s)) => s.msg(),
-        _ => "".to_string(),
-    });
+    let msg = match value {
+        Ok(CassResultValue::QueryError(err)) => future.err_string.get_or_init(|| err.msg()),
+        Err((_, s)) => s,
+        _ => "",
+    };
 
-    unsafe { write_str_to_c(msg.as_str(), message, message_length) };
+    unsafe { write_str_to_c(msg, message, message_length) };
 }
 
 #[unsafe(no_mangle)]

--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -403,10 +403,7 @@ pub unsafe extern "C" fn cass_future_ready(
         return cass_false;
     };
 
-    match future.result.get() {
-        None => cass_false,
-        Some(_) => cass_true,
-    }
+    future.result.get().is_some() as cass_bool_t
 }
 
 #[unsafe(no_mangle)]

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn testing_future_get_host(
         return;
     };
 
-    future.with_waited_result(|r| match r {
+    match future.waited_result() {
         Ok(CassResultValue::QueryResult(result)) => {
             // unwrap: Coordinator is none only for unit tests.
             let coordinator = result.coordinator.as_ref().unwrap();
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn testing_future_get_host(
             *host = std::ptr::null_mut();
             *host_length = 0;
         },
-    })
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/scylla-rust-wrapper/src/integration_testing.rs
+++ b/scylla-rust-wrapper/src/integration_testing.rs
@@ -520,14 +520,6 @@ pub(crate) mod stubs {
     }
 
     #[unsafe(no_mangle)]
-    pub extern "C" fn cass_cluster_set_num_threads_io(
-        _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-        _num_threads: u32,
-    ) -> CassError {
-        CassError::CASS_OK
-    }
-
-    #[unsafe(no_mangle)]
     pub extern "C" fn cass_cluster_set_queue_size_io(
         _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
         _queue_size: u32,

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -4,7 +4,6 @@ use crate::logging::Logger;
 use crate::logging::stderr_log_callback;
 use std::sync::LazyLock;
 use std::sync::RwLock;
-use tokio::runtime::Runtime;
 
 #[macro_use]
 mod binding;
@@ -190,7 +189,6 @@ pub(crate) mod cass_version_types {
     include_bindgen_generated!("cppdriver_version_types.rs");
 }
 
-pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| Runtime::new().unwrap());
 pub(crate) static LOGGER: LazyLock<RwLock<Logger>> = LazyLock::new(|| {
     RwLock::new(Logger {
         cb: Some(stderr_log_callback),

--- a/scylla-rust-wrapper/src/lib.rs
+++ b/scylla-rust-wrapper/src/lib.rs
@@ -30,6 +30,7 @@ pub(crate) mod misc;
 pub(crate) mod prepared;
 pub(crate) mod query_result;
 pub(crate) mod retry_policy;
+pub(crate) mod runtime;
 #[cfg(test)]
 mod ser_de_tests;
 pub(crate) mod session;

--- a/scylla-rust-wrapper/src/runtime.rs
+++ b/scylla-rust-wrapper/src/runtime.rs
@@ -1,0 +1,81 @@
+//! Manages tokio runtimes for the application.
+//!
+//! Runtime is per-cluster and can be changed with `cass_cluster_set_num_threads_io`.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Weak},
+};
+
+use tokio::runtime::Runtime;
+
+/// Manages tokio runtimes for the application.
+///
+/// Runtime is per-cluster and can be changed with `cass_cluster_set_num_threads_io`.
+/// Once a runtime is created, it is cached for future use.
+/// Once all `CassSession` instances that reference the runtime are dropped,
+/// the runtime is also dropped.
+pub(crate) struct Runtimes {
+    // Weak pointers are used to make runtimes dropped once all `CassSession` instances
+    // that reference them are freed.
+    default_runtime: Option<Weak<Runtime>>,
+    // This is Option to allow creating a static instance of Runtimes.
+    // (`HashMap::new` is not `const`).
+    n_thread_runtimes: Option<HashMap<usize, Weak<Runtime>>>,
+}
+
+pub(crate) static RUNTIMES: std::sync::Mutex<Runtimes> = {
+    std::sync::Mutex::new(Runtimes {
+        default_runtime: None,
+        n_thread_runtimes: None,
+    })
+};
+
+impl Runtimes {
+    fn cached_or_new_runtime(
+        weak_runtime: &mut Weak<Runtime>,
+        create_runtime: impl FnOnce() -> Result<Arc<Runtime>, std::io::Error>,
+    ) -> Result<Arc<Runtime>, std::io::Error> {
+        match weak_runtime.upgrade() {
+            Some(cached_runtime) => Ok(cached_runtime),
+            None => {
+                let runtime = create_runtime()?;
+                *weak_runtime = Arc::downgrade(&runtime);
+                Ok(runtime)
+            }
+        }
+    }
+
+    /// Returns a default tokio runtime.
+    ///
+    /// If it's not created yet, it will create a new one with the default configuration
+    /// and cache it for future use.
+    pub(crate) fn default_runtime(&mut self) -> Result<Arc<Runtime>, std::io::Error> {
+        let default_runtime_slot = self.default_runtime.get_or_insert_with(Weak::new);
+        Self::cached_or_new_runtime(default_runtime_slot, || Runtime::new().map(Arc::new))
+    }
+
+    /// Returns a tokio runtime with `n_threads` worker threads.
+    ///
+    /// If it's not created yet, it will create a new one and cache it for future use.
+    pub(crate) fn n_thread_runtime(
+        &mut self,
+        n_threads: usize,
+    ) -> Result<Arc<Runtime>, std::io::Error> {
+        let n_thread_runtimes = self.n_thread_runtimes.get_or_insert_with(HashMap::new);
+        let n_thread_runtime_slot = n_thread_runtimes.entry(n_threads).or_default();
+
+        Self::cached_or_new_runtime(n_thread_runtime_slot, || {
+            match n_threads {
+                0 => tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build(),
+                n => tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(n)
+                    .enable_all()
+                    .build(),
+            }
+            .map(Arc::new)
+        })
+    }
+}

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -79,7 +79,7 @@ impl CassConnectedSession {
         let cluster_client_id = cluster.get_client_id();
 
         let fut = Self::connect_fut(
-            Arc::clone(cluster.get_runtime()),
+            cluster.get_runtime(),
             session,
             session_builder,
             cluster_client_id,
@@ -89,7 +89,7 @@ impl CassConnectedSession {
         );
 
         CassFuture::make_raw(
-            Arc::clone(cluster.get_runtime()),
+            cluster.get_runtime(),
             fut,
             #[cfg(cpp_integration_testing)]
             None,

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -602,7 +602,7 @@ pub unsafe extern "C" fn cass_session_free(session_raw: CassOwnedSharedPtr<CassS
     };
 
     let close_fut = CassConnectedSession::close_fut(session_opt);
-    close_fut.with_waited_result(|_| ());
+    close_fut.waited_result();
 
     // We don't have to drop the session's Arc explicitly, because it has been moved
     // into the CassFuture, which is dropped here with the end of the scope.

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -67,9 +67,6 @@ CASS_EXPORT CassError cass_cluster_set_host_listener_callback(CassCluster* clust
 CASS_EXPORT CassError cass_cluster_set_no_compact(CassCluster* cluster, cass_bool_t enabled) {
   throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_no_compact\n");
 }
-CASS_EXPORT CassError cass_cluster_set_num_threads_io(CassCluster* cluster, unsigned num_threads) {
-  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_num_threads_io\n");
-}
 CASS_EXPORT CassError cass_cluster_set_prepare_on_all_hosts(CassCluster* cluster,
                                                             cass_bool_t enabled) {
   throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_prepare_on_all_hosts\n");


### PR DESCRIPTION
Fixes: #259

# What's done

This PR does the necessary refactors and implements `cass_cluster_set_num_threads_io`.

## Semantics

The semantics of the function is slightly different than in the CPP Driver:
- in CPP Driver, there are always `n+1` worker threads, where `n` is the argument passed to `cass_cluster_set_num_threads_io`. One worker thread serves the control connection and other background Session tasks, whereas the remaining `n` worker threads serve requests.
- in CPP-Rust Driver, the `n` argument is directly passed to `worker_threads()` config of the tokio `multi_thread` runtime. Those threads execute all tasks that are spawned in the wrapper and in the Rust Driver itself.

### 0 worker threads
This is an extension compared to the CPP Driver. 0 is handled specially: it uses `current_thread` tokio executor undeneath. Limitations and pitfalls of it are described in the function's documentation in `cassandra.h`.


## `CassFuture` refactors

In order to support holding the runtime in each `CassFuture` more cleanly, the `CassFuture` is split into two variants:
- `Resolvable`, which is like the `CassFuture` so far, but it also holds `Arc<Runtime>` it needs to use to poll the future,
- `Immediate`, which is created as an instantly ready future and thus does not need to store a runtime.

As a bonus, I cleaned up the logic in `CassFuture` a bit and provided more documentation and comments.


## Testing

I ran all examples with 0 worker threads. All but `callbacks` worked. `callbacks`, as expected, hung.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
