### PR TITLE
Release 1.0.0

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -51,9 +51,9 @@
  * over the Cassandra Binary Protocol (versions 1, 2, or 3).
  */
 
-#define CASS_VERSION_MAJOR 2
-#define CASS_VERSION_MINOR 16
-#define CASS_VERSION_PATCH 1
+#define CASS_VERSION_MAJOR 1
+#define CASS_VERSION_MINOR 0
+#define CASS_VERSION_PATCH 0
 #define CASS_VERSION_SUFFIX ""
 
 #ifdef __cplusplus

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-rust-wrapper"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "arc-swap",
  "assert_matches",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-rust-wrapper"
-version = "0.6.0"
+version = "1.0.0"
 edition = "2024"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"
 repository = "https://github.com/scylladb/scylla-rust-driver"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB CPP RS Driver 1.0.0, an API-compatible rewrite of https://github.com/scylladb/cpp-driver as a wrapper for the Rust driver. It fully replaces the CPP driver, which has already reached its End of Life.

Some minor features still need to be included. See Limitations section in README.md.

The underlying Rust driver used version: 1.5.0.

## Changes since 0.6.0:

**Big changes on our way to 1.0:**
- Switched to CPack for packaging. The new release process is more robust; involves testing that the deployment package is installable and that a simple test app works after installation ([#379](https://github.com/scylladb/cpp-rs-driver/pull/379)).

**Bug fixes:**
- Fixed index out of bounds panic when map collection has odd items ([#412](https://github.com/scylladb/cpp-rs-driver/pull/412)).

**Documentation:**
- Migrated docs to UV ([#410](https://github.com/scylladb/cpp-rs-driver/pull/410)).

**CI / developer tool improvements:**
- Blocked running `cmake` targeting root directory ([#403](https://github.com/scylladb/cpp-rs-driver/pull/403)).
- `make run-integration-test` no longer tries to update rust ([#406](https://github.com/scylladb/cpp-rs-driver/pull/406)).
- Fixed flaky unit tests due to port conflicts ([#414](https://github.com/scylladb/cpp-rs-driver/pull/414)).
- Fixed metrics test and fixed faulty CI  ([#420](https://github.com/scylladb/cpp-rs-driver/pull/420)).

**Others:**
- Bumped rust driver to 1.5.0 and bumped other dependencies ([#418](https://github.com/scylladb/cpp-rs-driver/pull/418)).


Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/cpp-rs-driver](https://github.com/scylladb/cpp-rs-driver)

Contributions are most welcome!

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!

Contributors since the last release:
| commits | author            |
|---------|-------------------|
|    16   | Dmitry Kropachev |
|     6   | Wojciech Przytuła |
|     4   | Karol Baryła |
