### PR TITLE
Declare MSRV (currently 1.85)

### DIFF
--- a/docs/source/topics/building.md
+++ b/docs/source/topics/building.md
@@ -10,7 +10,7 @@ instead.
 ## Compatibility
 
 * Compilers:
-  - rustc 1.85+ (as part of the Rust toolchain, available at [rustup.rs]);
+  - rustc (as part of the Rust toolchain, available at [rustup.rs]). The officially supported version is the most recent stable. Older versions may work, but we don't guarantee that.
   - any reasonable C/C++ compiler, such as GCC or Clang (for tests & examples).
 
 ## Dependencies

--- a/docs/source/topics/building.md
+++ b/docs/source/topics/building.md
@@ -10,7 +10,7 @@ instead.
 ## Compatibility
 
 * Compilers:
-  - rustc 1.82+ (as part of the Rust toolchain, available at [rustup.rs]);
+  - rustc 1.85+ (as part of the Rust toolchain, available at [rustup.rs]);
   - any reasonable C/C++ compiler, such as GCC or Clang (for tests & examples).
 
 ## Dependencies

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -8,6 +8,7 @@ readme = "./README.md"
 keywords = ["database", "scylla", "cql", "cassandra"]
 categories = ["database"]
 license = "MIT OR Apache-2.0"
+rust-version = "1.85"
 
 [dependencies]
 scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.3.0", features = [


### PR DESCRIPTION
This PR sets `rust-version` in Cargo.toml to the lowest possible MSRV (1.85) that supports Rust edition 2024, which is currently used in the project. The same version happens to be the current MSRV of the Rust Driver.

Because Clippy is now MSRV-aware, it no longer complains - because the fixes require Rust version that is higher than the MSRV - so the CI now passes.

Additionally, the `building.md` bullet about supported `rustc` versions now claims our support only for the most recent stable Rust version. This will allow bumping MSRV freely in case a new useful feature is released, as we would do in the past.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
