### PR TITLE
Update wrapper package name to scylla-rust-wrapper

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1149,36 +1149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scylla-cpp-driver-rust"
-version = "0.5.1"
-dependencies = [
- "assert_matches",
- "bindgen",
- "bytes",
- "chrono",
- "futures",
- "itertools 0.10.5",
- "libc",
- "machine-uid",
- "ntest",
- "num-derive",
- "num-traits",
- "openssl",
- "openssl-sys",
- "rand 0.8.5",
- "rusty-fork",
- "scylla",
- "scylla-cql",
- "scylla-proxy",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "uuid",
- "yoke",
-]
-
-[[package]]
 name = "scylla-cql"
 version = "1.3.0"
 source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.3.0#c9ca852b7dd476886f033d3797790d2d0206987f"
@@ -1225,6 +1195,36 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "scylla-rust-wrapper"
+version = "0.5.1"
+dependencies = [
+ "assert_matches",
+ "bindgen",
+ "bytes",
+ "chrono",
+ "futures",
+ "itertools 0.10.5",
+ "libc",
+ "machine-uid",
+ "ntest",
+ "num-derive",
+ "num-traits",
+ "openssl",
+ "openssl-sys",
+ "rand 0.8.5",
+ "rusty-fork",
+ "scylla",
+ "scylla-cql",
+ "scylla-proxy",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "yoke",
 ]
 
 [[package]]

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "scylla-cpp-driver-rust"
+name = "scylla-rust-wrapper"
 version = "0.5.1"
 edition = "2024"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"


### PR DESCRIPTION
This wrapper package is not exposed, so it is not big deal, but it's current name `scylla-cpp-driver-rust` does not make lot's of sense.
Rename it to `scylla-rust-wrapper` will make it less confusing.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have implemented Rust unit tests for the features/changes introduced.~~
- [ ] ~~I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
