### PR TITLE
Implement contact point shuffling

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -2485,8 +2485,6 @@ cass_cluster_set_use_schema(CassCluster* cluster,
 /**
  * Enable/Disable the randomization of the contact points list.
  *
- * <b>Warning:</b> This function is not yet implemented.
- *
  * <b>Default:</b> cass_true (enabled).
  *
  * <b>Important:</b> This setting should only be disabled for debugging or

--- a/scylla-rust-wrapper/src/api.rs
+++ b/scylla-rust-wrapper/src/api.rs
@@ -130,7 +130,7 @@ pub mod cluster {
         // cass_cluster_set_tracing_retry_wait_time, UNIMPLEMENTED
         cass_cluster_set_use_beta_protocol_version,
         // cass_cluster_set_use_hostname_resolution, UNIMPLEMENTED
-        // cass_cluster_set_use_randomized_contact_points, UNIMPLEMENTED, stub present
+        cass_cluster_set_use_randomized_contact_points,
         cass_cluster_set_use_schema,
         cass_cluster_set_whitelist_dc_filtering,
         cass_cluster_set_whitelist_dc_filtering_n,
@@ -987,7 +987,6 @@ pub mod integration_testing {
         cass_cluster_set_queue_size_io,
         cass_cluster_set_cloud_secure_connection_bundle_n,
         cass_cluster_set_exponential_reconnect,
-        cass_cluster_set_use_randomized_contact_points,
         cass_custom_payload_new,
         cass_function_meta_name,
         cass_future_custom_payload_item,

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -14,6 +14,8 @@ use crate::timestamp_generator::CassTimestampGen;
 use crate::types::*;
 use openssl::ssl::SslContextBuilder;
 use openssl_sys::SSL_CTX_up_ref;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
 use scylla::client::execution_profile::ExecutionProfileBuilder;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::client::{PoolSize, SelfIdentity, WriteCoalescingDelay};
@@ -104,6 +106,7 @@ pub struct CassCluster {
     auth_password: Option<String>,
 
     client_id: Option<uuid::Uuid>,
+    shuffle_contact_points: bool,
 }
 
 impl CassCluster {
@@ -179,13 +182,21 @@ impl CassCluster {
     // We want to make sure that the returned future does not depend
     // on the provided &CassCluster, hence the `static here.
     pub(crate) fn build_session_builder(&self) -> impl Future<Output = SessionBuilder> + 'static {
+        let mut execution_profile_builder = self.default_execution_profile_builder.clone();
+        let load_balancing_config = self.load_balancing_config.clone();
+        let mut session_builder = self.session_builder.clone();
         let known_nodes = self
             .contact_points
             .iter()
             .map(|cp| format!("{}:{}", cp, self.port));
-        let mut execution_profile_builder = self.default_execution_profile_builder.clone();
-        let load_balancing_config = self.load_balancing_config.clone();
-        let mut session_builder = self.session_builder.clone().known_nodes(known_nodes);
+        if self.shuffle_contact_points {
+            let mut collected_contact_points = known_nodes.collect::<Vec<_>>();
+            collected_contact_points.shuffle(&mut thread_rng());
+            session_builder = session_builder.known_nodes(collected_contact_points);
+        } else {
+            session_builder = session_builder.known_nodes(known_nodes);
+        }
+
         if let (Some(username), Some(password)) = (&self.auth_username, &self.auth_password) {
             session_builder = session_builder.user(username, password)
         }
@@ -347,6 +358,7 @@ pub unsafe extern "C" fn cass_cluster_new() -> CassOwnedExclusivePtr<CassCluster
         execution_profile_map: Default::default(),
         load_balancing_config: Default::default(),
         client_id: None,
+        shuffle_contact_points: true,
     }))
 }
 
@@ -534,6 +546,21 @@ pub unsafe extern "C" fn cass_cluster_set_use_schema(
     };
 
     cluster.session_builder.config.fetch_schema_metadata = enabled != 0;
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cass_cluster_set_use_randomized_contact_points(
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
+    enabled: cass_bool_t,
+) -> CassError {
+    let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
+        tracing::error!("Provided null cluster pointer to cass_cluster_set_use_schema!");
+        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    };
+
+    cluster.shuffle_contact_points = enabled == cass_true;
+
+    CassError::CASS_OK
 }
 
 #[unsafe(no_mangle)]

--- a/scylla-rust-wrapper/src/testing/integration.rs
+++ b/scylla-rust-wrapper/src/testing/integration.rs
@@ -401,16 +401,6 @@ pub(crate) mod stubs {
     pub struct CassCustomPayload;
 
     #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn cass_cluster_set_use_randomized_contact_points(
-        _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-        _enabled: cass_bool_t,
-    ) -> CassError {
-        // FIXME: should set `use_randomized_contact_points` flag in cluster config
-
-        CassError::CASS_OK
-    }
-
-    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn cass_cluster_set_cloud_secure_connection_bundle(
         cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
         path: *const c_char,


### PR DESCRIPTION
It is done in a simple way - by just shuffling the list before passing it to Rust Driver. This matches the cpp-driver implementation.

A possibly better way is to implement ContronConnectionPolicy in Rust Driver, and use it here to make shuffling possible for all hosts (not only contact points) and re-shuffle each time CC is broken. This is a greater effort, so for now lets go with cpp-driver impl.

I wanted to enable `CASSANDRA_INTEGRATION_TEST_F(ControlConnectionFourNodeClusterTests, RandomizedContactPoints)`, but it assumes that round robin policy is actually round robin, which is not the case for our fork. I also fail to see how this test verifies contact point randomization.

After merging, I'll open and issue about improving this mechanism in the futre using CCPolicy.

Fixes: https://github.com/scylladb/cpp-rs-driver/issues/241

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- [ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
- [x] I added appropriate `Fixes:` annotations to PR description.
