### PR TITLE
Implement cass_cluster_set_resolve_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
 - cass_cluster_set_queue_size_event
 - cass_cluster_set_queue_size_io
 - cass_cluster_set_reconnect_wait_time
-- cass_cluster_set_resolve_timeout
 - cass_cluster_set_tracing_consistency
 - cass_cluster_set_tracing_max_wait_time
 - cass_cluster_set_tracing_retry_wait_time

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -1925,8 +1925,6 @@ cass_cluster_set_request_timeout(CassCluster* cluster,
 /**
  * Sets the timeout for waiting for DNS name resolution.
  *
- * <b>Warning:</b> This function is not yet implemented.
- *
  * <b>Default:</b> 2000 milliseconds
  *
  * @public @memberof CassCluster

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1124,7 +1124,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scylla"
 version = "1.4.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.4.1#d0018f6575e5d851d0f44a47e22a17e2b405d4e9"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=7e41ad40adc9946c55e2585576cd8a74dc05ce60#7e41ad40adc9946c55e2585576cd8a74dc05ce60"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "scylla-cql"
 version = "1.4.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.4.1#d0018f6575e5d851d0f44a47e22a17e2b405d4e9"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=7e41ad40adc9946c55e2585576cd8a74dc05ce60#7e41ad40adc9946c55e2585576cd8a74dc05ce60"
 dependencies = [
  "byteorder",
  "bytes",
@@ -1170,7 +1170,7 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "1.4.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.4.1#d0018f6575e5d851d0f44a47e22a17e2b405d4e9"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=7e41ad40adc9946c55e2585576cd8a74dc05ce60#7e41ad40adc9946c55e2585576cd8a74dc05ce60"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1181,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "scylla-proxy"
 version = "0.0.5"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.4.1#d0018f6575e5d851d0f44a47e22a17e2b405d4e9"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=7e41ad40adc9946c55e2585576cd8a74dc05ce60#7e41ad40adc9946c55e2585576cd8a74dc05ce60"
 dependencies = [
  "bigdecimal",
  "byteorder",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.85"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.4.1", features = [
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "7e41ad40adc9946c55e2585576cd8a74dc05ce60", features = [
     "openssl-010",
     "metrics",
 ] }
@@ -36,8 +36,8 @@ bindgen = "0.65"
 chrono = "0.4.20"
 
 [dev-dependencies]
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.4.1" }
-scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.4.1" }
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "7e41ad40adc9946c55e2585576cd8a74dc05ce60" }
+scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "7e41ad40adc9946c55e2585576cd8a74dc05ce60" }
 bytes = "1.10.0"
 itertools = "0.10.3"
 assert_matches = "1.5.0"

--- a/scylla-rust-wrapper/src/api.rs
+++ b/scylla-rust-wrapper/src/api.rs
@@ -115,7 +115,7 @@ pub mod cluster {
         // cass_cluster_set_queue_size_io, UNIMPLEMENTED
         // cass_cluster_set_reconnect_wait_time, UNIMPLEMENTED
         cass_cluster_set_request_timeout,
-        // cass_cluster_set_resolve_timeout, UNIMPLEMENTED
+        cass_cluster_set_resolve_timeout,
         cass_cluster_set_retry_policy,
         cass_cluster_set_schema_agreement_interval,
         cass_cluster_set_serial_consistency,


### PR DESCRIPTION
DNS timeouts were recently added to Rust Driver, which allows us to implement the missing function here.
This PR bumps Rust Driver to the commit that contains this new feature, and adds the function.

I did not enable any tests, because I found no tests that use this. I also don't see how I could write them.

Fixes: https://github.com/scylladb/cpp-rs-driver/issues/258

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have implemented Rust unit tests for the features/changes introduced.~~
- [ ] ~~I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
