### PR TITLE
change default serial consistency to `LOCAL_SERIAL`

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -1700,7 +1700,7 @@ cass_cluster_set_consistency(CassCluster* cluster,
 /**
  * Sets default serial consistency level of statement.
  *
- * <b>Default:</b> CASS_CONSISTENCY_ANY
+ * <b>Default:</b> CASS_CONSISTENCY_LOCAL_SERIAL
  *
  * @public @memberof CassCluster
  *

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -40,8 +40,9 @@ use crate::cass_compression_types::CassCompressionType;
 // According to `cassandra.h` the defaults for
 // - consistency for statements is LOCAL_ONE,
 pub(crate) const DEFAULT_CONSISTENCY: Consistency = Consistency::LocalOne;
-// - serial consistency for statements is ANY, which corresponds to None in Rust Driver.
-const DEFAULT_SERIAL_CONSISTENCY: Option<SerialConsistency> = None;
+// - serial consistency for statements is LOCAL_SERIAL. This is different from CPP Driver's ANY - see
+//   https://github.com/scylladb/cpp-rust-driver/issues/335 for context.
+const DEFAULT_SERIAL_CONSISTENCY: Option<SerialConsistency> = Some(SerialConsistency::LocalSerial);
 // - request client timeout is 12000 millis,
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(12000);
 // - fetching schema metadata is true

--- a/scylla-rust-wrapper/tests/integration/consistency.rs
+++ b/scylla-rust-wrapper/tests/integration/consistency.rs
@@ -281,9 +281,10 @@ fn check_for_all_consistencies_and_setting_options(
             // #define CASS_DEFAULT_SERIAL_CONSISTENCY CASS_CONSISTENCY_ANY
             // ```
             const DEFAULT_CONSISTENCY: Consistency = Consistency::LocalOne;
-            // This is the CPP Driver default, but Rust Driver's default (LocalSerial) is arguably more reasonable.
-            // TODO: consider changing the default in CPP-Rust Driver to LocalSerial.
-            const DEFAULT_SERIAL_CONSISTENCY: Option<SerialConsistency> = None;
+            // CPP Driver's default is ANY, but Rust Driver's default (LocalSerial) is arguably more reasonable.
+            // See https://github.com/scylladb/cpp-rust-driver/issues/335 for discussion.
+            const DEFAULT_SERIAL_CONSISTENCY: Option<SerialConsistency> =
+                Some(SerialConsistency::LocalSerial);
 
             {
                 // Unprepared statement.


### PR DESCRIPTION
Although the C++ Driver default is `ANY`, we believe `LOCAL_SERIAL` is a safer default: `ANY` is not valid for LWTs, and sending it will result in errors from the server.

Fixes: https://github.com/scylladb/cpp-rust-driver/issues/335

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
