### PR TITLE
Add reconnect policy configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ControlConnectionTests.Integration_Cassandra_TerminatedUsingMultipleIoThreadsWithError\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionAlreadyExists\
-:MetricsTests.Integration_Cassandra_StatsConnections\
 :MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests\
 :*NoCompactEnabledConnection\
 :PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount)
@@ -111,7 +110,6 @@ CASSANDRA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionAlreadyExists\
 :SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart\
-:MetricsTests.Integration_Cassandra_StatsConnections\
 :MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests\
 :*NoCompactEnabledConnection\
 :PreparedMetadataTests.Integration_Cassandra_AlterProperlyUpdatesColumnCount)

--- a/README.md
+++ b/README.md
@@ -267,7 +267,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
 - cass_cluster_set_prepare_on_up_or_add_host
 - cass_cluster_set_queue_size_event
 - cass_cluster_set_queue_size_io
-- cass_cluster_set_reconnect_wait_time
 - cass_cluster_set_tracing_consistency
 - cass_cluster_set_tracing_max_wait_time
 - cass_cluster_set_tracing_retry_wait_time

--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
 - cass_cluster_set_cloud_secure_connection_bundle_n
 - cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init
 - cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init_n
-- cass_cluster_set_constant_reconnect
 - cass_cluster_set_host_listener_callback
 - cass_cluster_set_max_concurrent_creation
 - cass_cluster_set_max_concurrent_requests_threshold

--- a/README.md
+++ b/README.md
@@ -253,7 +253,6 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
 - cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init
 - cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init_n
 - cass_cluster_set_constant_reconnect
-- cass_cluster_set_exponential_reconnect
 - cass_cluster_set_host_listener_callback
 - cass_cluster_set_max_concurrent_creation
 - cass_cluster_set_max_concurrent_requests_threshold

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -1819,8 +1819,6 @@ cass_cluster_set_reconnect_wait_time(CassCluster* cluster,
  *
  * @public @memberof CassCluster
  *
- * <b>Warning:</b> This function is not yet implemented.
- *
  * @param[in] cluster
  * @param[in] delay_ms Time in milliseconds to delay attempting a reconnection;
  * 0 to perform a reconnection immediately.

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -1834,8 +1834,6 @@ cass_cluster_set_constant_reconnect(CassCluster* cluster,
  * longer between each reconnection attempt; however will maintain a constant
  * delay once the maximum delay is reached.
  *
- * <b>Warning:</b> This function is not yet implemented.
- *
  * <b>Default:</b>
  * <ul>
  *   <li>2000 milliseconds base delay</li>

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1124,7 +1124,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scylla"
 version = "1.4.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=530dbfa7c9df0d7d863e2a11691ed95f7ad429ae#530dbfa7c9df0d7d863e2a11691ed95f7ad429ae"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=4f02969823f7b07b0d6b007a11863fe4aac95821#4f02969823f7b07b0d6b007a11863fe4aac95821"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "scylla-cql"
 version = "1.4.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=530dbfa7c9df0d7d863e2a11691ed95f7ad429ae#530dbfa7c9df0d7d863e2a11691ed95f7ad429ae"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=4f02969823f7b07b0d6b007a11863fe4aac95821#4f02969823f7b07b0d6b007a11863fe4aac95821"
 dependencies = [
  "byteorder",
  "bytes",
@@ -1170,7 +1170,7 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "1.4.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=530dbfa7c9df0d7d863e2a11691ed95f7ad429ae#530dbfa7c9df0d7d863e2a11691ed95f7ad429ae"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=4f02969823f7b07b0d6b007a11863fe4aac95821#4f02969823f7b07b0d6b007a11863fe4aac95821"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1181,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "scylla-proxy"
 version = "0.0.5"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=530dbfa7c9df0d7d863e2a11691ed95f7ad429ae#530dbfa7c9df0d7d863e2a11691ed95f7ad429ae"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=4f02969823f7b07b0d6b007a11863fe4aac95821#4f02969823f7b07b0d6b007a11863fe4aac95821"
 dependencies = [
  "bigdecimal",
  "byteorder",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -11,11 +11,12 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.85"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "530dbfa7c9df0d7d863e2a11691ed95f7ad429ae", features = [
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "4f02969823f7b07b0d6b007a11863fe4aac95821", features = [
     "openssl-010",
     "metrics",
     "unstable-cpp-rs",
     "unstable-host-listener",
+    "unstable-reconnect-policy"
 ] }
 tokio = { version = "1.27.0", features = ["full"] }
 uuid = "1.1.2"
@@ -38,8 +39,8 @@ bindgen = "0.65"
 chrono = "0.4.20"
 
 [dev-dependencies]
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "530dbfa7c9df0d7d863e2a11691ed95f7ad429ae" }
-scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "530dbfa7c9df0d7d863e2a11691ed95f7ad429ae" }
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "4f02969823f7b07b0d6b007a11863fe4aac95821" }
+scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "4f02969823f7b07b0d6b007a11863fe4aac95821" }
 bytes = "1.10.0"
 itertools = "0.10.3"
 assert_matches = "1.5.0"

