### PR TITLE
doc: publish the docs for version v1.0.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,12 +12,12 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Global variables
 
 # Builds documentation for the following tags and branches.
-TAGS = []
+TAGS = ["v1.0.0"]
 BRANCHES = [
     "master",
 ]
 # Sets the latest version.
-LATEST_VERSION = "master"
+LATEST_VERSION = "v1.0.0"
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated


### PR DESCRIPTION
Currently, the documentation at https://cpp-rs-driver.docs.scylladb.com/ is only published for the master branch.
This PR enables publishing the docs for version v1.0.0.

Each time we release a new version, the list of versions in the conf.py file should be updated.