### PR TITLE
docs: fix build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,14 +12,12 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Global variables
 
 # Builds documentation for the following tags and branches.
-TAGS = [
-    "v0.5.1",
-]
+TAGS = []
 BRANCHES = [
     "master",
 ]
 # Sets the latest version.
-LATEST_VERSION = "v0.5.1"
+LATEST_VERSION = "master"
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated


### PR DESCRIPTION
Fixes the build https://github.com/scylladb/cpp-rust-driver/actions/runs/17674022220/job/50231868500

**Reason:** The tag v0.5.1 does not include the configuration required to build the API reference.

To generate docs for v0.5.1, either backport the relevant [documentation commits](https://github.com/scylladb/cpp-rust-driver/commits/master/) or wait for the next release.

Tip: We recommend building docs from branches instead of tags so you can make edits: https://sphinx-theme.scylladb.com/stable/configuration/multiversion.html#listing-new-versions
