### PR TITLE
Makefile: exclude smoke test app packages from release artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -655,13 +655,12 @@ collect-package-artifacts:
 ifeq ($(OS_TYPE),windows)
 	@pwsh -NoProfile -Command " \
 		New-Item -ItemType Directory -Path artifacts\windows -Force | Out-Null; \
-		Get-ChildItem build -Filter *.msi | Copy-Item -Destination artifacts\windows; \
-		Get-ChildItem $(SMOKE_TEST_DIR)/build -Filter *.msi -ErrorAction SilentlyContinue | Copy-Item -Destination artifacts\windows"
+		Get-ChildItem build -Filter *.msi | Copy-Item -Destination artifacts\windows"
 else ifeq ($(OS_TYPE),macos)
 	@set -euo pipefail
 	shopt -s nullglob
 	mkdir -p artifacts/macos
-	for file in build/*.pkg build/*.dmg $(SMOKE_TEST_DIR)/build/*.pkg $(SMOKE_TEST_DIR)/build/*.dmg; do
+	for file in build/*.pkg build/*.dmg; do
 		cp "$$file" artifacts/macos/
 	done
 else


### PR DESCRIPTION
## Summary
- Remove smoke test app package paths from `collect-package-artifacts` target on Windows and macOS
- This prevents smoke test app packages from being uploaded to GitHub release assets
- Linux artifact collection was already correct (only collected from `build/`)

Fixes #421