### PR TITLE
Release 0.6.0

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-rust-wrapper"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arc-swap",
  "assert_matches",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-rust-wrapper"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"
 repository = "https://github.com/scylladb/scylla-rust-driver"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB CPP RS Driver 0.6.0, an API-compatible rewrite of https://github.com/scylladb/cpp-driver as a wrapper for the Rust driver. It will fully replace the CPP driver, which is already reaching its End of Life.
**The current driver version should be considered Beta**.

Some minor features still need to be included. See Limitations section in README.md.

The underlying Rust driver used version: 4f02969823f7b07b0d6b007a11863fe4aac95821 (not yet released commit from main branch).

## Changes

**Big changes on our way to 1.0:**
- Declared MSRV (currently 1.85) ([#371](https://github.com/scylladb/cpp-rs-driver/pull/371)).
- Updated wrapper package name to scylla-rust-wrapper ([#381](https://github.com/scylladb/cpp-rs-driver/pull/381)).
- Categorized unimplemented functions ([#382](https://github.com/scylladb/cpp-rs-driver/pull/382)).
- Rename from cpp-rust-driver to cpp-rs-driver ([#370](https://github.com/scylladb/cpp-rs-driver/pull/370)).

**New features / enhancements:**
- Added API to specify metadata request timeout ([#353](https://github.com/scylladb/cpp-rs-driver/pull/353)).
- Implemented `cass_cluster_set_num_threads_io` ([#354](https://github.com/scylladb/cpp-rs-driver/pull/354)).
- Changed default serial consistency to `LOCAL_SERIAL` to prevent failures when executing LWTs without specifying serial consistency explicitly ([#369](https://github.com/scylladb/cpp-rs-driver/pull/369)).
- Messages are now logged upon errors ([#378](https://github.com/scylladb/cpp-rs-driver/pull/378)).
- Implemented `cass_cluster_set_host_listener_callback` ([#398](https://github.com/scylladb/cpp-rs-driver/pull/398)).
- Updated Rust driver to 1.3.1 ([#380](https://github.com/scylladb/cpp-rs-driver/pull/380)) and to 1.4.1 ([#391](https://github.com/scylladb/cpp-rs-driver/pull/391)).
- Implemented `cass_cluster_set_resolve_timeout` ([#393](https://github.com/scylladb/cpp-rs-driver/pull/393)).
- Implemented contact point shuffling ([#396](https://github.com/scylladb/cpp-rs-driver/pull/396)).
- Implemented APIs for configuring reconnect policy ([#402](https://github.com/scylladb/cpp-rs-driver/pull/402)).

**Bug fixes:**
- Made Rust errors conversion to `CassError` more appropriate ([#352](https://github.com/scylladb/cpp-rs-driver/pull/352)).
- Fixed panic upon runtime drop from async context ([#363](https://github.com/scylladb/cpp-rs-driver/pull/363)).

**Documentation:**
- Introduced docs from CPP Driver and adjust ([#357](https://github.com/scylladb/cpp-rs-driver/pull/357)).
- Fixed docs build ([#367](https://github.com/scylladb/cpp-rs-driver/pull/367)).
- Updated README.md ([#372](https://github.com/scylladb/cpp-rs-driver/pull/372)).
- Styled API reference docs ([#386](https://github.com/scylladb/cpp-rs-driver/pull/386)).

**CI / developer tool improvements:**
- Examples are now run in CI ([#336](https://github.com/scylladb/cpp-rs-driver/pull/336)).
- Removed old OSS Scyllas from CI workflows ([#348](https://github.com/scylladb/cpp-rs-driver/pull/348)).

**Others:**
- Appeased clippy 1.89 ([#359](https://github.com/scylladb/cpp-rs-driver/pull/359)).
- Restructured modules & move some session tests to integration ([#375](https://github.com/scylladb/cpp-rs-driver/pull/375)).

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/cpp-rs-driver](https://github.com/scylladb/cpp-rs-driver)

Contributions are most welcome!

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:

| commits | author            |
|---------|-------------------|
|   149 | Wojciech Przytuła |
|    12  | Karol Baryła |
|     9   | Dmitry Kropachev |
|    5    | David Garcia |
|    4    | dependabot[bot] |


```