### PR TITLE
Block running `cmake` targeting root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ log/
 docs/source/api
 doxygen/xml
 
+# Leftovers from manually running `cmake`
+CMakeCache.txt
+CMakeFiles/
+
 # Codex / MCP
 .codex/
 .codex-cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,13 @@ option(CASS_USE_LIBUV "Use libuv" OFF)
 
 set(CASS_CPP_STANDARD "11" CACHE STRING "C++ standard (11, 14, 17, etc.)")
 
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+  message(FATAL_ERROR
+          "In-source builds are not allowed.\n"
+          "Use: cmake -S . -B build"
+  )
+endif()
+
 if(CASS_BUILD_SHARED)
   set(BUILD_SHARED_LIBS ON)
 endif()


### PR DESCRIPTION
If you run raw `cmake` it messes up the root directory.
ASAIK there is no way to default to certain directory, so it should not be allowed.
This PR makes `cmake` block such runs

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have implemented Rust unit tests for the features/changes introduced.~~
- [ ] ~~I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
