### PR TITLE
IT: fix flaky HeartbeatTests.HeartbeatFailed test

### DIFF
--- a/tests/src/integration/tests/test_heartbeat.cpp
+++ b/tests/src/integration/tests/test_heartbeat.cpp
@@ -84,8 +84,12 @@ CASSANDRA_INTEGRATION_TEST_F(HeartbeatTests, HeartbeatFailed) {
   CHECK_FAILURE;
 
   logger_.add_critera("Timed out while waiting for response to keepalive request");
-  Cluster cluster =
-      default_cluster().with_connection_heartbeat_interval(1).with_connection_idle_timeout(5);
+  // Use 1 connection per host to avoid asynchronous shard-aware connection
+  // establishment that could race with the baseline connection count read.
+  Cluster cluster = default_cluster()
+                        .with_core_connections_per_host(1)
+                        .with_connection_heartbeat_interval(1)
+                        .with_connection_idle_timeout(5);
   connect(cluster);
 
   cass_uint64_t initial_connections = session_.metrics().stats.total_connections;


### PR DESCRIPTION
## Summary
- Fix flaky `HeartbeatTests.Integration_Cassandra_HeartbeatFailed` test by using 1 connection per host (`with_core_connections_per_host(1)`) instead of the default per-shard pool
- The default pool size causes asynchronous shard-aware connection establishment to race with the baseline `total_connections` count read, making the count non-deterministic and the assertion flaky

Fixes #395

## Test plan
- [x] Run `HeartbeatTests.Integration_Cassandra_HeartbeatFailed` repeatedly to verify it no longer flakes