### PR TITLE
Update driver to 1.4.1

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1123,8 +1123,8 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "1.3.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.3.1#01e72a4b96739c62a482b3a5211adb2ffc184db8"
+version = "1.4.1"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.4.1#d0018f6575e5d851d0f44a47e22a17e2b405d4e9"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1150,8 +1150,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "1.3.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.3.1#01e72a4b96739c62a482b3a5211adb2ffc184db8"
+version = "1.4.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.4.1#d0018f6575e5d851d0f44a47e22a17e2b405d4e9"
 dependencies = [
  "byteorder",
  "bytes",
@@ -1169,8 +1169,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "1.3.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.3.1#01e72a4b96739c62a482b3a5211adb2ffc184db8"
+version = "1.4.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.4.1#d0018f6575e5d851d0f44a47e22a17e2b405d4e9"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1180,8 +1180,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-proxy"
-version = "0.0.4"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.3.1#01e72a4b96739c62a482b3a5211adb2ffc184db8"
+version = "0.0.5"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.4.1#d0018f6575e5d851d0f44a47e22a17e2b405d4e9"
 dependencies = [
  "bigdecimal",
  "byteorder",
@@ -1201,6 +1201,7 @@ dependencies = [
 name = "scylla-rust-wrapper"
 version = "0.5.1"
 dependencies = [
+ "arc-swap",
  "assert_matches",
  "bindgen",
  "bytes",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.85"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.3.1", features = [
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.4.1", features = [
     "openssl-010",
     "metrics",
 ] }
@@ -29,14 +29,15 @@ tracing = "0.1.37"
 futures = "0.3"
 thiserror = "1.0"
 yoke = { version = "0.8.0", features = ["derive"] }
+arc-swap = "1.3.0"
 
 [build-dependencies]
 bindgen = "0.65"
 chrono = "0.4.20"
 
 [dev-dependencies]
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.3.1" }
-scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.3.1" }
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.4.1" }
+scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.4.1" }
 bytes = "1.10.0"
 itertools = "0.10.3"
 assert_matches = "1.5.0"

--- a/scylla-rust-wrapper/tests/integration/consistency.rs
+++ b/scylla-rust-wrapper/tests/integration/consistency.rs
@@ -34,6 +34,7 @@ use scylla_cpp_driver::api::statement::{
     cass_statement_set_execution_profile, cass_statement_set_serial_consistency,
 };
 use scylla_cpp_driver::argconv::{CConst, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr};
+use scylla_cql::frame::protocol_features::ProtocolFeatures;
 use scylla_proxy::{
     Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
     TargetShard, WorkerError,
@@ -178,7 +179,9 @@ fn check_consistencies(
     mut request_rx: UnboundedReceiver<(RequestFrame, Option<TargetShard>)>,
 ) -> UnboundedReceiver<(RequestFrame, Option<TargetShard>)> {
     let (request_frame, _shard) = request_rx.blocking_recv().unwrap();
-    let deserialized_request = request_frame.deserialize().unwrap();
+    let deserialized_request = request_frame
+        .deserialize(&ProtocolFeatures::default())
+        .unwrap();
     assert_eq!(deserialized_request.get_consistency().unwrap(), consistency);
     assert_eq!(
         deserialized_request.get_serial_consistency().unwrap(),

--- a/tests/src/integration/tests/test_prepared_metadata.cpp
+++ b/tests/src/integration/tests/test_prepared_metadata.cpp
@@ -68,6 +68,12 @@ public:
 CASSANDRA_INTEGRATION_TEST_F(PreparedMetadataTests, AlterDoesntUpdateColumnCount) {
   CHECK_FAILURE;
 
+  // Scylla has support for result metadata id extension in protocol v4.
+  CCM::CassVersion cass_version = this->server_version_;
+  if (Options::is_scylla() && cass_version >= "2025.3.0") {
+      SKIP_TEST_VERSION(cass_version.to_string(), "before 2025.3.0")
+  }
+
   // Ensure beta protocol is not set
   Session session = default_cluster()
                         .with_beta_protocol(false)


### PR DESCRIPTION
This PR updates the driver version to 1.4.1. This update is a bit more complicated than usual, because of result metadata id extension, which we must take care to support correctly.
I introduced a layer that caches computed CassResultMetadata, and recomputes when necessary.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- [x] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