--- a/scylla-rust-wrapper/src/api.rs
+++ b/scylla-rust-wrapper/src/api.rs
@@ -113,7 +113,7 @@ pub mod cluster {
         cass_cluster_set_protocol_version,
         cass_cluster_set_queue_size_event, // No-op both in CPP and in the wrapper.
         // cass_cluster_set_queue_size_io, UNIMPLEMENTED
-        // cass_cluster_set_reconnect_wait_time, UNIMPLEMENTED
+        cass_cluster_set_reconnect_wait_time,
         cass_cluster_set_request_timeout,
         cass_cluster_set_resolve_timeout,
         cass_cluster_set_retry_policy,

--- a/scylla-rust-wrapper/src/api.rs
+++ b/scylla-rust-wrapper/src/api.rs
@@ -71,7 +71,7 @@ pub mod cluster {
         cass_cluster_set_connection_heartbeat_interval,
         cass_cluster_set_connection_idle_timeout,
         cass_cluster_set_consistency,
-        // cass_cluster_set_constant_reconnect, UNIMPLEMENTED
+        cass_cluster_set_constant_reconnect,
         cass_cluster_set_contact_points,
         cass_cluster_set_contact_points_n,
         cass_cluster_set_constant_speculative_execution_policy,

--- a/scylla-rust-wrapper/src/api.rs
+++ b/scylla-rust-wrapper/src/api.rs
@@ -81,7 +81,7 @@ pub mod cluster {
         cass_cluster_set_credentials_n,
         cass_cluster_set_execution_profile,
         cass_cluster_set_execution_profile_n,
-        // cass_cluster_set_exponential_reconnect, UNIMPLEMENTED, stub present
+        cass_cluster_set_exponential_reconnect,
         cass_cluster_set_host_listener_callback,
         cass_cluster_set_latency_aware_routing,
         cass_cluster_set_latency_aware_routing_settings,
@@ -985,7 +985,6 @@ pub mod integration_testing {
         cass_cluster_set_cloud_secure_connection_bundle,
         cass_cluster_set_queue_size_io,
         cass_cluster_set_cloud_secure_connection_bundle_n,
-        cass_cluster_set_exponential_reconnect,
         cass_custom_payload_new,
         cass_function_meta_name,
         cass_future_custom_payload_item,

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -1630,6 +1630,14 @@ pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn cass_cluster_set_reconnect_wait_time(
+    cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
+    wait_time_ms: c_uint,
+) {
+    unsafe { cass_cluster_set_constant_reconnect(cluster_raw, wait_time_ms.into()) }
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_constant_reconnect(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
     wait_time_ms: cass_uint64_t,

--- a/scylla-rust-wrapper/src/testing/integration.rs
+++ b/scylla-rust-wrapper/src/testing/integration.rs
@@ -426,35 +426,6 @@ pub(crate) mod stubs {
     }
 
     #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn cass_cluster_set_exponential_reconnect(
-        _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-        base_delay_ms: cass_uint64_t,
-        max_delay_ms: cass_uint64_t,
-    ) -> CassError {
-        if base_delay_ms <= 1 {
-            // Base delay must be greater than 1
-            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
-        }
-
-        if max_delay_ms <= 1 {
-            // Max delay must be greater than 1
-            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
-        }
-
-        if max_delay_ms < base_delay_ms {
-            // Max delay cannot be less than base delay
-            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
-        }
-
-        // FIXME: should set exponential reconnect with base_delay_ms and max_delay_ms
-        /*
-        cluster->config().set_exponential_reconnect(base_delay_ms, max_delay_ms);
-        */
-
-        CassError::CASS_OK
-    }
-
-    #[unsafe(no_mangle)]
     pub extern "C" fn cass_custom_payload_new() -> *const CassCustomPayload {
         // FIXME: should create a new custom payload that must be freed
         std::ptr::null()

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -58,9 +58,6 @@ CASS_EXPORT CassError cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib
   throw std::runtime_error(
       "UNIMPLEMENTED cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init\n");
 }
-CASS_EXPORT void cass_cluster_set_constant_reconnect(CassCluster* cluster, cass_uint64_t delay_ms) {
-  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_constant_reconnect\n");
-}
 CASS_EXPORT CassError cass_cluster_set_no_compact(CassCluster* cluster, cass_bool_t enabled) {
   throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_no_compact\n");
 }

--- a/tests/src/integration/tests/test_metrics.cpp
+++ b/tests/src/integration/tests/test_metrics.cpp
@@ -47,16 +47,18 @@ CASSANDRA_INTEGRATION_TEST_F(MetricsTests, StatsConnections) {
                         .with_constant_reconnect(10)
                         .connect(); // low reconnect for faster node restart
 
+  // All expected values are greater by 1 than in cpp-driver.
+  // This is caused by Rust Driver including Control Connection in the metrics.
   CassMetrics metrics = session.metrics();
-  EXPECT_EQ(2u, metrics.stats.total_connections);
+  EXPECT_EQ(3u, metrics.stats.total_connections);
 
   stop_node(1);
   metrics = session.metrics();
-  EXPECT_EQ(1u, metrics.stats.total_connections);
+  EXPECT_EQ(2u, metrics.stats.total_connections);
 
   start_node(1);
   metrics = session.metrics();
-  EXPECT_EQ(2u, metrics.stats.total_connections);
+  EXPECT_EQ(3u, metrics.stats.total_connections);
 }
 
 /**


### PR DESCRIPTION
This PR introduces configuration for reconnect policies, that were recently added as unstable feature in Rust Driver.
All 3 functions are added. 
`cass_cluster_set_reconnect_wait_time` is an alias for `cass_cluster_set_constant_reconnect`. This is done same way in cpp-driver.
`cass_cluster_set_exponential_reconnect` performs validation of its arguments, in order to avoid throwing Rust panic in case of invalid args.

## Tests
I found all tests that configure the reconnect policy, executed them, and investigated the result.

(ControlConnectionTwoNodeClusterTests, Reconnection) - uses Cassandra-specific config values
(ControlConnectionTwoNodeClusterTests, StatusChange) - Waits for specific log messages. I changed them to the new debug logs introduced in Rust Driver, but it did not work. Maybe debug-level messages are not captured by the test harness? idk. Even if this part worked, we would need to fix `check_hosts` function used by the tests. It assumes Round Robin policy.
(ControlConnectionTests, FullOutage) - Also uses the logger and `check_hosts`, so I expect the same problems as above.
(MetricsTests, StatsConnections) - WORKS, required changing values (most likely because Rust Driver takes metrics also for CC). I made the change and enabled it.
(PrepareOnAllTests, *): It looks like Scylla doesn't support `prepared_statements` table and the tests use it.
(PrepareOnUpAndAddTests, *): Same as above. Also I don't expect them to pass because we don't support re-prepare on upp/add (and don't plan to).
(SslTests, ReconnectAfterClusterCrashAndRestart):
```
[----------] 1 test from SslTests
[ RUN      ] SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart
1765803052612 [DEBUG] (scylla_cpp_driver::logging:177) message: Log level is set to TRACE
ccm> ccm list
ccm> ccm list
ccm> ccm list
ccm> ccm stop
ccm> ccm status
ccm> ccm create --scylla -n 1:0 -i 127.0.0. -v release:2025.3 -b --ssl=/tmp/ssl cpp-driver_2025-3-0_1-0-ssl
/home/karolbaryla/repos/cpp-rust-driver/tests/src/integration/integration.cpp:192: Failure
Failed
Traceback (most recent call last):
  File "/nix/store/7s0dd9crwvx17pccp2r7w89vdwqcnz2m-scylla_ccm-0.1/bin/..ccm-wrapped-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/7s0dd9crwvx17pccp2r7w89vdwqcnz2m-scylla_ccm-0.1/lib/python3.11/site-packages/ccmlib/bin/__init__.py", line 75, in main
    cmd.run()
  File "/nix/store/7s0dd9crwvx17pccp2r7w89vdwqcnz2m-scylla_ccm-0.1/lib/python3.11/site-packages/ccmlib/cmds/cluster_cmds.py", line 258, in run
    cluster.enable_ssl(self.options.ssl_path, self.options.require_client_auth)
  File "/nix/store/7s0dd9crwvx17pccp2r7w89vdwqcnz2m-scylla_ccm-0.1/lib/python3.11/site-packages/ccmlib/scylla_cluster.py", line 243, in enable_ssl
    raise FileNotFoundError(f"Required SSL file not found: {file_path}")
FileNotFoundError: Required SSL file not found: /tmp/ssl/ccm_node.pem

[  FAILED  ] SslTests.Integration_Cassandra_ReconnectAfterClusterCrashAndRestart (14525 ms)
[----------] 1 test from SslTests (14525 ms total)
```

The path passed to CCM looks weird, like a slash was replaced with space: `--ssl=/tmp/ssl cpp-driver_2025-3-0_1-0-ssl`
My guess is that we have a bug in test utils that setup the SSL-enabled cluster. It is worth looking into, but out of scope for this PR.

Fixes: https://github.com/scylladb/cpp-rs-driver/issues/264

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- [x] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
- [x] I added appropriate `Fixes:` annotations to PR description.
