### PR TITLE
Make `make run-integration-test` do not try to update rust

### DIFF
--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -126,11 +126,8 @@ jobs:
           path: ${{ env.INTEGRATION_TEST_BIN }}
           key: ${{ env.INTEGRATION_TEST_BIN_CACHE_KEY }}
 
-      - name: Install valgrind
-        run: make install-valgrind-if-missing
-
-      - name: Install binary dependencies
-        run: make install-bin-dependencies
+      - name: Prepare environment
+        run: make update-rust-tooling prepare-integration-test
 
       - name: Run integration tests on Scylla ${{ steps.scylla-version.outputs.value }}
         id: run-integration-tests
@@ -217,11 +214,8 @@ jobs:
           path: ${{ env.INTEGRATION_TEST_BIN }}
           key: ${{ env.INTEGRATION_TEST_BIN_CACHE_KEY }}
 
-      - name: Install valgrind
-        run: make install-valgrind-if-missing
-
-      - name: Install binary dependencies
-        run: make install-bin-dependencies
+      - name: Prepare environment
+        run: make update-rust-tooling prepare-integration-test
 
       - name: Run integration tests on Cassandra ${{ steps.cassandra-version.outputs.value }}
         id: run-integration-tests

--- a/Makefile
+++ b/Makefile
@@ -259,11 +259,11 @@ build-examples:
 		cmake -DCASS_BUILD_INTEGRATION_TESTS=off -DCASS_BUILD_EXAMPLES=on -DCMAKE_BUILD_TYPE=Release .. && (make -j 4 || make);\
 	}
 
-_update-rust-tooling:
+update-rust-tooling:
 	@echo "Run rustup update"
 	@rustup update stable
 
-check-cargo: install-cargo-if-missing _update-rust-tooling
+check-cargo: install-cargo-if-missing
 	@echo "Running \"cargo check\" in ./scylla-rust-wrapper"
 	@cd ${CURRENT_DIR}/scylla-rust-wrapper; cargo check --all-targets
 
@@ -271,19 +271,19 @@ fix-cargo:
 	@echo "Running \"cargo fix --verbose --all\" in ./scylla-rust-wrapper"
 	@cd ${CURRENT_DIR}/scylla-rust-wrapper; cargo fix --verbose --all
 
-check-cargo-clippy: install-cargo-if-missing _update-rust-tooling
+check-cargo-clippy: install-cargo-if-missing
 	@echo "Running \"cargo clippy --verbose --all-targets -- -D warnings -Aclippy::uninlined_format_args\" in ./scylla-rust-wrapper"
 	@cd ${CURRENT_DIR}/scylla-rust-wrapper; RUSTFLAGS="${FULL_RUSTFLAGS}" cargo clippy --verbose --all-targets -- -D warnings -Aclippy::uninlined_format_args
 
-fix-cargo-clippy: install-cargo-if-missing _update-rust-tooling
+fix-cargo-clippy: install-cargo-if-missing
 	@echo "Running \"cargo clippy --verbose --all-targets --fix -- -D warnings -Aclippy::uninlined_format_args\" in ./scylla-rust-wrapper"
 	@cd ${CURRENT_DIR}/scylla-rust-wrapper; cargo clippy --verbose --all-targets --fix -- -D warnings -Aclippy::uninlined_format_args
 
-check-cargo-fmt: install-cargo-if-missing _update-rust-tooling
+check-cargo-fmt: install-cargo-if-missing
 	@echo "Running \"cargo fmt --verbose --all -- --check\" in ./scylla-rust-wrapper"
 	@cd ${CURRENT_DIR}/scylla-rust-wrapper; cargo fmt --verbose --all -- --check
 
-fix-cargo-fmt: install-cargo-if-missing _update-rust-tooling
+fix-cargo-fmt: install-cargo-if-missing
 	@echo "Running \"cargo fmt --verbose --all\" in ./scylla-rust-wrapper"
 	@cd ${CURRENT_DIR}/scylla-rust-wrapper; cargo fmt --verbose --all
 
@@ -299,9 +299,15 @@ check: check-clang-format check-cargo check-cargo-clippy check-cargo-fmt
 
 fix: fix-clang-format fix-cargo fix-cargo-clippy fix-cargo-fmt
 
-prepare-integration-test: update-apt-cache-if-needed install-valgrind-if-missing install-cargo-if-missing _update-rust-tooling
-	@sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
+.prepare-environment-update-aio-max-nr:
+	@if (( $$(< /proc/sys/fs/aio-max-nr) < 2097152 )); then \
+		echo 2097152 | sudo tee /proc/sys/fs/aio-max-nr >/dev/null; \
+	fi
+
+.prepare-environment-install-libc:
 	@dpkg -l libc6-dbg >/dev/null 2>&1 || sudo apt-get install -y libc6-dbg
+
+prepare-integration-test: .prepare-environment-install-libc update-apt-cache-if-needed install-valgrind-if-missing install-cargo-if-missing
 
 download-ccm-scylla-image: install-ccm-if-missing
 	@echo "Downloading scylla ${SCYLLA_VERSION} CCM image"
@@ -317,7 +323,7 @@ download-ccm-cassandra-image: install-ccm-if-missing
 	@ccm create ccm_1 -i 127.0.1. -n 3:0 -v "${CASSANDRA_VERSION}" --config-dir=/tmp/download-cassandra.ccm
 	@rm -rf /tmp/download-cassandra.ccm
 
-run-test-integration-scylla: prepare-integration-test download-ccm-scylla-image
+run-test-integration-scylla: .prepare-environment-update-aio-max-nr
 ifdef DONT_REBUILD_INTEGRATION_BIN
 run-test-integration-scylla: build-integration-test-bin-if-missing
 else
@@ -328,7 +334,7 @@ endif
 	@echo "Running timeout sensitive tests on scylla ${SCYLLA_VERSION}"
 	build/cassandra-integration-tests --scylla --version=${SCYLLA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${SCYLLA_NO_VALGRIND_TEST_FILTER}"
 
-run-test-integration-cassandra: prepare-integration-test download-ccm-cassandra-image install-java8-if-missing
+run-test-integration-cassandra: install-java8-if-missing
 ifdef DONT_REBUILD_INTEGRATION_BIN
 run-test-integration-cassandra: build-integration-test-bin-if-missing
 else
@@ -339,7 +345,7 @@ endif
 	@echo "Running timeout sensitive tests on cassandra ${CASSANDRA_VERSION}"
 	build/cassandra-integration-tests --version=${CASSANDRA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${CASSANDRA_NO_VALGRIND_TEST_FILTER}"
 
-run-test-unit: install-cargo-if-missing _update-rust-tooling
+run-test-unit: install-cargo-if-missing
 	@cd ${CURRENT_DIR}/scylla-rust-wrapper; RUSTFLAGS="${FULL_RUSTFLAGS}" cargo test
 
 # Currently not used.


### PR DESCRIPTION
It is frustrating, we should not do it.

Fixes: https://github.com/scylladb/cpp-rs-driver/issues/401
## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have implemented Rust unit tests for the features/changes introduced.~~
- [ ] ~~I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
