### PR TITLE
Fix metrics test and fix faulty CI 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ SPACE := ${EMPTY} ${EMPTY}
 .ONESHELL:
 
 SHELL := bash
+.SHELLFLAGS := -ec
 ifeq ($(OS),Windows_NT)
     SHELL := pwsh.exe
-    .SHELLFLAGS := -NoProfile -Command
+    .SHELLFLAGS := -NoProfile -Command $$ErrorActionPreference = 'Stop';
 endif
 
 UNAME_S := $(shell uname -s)

--- a/tests/src/integration/tests/test_metrics.cpp
+++ b/tests/src/integration/tests/test_metrics.cpp
@@ -47,18 +47,16 @@ CASSANDRA_INTEGRATION_TEST_F(MetricsTests, StatsConnections) {
                         .with_constant_reconnect(10)
                         .connect(); // low reconnect for faster node restart
 
-  // All expected values are greater by 1 than in cpp-driver.
-  // This is caused by Rust Driver including Control Connection in the metrics.
   CassMetrics metrics = session.metrics();
-  EXPECT_EQ(3u, metrics.stats.total_connections);
+  EXPECT_EQ(2u, metrics.stats.total_connections);
 
   stop_node(1);
   metrics = session.metrics();
-  EXPECT_EQ(2u, metrics.stats.total_connections);
+  EXPECT_EQ(1u, metrics.stats.total_connections);
 
   start_node(1);
   metrics = session.metrics();
-  EXPECT_EQ(3u, metrics.stats.total_connections);
+  EXPECT_EQ(2u, metrics.stats.total_connections);
 }
 
 /**


### PR DESCRIPTION
Just before releasing 1.0.0, I was looking at the running CI integration tests action. Suddenly, I saw a test failing. **Yet then the CI run succeeded**!

We discovered that the make recipe for running integration tests, which is used by the CI, keeps running even if some earlier subcommand in that recipe, including the main part of integration tests run under valgrind, fails with a nonzero code.
The culprit was found to be `.ONESHELL` directive on top of the Makefile, combined with lack of the `-e` option set in the run shells. Adding `-e` option to `.SHELLFLAGS` fixed the issue.

The test (from MetricsTest) was failing due to recent change in Rust Driver. Adjusting it was trivial.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
