### PR TITLE
Optimization for request result

### DIFF
--- a/examples/result_iteration_bench/.gitignore
+++ b/examples/result_iteration_bench/.gitignore
@@ -1,0 +1,1 @@
+result_iteration_bench

--- a/examples/result_iteration_bench/CMakeLists.txt
+++ b/examples/result_iteration_bench/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
+set(PROJECT_EXAMPLE_NAME result_iteration_bench)
+
+file(GLOB EXAMPLE_SRC_FILES *.c)
+include_directories(${INCLUDES})
+add_executable(${PROJECT_EXAMPLE_NAME} ${EXAMPLE_SRC_FILES})
+target_link_libraries(${PROJECT_EXAMPLE_NAME} ${PROJECT_LIB_NAME_TARGET} ${CASS_LIBS})
+add_dependencies(${PROJECT_EXAMPLE_NAME} ${PROJECT_LIB_NAME_TARGET})
+
+set_target_properties(${PROJECT_EXAMPLE_NAME} PROPERTIES FOLDER "Examples"
+                                                         COMPILE_FLAGS "${EXAMPLE_CMAKE_C_FLAGS}")

--- a/examples/result_iteration_bench/result_iteration_bench.c
+++ b/examples/result_iteration_bench/result_iteration_bench.c
@@ -1,0 +1,435 @@
+/*
+  This is free and unencumbered software released into the public domain.
+
+  Anyone is free to copy, modify, publish, use, compile, sell, or
+  distribute this software, either in source code form or as a compiled
+  binary, for any purpose, commercial or non-commercial, and by any
+  means.
+
+  In jurisdictions that recognize copyright laws, the author or authors
+  of this software dedicate any and all copyright interest in the
+  software to the public domain. We make this dedication for the benefit
+  of the public at large and to the detriment of our heirs and
+  successors. We intend this dedication to be an overt act of
+  relinquishment in perpetuity of all present and future rights to this
+  software under copyright law.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.
+
+  For more information, please refer to <http://unlicense.org/>
+*/
+
+/*
+ * Benchmark for result iteration performance.
+ *
+ * Creates a table with 10 columns, inserts 10000 rows, then performs
+ * an unpaged SELECT * and measures how long it takes to iterate over
+ * all rows in the result set. The iteration is repeated multiple times
+ * to get stable measurements.
+ */
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "cassandra.h"
+
+/*
+ * Allocation tracking via interposition.
+ * We override malloc/realloc/free to count calls, forwarding
+ * to the real implementations via dlsym(RTLD_NEXT, ...).
+ */
+
+static size_t g_malloc_count = 0;
+static size_t g_realloc_count = 0;
+static size_t g_free_count = 0;
+
+typedef void* (*real_malloc_t)(size_t);
+typedef void* (*real_realloc_t)(void*, size_t);
+typedef void (*real_free_t)(void*);
+
+static real_malloc_t real_malloc = NULL;
+static real_realloc_t real_realloc = NULL;
+static real_free_t real_free = NULL;
+
+/* Small static buffer to bootstrap dlsym (which may call malloc internally). */
+static char bootstrap_buf[4096];
+static size_t bootstrap_used = 0;
+static int resolving = 0;
+
+static void ensure_real_funcs(void) {
+  if (real_malloc != NULL) return;
+  resolving = 1;
+  real_malloc = (real_malloc_t)dlsym(RTLD_NEXT, "malloc");
+  real_realloc = (real_realloc_t)dlsym(RTLD_NEXT, "realloc");
+  real_free = (real_free_t)dlsym(RTLD_NEXT, "free");
+  resolving = 0;
+}
+
+void* malloc(size_t size) {
+  if (resolving) {
+    /* dlsym is resolving symbols and called malloc - use static buffer. */
+    size_t aligned = (size + 7) & ~(size_t)7; /* align to 8 */
+    if (bootstrap_used + aligned > sizeof(bootstrap_buf)) {
+      return NULL;
+    }
+    void* ptr = bootstrap_buf + bootstrap_used;
+    bootstrap_used += aligned;
+    return ptr;
+  }
+  ensure_real_funcs();
+  g_malloc_count++;
+  return real_malloc(size);
+}
+
+void* realloc(void* ptr, size_t size) {
+  if (resolving) {
+    size_t aligned = (size + 7) & ~(size_t)7;
+    if (bootstrap_used + aligned > sizeof(bootstrap_buf)) {
+      return NULL;
+    }
+    size_t old_bootstrap_used = bootstrap_used;
+    void* new_ptr = bootstrap_buf + bootstrap_used;
+    bootstrap_used += aligned;
+    /* Copy old data if ptr is in the bootstrap buffer. */
+    if (ptr != NULL && ptr >= (void*)bootstrap_buf &&
+        ptr < (void*)(bootstrap_buf + sizeof(bootstrap_buf))) {
+      size_t old_offset = (char*)ptr - bootstrap_buf;
+      size_t old_avail = old_bootstrap_used - old_offset;
+      size_t copy_size = old_avail < size ? old_avail : size;
+      memcpy(new_ptr, ptr, copy_size);
+    }
+    return new_ptr;
+  }
+  ensure_real_funcs();
+  g_realloc_count++;
+  return real_realloc(ptr, size);
+}
+
+void free(void* ptr) {
+  /* Ignore frees into our bootstrap buffer. */
+  if (ptr >= (void*)bootstrap_buf && ptr < (void*)(bootstrap_buf + sizeof(bootstrap_buf))) {
+    return;
+  }
+  if (resolving) return;
+  ensure_real_funcs();
+  g_free_count++;
+  real_free(ptr);
+}
+
+#define NUM_ROWS 10000
+#define NUM_INSERT_CONCURRENT 500
+#define NUM_BENCH_ITERATIONS 20
+
+void print_error(CassFuture* future) {
+  const char* message;
+  size_t message_length;
+  cass_future_error_message(future, &message, &message_length);
+  fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
+}
+
+CassCluster* create_cluster(const char* hosts) {
+  CassCluster* cluster = cass_cluster_new();
+  cass_cluster_set_contact_points(cluster, hosts);
+  return cluster;
+}
+
+CassError connect_session(CassSession* session, const CassCluster* cluster) {
+  CassError rc = CASS_OK;
+  CassFuture* future = cass_session_connect(session, cluster);
+
+  cass_future_wait(future);
+  rc = cass_future_error_code(future);
+  if (rc != CASS_OK) {
+    print_error(future);
+  }
+  cass_future_free(future);
+
+  return rc;
+}
+
+CassError execute_query(CassSession* session, const char* query) {
+  CassError rc = CASS_OK;
+  CassFuture* future = NULL;
+  CassStatement* statement = cass_statement_new(query, 0);
+
+  future = cass_session_execute(session, statement);
+  cass_future_wait(future);
+
+  rc = cass_future_error_code(future);
+  if (rc != CASS_OK) {
+    print_error(future);
+  }
+
+  cass_future_free(future);
+  cass_statement_free(statement);
+
+  return rc;
+}
+
+void insert_rows(CassSession* session) {
+  const char* query = "INSERT INTO result_iter_bench.bench_table "
+                      "(pk, col1, col2, col3, col4, col5, col6, col7, col8, col9) "
+                      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+  int total_sent = 0;
+
+  while (total_sent < NUM_ROWS) {
+    int batch_size = NUM_ROWS - total_sent;
+    int i;
+    CassFuture** futures;
+
+    if (batch_size > NUM_INSERT_CONCURRENT) {
+      batch_size = NUM_INSERT_CONCURRENT;
+    }
+
+    futures = (CassFuture**)malloc(sizeof(CassFuture*) * batch_size);
+
+    for (i = 0; i < batch_size; ++i) {
+      int row_id = total_sent + i;
+      char str_buf[64];
+      CassStatement* statement = cass_statement_new(query, 10);
+
+      cass_statement_bind_int32(statement, 0, row_id);
+
+      sprintf(str_buf, "value_%d_col1", row_id);
+      cass_statement_bind_string(statement, 1, str_buf);
+
+      sprintf(str_buf, "value_%d_col2", row_id);
+      cass_statement_bind_string(statement, 2, str_buf);
+
+      cass_statement_bind_int32(statement, 3, row_id * 10);
+      cass_statement_bind_int64(statement, 4, (cass_int64_t)row_id * 100);
+      cass_statement_bind_float(statement, 5, (cass_float_t)row_id * 1.1f);
+      cass_statement_bind_double(statement, 6, (cass_double_t)row_id * 2.2);
+      cass_statement_bind_bool(statement, 7, row_id % 2 == 0 ? cass_true : cass_false);
+      cass_statement_bind_int32(statement, 8, row_id + 1000);
+      cass_statement_bind_int64(statement, 9, (cass_int64_t)row_id + 2000);
+
+      futures[i] = cass_session_execute(session, statement);
+      cass_statement_free(statement);
+    }
+
+    for (i = 0; i < batch_size; ++i) {
+      CassError rc = cass_future_error_code(futures[i]);
+      if (rc != CASS_OK) {
+        print_error(futures[i]);
+      }
+      cass_future_free(futures[i]);
+    }
+
+    free(futures);
+    total_sent += batch_size;
+  }
+
+  printf("Inserted %d rows.\n", total_sent);
+}
+
+/*
+ * Executes an unpaged SELECT * and returns the result.
+ * The caller is responsible for freeing the result.
+ * Returns NULL on error.
+ */
+const CassResult* execute_select_all(CassSession* session) {
+  const CassResult* result = NULL;
+  CassError rc = CASS_OK;
+  CassFuture* future = NULL;
+  CassStatement* statement = cass_statement_new("SELECT * FROM result_iter_bench.bench_table", 0);
+
+  /* Disable paging to get all rows in a single result set. */
+  cass_statement_set_paging_size(statement, -1);
+
+  future = cass_session_execute(session, statement);
+  cass_future_wait(future);
+
+  rc = cass_future_error_code(future);
+  if (rc != CASS_OK) {
+    print_error(future);
+  } else {
+    result = cass_future_get_result(future);
+  }
+
+  cass_future_free(future);
+  cass_statement_free(statement);
+
+  return result;
+}
+
+/*
+ * Iterates over all rows in the result, reading every column value
+ * to simulate realistic consumption. Returns the number of rows iterated.
+ * Frees the result when done.
+ */
+size_t iterate_result(const CassResult* result) {
+  size_t row_count = 0;
+  CassIterator* iterator = cass_iterator_from_result(result);
+
+  while (cass_iterator_next(iterator)) {
+    const CassRow* row = cass_iterator_get_row(iterator);
+
+    /* Read all columns to realistically exercise the iteration path. */
+    cass_int32_t pk;
+    const char* col1;
+    size_t col1_len;
+    const char* col2;
+    size_t col2_len;
+    cass_int32_t col3;
+    cass_int64_t col4;
+    cass_float_t col5;
+    cass_double_t col6;
+    cass_bool_t col7;
+    cass_int32_t col8;
+    cass_int64_t col9;
+
+    cass_value_get_int32(cass_row_get_column(row, 0), &pk);
+    cass_value_get_string(cass_row_get_column(row, 1), &col1, &col1_len);
+    cass_value_get_string(cass_row_get_column(row, 2), &col2, &col2_len);
+    cass_value_get_int32(cass_row_get_column(row, 3), &col3);
+    cass_value_get_int64(cass_row_get_column(row, 4), &col4);
+    cass_value_get_float(cass_row_get_column(row, 5), &col5);
+    cass_value_get_double(cass_row_get_column(row, 6), &col6);
+    cass_value_get_bool(cass_row_get_column(row, 7), &col7);
+    cass_value_get_int32(cass_row_get_column(row, 8), &col8);
+    cass_value_get_int64(cass_row_get_column(row, 9), &col9);
+
+    row_count++;
+  }
+
+  cass_iterator_free(iterator);
+  cass_result_free(result);
+
+  return row_count;
+}
+
+double time_diff_ms(struct timespec* start, struct timespec* end) {
+  double sec = (double)(end->tv_sec - start->tv_sec);
+  double nsec = (double)(end->tv_nsec - start->tv_nsec);
+  return sec * 1000.0 + nsec / 1000000.0;
+}
+
+int compare_double(const void* a, const void* b) {
+  double da = *(const double*)a;
+  double db = *(const double*)b;
+  if (da < db) return -1;
+  if (da > db) return 1;
+  return 0;
+}
+
+int main(int argc, char* argv[]) {
+  int i;
+  double total_ms = 0.0;
+  double min_ms, max_ms, median_ms;
+  double timings[NUM_BENCH_ITERATIONS];
+  CassCluster* cluster = NULL;
+  CassSession* session = cass_session_new();
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
+
+  if (connect_session(session, cluster) != CASS_OK) {
+    cass_cluster_free(cluster);
+    cass_session_free(session);
+    return -1;
+  }
+
+  /* Set up schema. */
+  execute_query(session, "CREATE KEYSPACE IF NOT EXISTS result_iter_bench WITH replication = { "
+                         "'class': 'SimpleStrategy', 'replication_factor': '1' }");
+
+  execute_query(session, "DROP TABLE IF EXISTS result_iter_bench.bench_table");
+
+  execute_query(session, "CREATE TABLE result_iter_bench.bench_table ("
+                         "pk int PRIMARY KEY, "
+                         "col1 text, "
+                         "col2 text, "
+                         "col3 int, "
+                         "col4 bigint, "
+                         "col5 float, "
+                         "col6 double, "
+                         "col7 boolean, "
+                         "col8 int, "
+                         "col9 bigint)");
+
+  /* Insert rows. */
+  printf("Inserting %d rows...\n", NUM_ROWS);
+  insert_rows(session);
+
+  /* Warm-up: run one iteration before timing to warm up caches. */
+  {
+    const CassResult* result = execute_select_all(session);
+    assert(result != NULL);
+    size_t warmup_count = iterate_result(result);
+    printf("Warm-up: iterated over %zu rows.\n", warmup_count);
+    assert(warmup_count == NUM_ROWS);
+  }
+
+  /* Benchmark: only the result iteration is timed, not query execution. */
+  printf("\nRunning %d benchmark iterations (timing iteration only)...\n\n", NUM_BENCH_ITERATIONS);
+
+  for (i = 0; i < NUM_BENCH_ITERATIONS; ++i) {
+    struct timespec start, end;
+    size_t row_count;
+    double elapsed_ms;
+    const CassResult* result;
+    size_t malloc_before, realloc_before, free_before;
+
+    /* Execute query and wait for result (not timed). */
+    result = execute_select_all(session);
+    assert(result != NULL);
+
+    /* Snapshot alloc counters, then time only the iteration. */
+    malloc_before = g_malloc_count;
+    realloc_before = g_realloc_count;
+    free_before = g_free_count;
+
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    row_count = iterate_result(result);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    assert(row_count == NUM_ROWS);
+
+    elapsed_ms = time_diff_ms(&start, &end);
+    timings[i] = elapsed_ms;
+    total_ms += elapsed_ms;
+
+    printf("  Iteration %2d: %zu rows in %.3f ms  |  mallocs: %zu  reallocs: %zu  frees: %zu\n",
+           i + 1, row_count, elapsed_ms, g_malloc_count - malloc_before,
+           g_realloc_count - realloc_before, g_free_count - free_before);
+  }
+
+  /* Compute statistics. */
+  qsort(timings, NUM_BENCH_ITERATIONS, sizeof(double), compare_double);
+  min_ms = timings[0];
+  max_ms = timings[NUM_BENCH_ITERATIONS - 1];
+  if (NUM_BENCH_ITERATIONS % 2 == 0) {
+    median_ms = (timings[NUM_BENCH_ITERATIONS / 2 - 1] + timings[NUM_BENCH_ITERATIONS / 2]) / 2.0;
+  } else {
+    median_ms = timings[NUM_BENCH_ITERATIONS / 2];
+  }
+
+  printf("\n--- Benchmark Results (%d rows x %d iterations) ---\n", NUM_ROWS, NUM_BENCH_ITERATIONS);
+  printf("  Min:    %.3f ms\n", min_ms);
+  printf("  Max:    %.3f ms\n", max_ms);
+  printf("  Median: %.3f ms\n", median_ms);
+  printf("  Mean:   %.3f ms\n", total_ms / NUM_BENCH_ITERATIONS);
+  printf("  p95:    %.3f ms\n", timings[(int)(NUM_BENCH_ITERATIONS * 0.95) - 1]);
+  printf("  Total:  %.3f ms\n", total_ms);
+
+  /* Clean up. */
+  cass_cluster_free(cluster);
+  cass_session_free(session);
+
+  return 0;
+}

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1188,7 +1188,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "yoke",
 ]
 
 [[package]]

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -31,7 +31,6 @@ tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing = "0.1.37"
 futures = "0.3"
 thiserror = "1.0"
-yoke = { version = "0.8.0", features = ["derive"] }
 arc-swap = "1.3.0"
 
 [build-dependencies]

--- a/scylla-rust-wrapper/src/iterator.rs
+++ b/scylla-rust-wrapper/src/iterator.rs
@@ -40,6 +40,8 @@ impl CassResultIterator<'_> {
             return false;
         };
 
+        let old_row = rows_result_iterator.current_row.take();
+
         let new_row =
             rows_result_iterator
                 .iterator
@@ -50,6 +52,7 @@ impl CassResultIterator<'_> {
                             CassRow::from_raw_row_and_metadata(
                                 raw_row,
                                 rows_result_iterator.result_metadata,
+                                old_row,
                             )
                         })
                         .inspect_err(|e| {

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -124,6 +124,12 @@ impl CassResult {
     }
 }
 
+impl CassRowsResult {
+    pub(crate) fn first_row(&self) -> Option<&CassRow<'_>> {
+        self.first_row.as_ref().map(|r| r.row())
+    }
+}
+
 impl FFI for CassResult {
     type Origin = FromArc;
 }
@@ -1133,13 +1139,12 @@ pub unsafe extern "C" fn cass_result_first_row(
         return RefFFI::null();
     };
 
-    let CassResultKind::Rows(CassRowsResult { first_row, .. }) = &result.kind else {
+    let CassResultKind::Rows(cass_rows_result) = &result.kind else {
         return RefFFI::null();
     };
 
-    first_row
-        .as_ref()
-        .map(RowWithSelfBorrowedResultData::row)
+    cass_rows_result
+        .first_row()
         .map(RefFFI::as_ptr)
         .unwrap_or(RefFFI::null())
 }

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -10,7 +10,6 @@ use crate::cql_types::inet::CassInet;
 use crate::cql_types::uuid::CassUuid;
 use crate::types::*;
 use cass_raw_value::CassRawValue;
-use row_with_self_borrowed_result_data::RowWithSelfBorrowedResultData;
 use scylla::cluster::metadata::{ColumnType, NativeType};
 use scylla::deserialize::row::{
     BuiltinDeserializationError, BuiltinDeserializationErrorKind, ColumnIterator, DeserializeRow,
@@ -24,6 +23,7 @@ use scylla::value::{
     Counter, CqlDate, CqlDecimalBorrowed, CqlDuration, CqlTime, CqlTimestamp, CqlTimeuuid,
 };
 use std::convert::TryInto;
+use std::mem::ManuallyDrop;
 use std::net::IpAddr;
 use std::os::raw::c_char;
 use std::sync::Arc;
@@ -38,9 +38,49 @@ pub(crate) enum CassResultKind {
 
 #[derive(Debug)]
 pub(crate) struct CassRowsResult {
-    // Arc: shared with first_row (yoke).
-    pub(crate) shared_data: Arc<CassRowsResultSharedData>,
-    pub(crate) first_row: Option<RowWithSelfBorrowedResultData>,
+    pub(crate) shared_data: CassRowsResultSharedData,
+    /// SAFETY: borrows from `shared_data`. See [`SelfBorrowingFirstRow`] docs.
+    first_row: Option<SelfBorrowingFirstRow>,
+}
+
+impl Drop for CassRowsResult {
+    fn drop(&mut self) {
+        // Drop first_row before shared_data, because it borrows from shared_data.
+        if let Some(SelfBorrowingFirstRow(row)) = self.first_row.take() {
+            drop(ManuallyDrop::into_inner(row));
+        }
+    }
+}
+
+/// A wrapper around a `CassRow` that self-borrows from sibling data.
+///
+/// The contained `CassRow` actually borrows from `CassRowsResultSharedData`
+/// stored as a sibling field in `CassRowsResult`. The lifetime is erased
+/// to `'static` because Rust cannot express self-referential lifetimes.
+///
+/// # Safety invariants
+///
+/// 1. `CassRowsResult` is always stored inside `Arc<CassResult>`,
+///    so the address of `CassRowsResultSharedData` is stable.
+/// 2. `CassRowsResult::Drop` drops this field before `shared_data`.
+/// 3. Access is only through [`row()`](Self::row), which shortens the
+///    lifetime to `&self`, preventing the reference from escaping.
+#[derive(Debug)]
+struct SelfBorrowingFirstRow(ManuallyDrop<CassRow<'static>>);
+
+impl SelfBorrowingFirstRow {
+    /// Returns a reference to the contained row with the lifetime shortened
+    /// to match the borrow of `self`.
+    ///
+    /// This is critical for soundness: the stored `CassRow<'static>` actually
+    /// borrows from sibling data. By returning `&'a CassRow<'a>`, we tie
+    /// the lifetime to `&self`, which is bounded by `Arc<CassResult>`.
+    fn row<'a>(&'a self) -> &'a CassRow<'a> {
+        // SAFETY: We shorten the lifetime from 'static to 'a.
+        // The actual data lifetime is the Arc<CassResult> lifetime,
+        // and 'a (the &self borrow) cannot exceed that.
+        unsafe { &*(&*self.0 as *const CassRow<'a>) }
+    }
 }
 
 #[derive(Debug)]
@@ -72,6 +112,10 @@ impl CassResult {
     /// - query result
     /// - paging state response
     /// - optional cached result metadata - it's provided for prepared statements
+    ///
+    /// Returns `Arc<CassResult>` directly, because for rows results the first row
+    /// self-borrows from `CassRowsResultSharedData`. The data must be at its final
+    /// address (inside Arc) before the self-borrow is created.
     pub(crate) fn from_result_payload(
         result: QueryResult,
         paging_state_response: PagingStateResponse,
@@ -90,20 +134,33 @@ impl CassResult {
                     });
 
                 let (raw_rows, tracing_id, _, coordinator) = rows_result.into_inner();
-                let shared_data = Arc::new(CassRowsResultSharedData { raw_rows, metadata });
-                let first_row = RowWithSelfBorrowedResultData::first_from_raw_rows_and_metadata(
-                    Arc::clone(&shared_data),
-                )?;
+                let shared_data = CassRowsResultSharedData { raw_rows, metadata };
 
-                let result_arc = Arc::new(CassResult {
+                // Phase 1: Create CassResult without first_row.
+                let mut result_arc = Arc::new(CassResult {
                     tracing_id,
                     paging_state_response,
                     kind: CassResultKind::Rows(CassRowsResult {
                         shared_data,
-                        first_row,
+                        first_row: None,
                     }),
                     coordinator,
                 });
+
+                // Phase 2: Now that shared_data is at its final address inside
+                // the Arc, we can deserialize the first row which borrows from it.
+                {
+                    let result_mut =
+                        Arc::get_mut(&mut result_arc).expect("sole owner of freshly created Arc");
+                    let CassResultKind::Rows(ref mut rows_result) = result_mut.kind else {
+                        unreachable!("We just created this with Rows variant");
+                    };
+                    // SAFETY: `shared_data` is at its final address inside the Arc
+                    // and won't move. See `SelfBorrowingFirstRow` safety docs.
+                    unsafe {
+                        rows_result.init_first_row()?;
+                    }
+                }
 
                 Ok(result_arc)
             }
@@ -125,6 +182,48 @@ impl CassResult {
 }
 
 impl CassRowsResult {
+    /// Deserializes the first row from `shared_data` and stores it in `first_row`.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called when `self` is at its final address (inside `Arc<CassResult>`).
+    /// The deserialized row borrows from `self.shared_data`. The caller must ensure
+    /// the address of `shared_data` will not change after this call.
+    unsafe fn init_first_row(&mut self) -> Result<(), Arc<CassErrorResult>> {
+        let CassRowsResultSharedData {
+            ref raw_rows,
+            ref metadata,
+        } = self.shared_data;
+
+        let mut iter = raw_rows
+            .rows_iter::<CassRawRow>()
+            // unwrap: CassRawRow always passes the typecheck.
+            .unwrap();
+
+        let first_row = iter
+            .next()
+            .map(|raw_row_result| -> Result<_, Arc<CassErrorResult>> {
+                let raw_row = raw_row_result
+                    .map_err(CassErrorResult::from)
+                    .map_err(Arc::new)?;
+                let row = CassRow::from_raw_row_and_metadata(raw_row, metadata, None)
+                    .map_err(CassErrorResult::from)
+                    .map_err(Arc::new)?;
+                // SAFETY: Transmute CassRow<'a> to CassRow<'static>.
+                // This erases the lifetime, which is safe because:
+                // 1. shared_data lives inside Arc<CassResult> (stable address).
+                // 2. CassRowsResult::Drop drops first_row before shared_data.
+                // 3. SelfBorrowingFirstRow::row() shortens the lifetime back
+                //    on access, preventing the reference from escaping.
+                let row_static: CassRow<'static> = unsafe { std::mem::transmute(row) };
+                Ok(SelfBorrowingFirstRow(ManuallyDrop::new(row_static)))
+            })
+            .transpose()?;
+
+        self.first_row = first_row;
+        Ok(())
+    }
+
     pub(crate) fn first_row(&self) -> Option<&CassRow<'_>> {
         self.first_row.as_ref().map(|r| r.row())
     }
@@ -183,7 +282,7 @@ impl FFI for CassRow<'_> {
 
 impl<'result> CassRow<'result> {
     pub(crate) fn from_raw_row_and_metadata(
-        row: CassRawRow<'result, 'result>,
+        raw_row: CassRawRow<'result, 'result>,
         result_metadata: &'result CassResultMetadata,
         old_row: Option<Self>,
     ) -> Result<Self, DeserializationError> {
@@ -193,10 +292,10 @@ impl<'result> CassRow<'result> {
                 old_vec.clear();
                 old_vec
             }
-            None => Vec::with_capacity(row.columns.columns_remaining()),
+            None => Vec::with_capacity(raw_row.columns.columns_remaining()),
         };
 
-        let mut raw_columns_with_cass_metadata = row
+        let mut raw_columns_with_cass_metadata = raw_row
             .columns
             .zip(result_metadata.col_specs.iter())
             .map(|(raw_column_res, cass_metadata)| {
@@ -233,90 +332,6 @@ impl<'result> CassRow<'result> {
             columns,
             result_metadata,
         })
-    }
-}
-
-/// Module defining [`RowWithSelfBorrowedResultData`] struct.
-/// The purpose of this module is so the `query_result` module does not directly depend on `yoke`.
-mod row_with_self_borrowed_result_data {
-    use std::sync::Arc;
-
-    use yoke::{Yoke, Yokeable};
-
-    use crate::cass_error::CassErrorResult;
-    use crate::query_result::CassRawRow;
-
-    use super::{CassRow, CassRowsResultSharedData};
-
-    /// A simple wrapper over CassRow.
-    /// Needed, so we can implement Yokeable for it, instead of implementing it for CassRow.
-    #[derive(Debug, Yokeable)]
-    struct CassRowWrapper<'result>(CassRow<'result>);
-
-    /// A wrapper over struct which self-borrows the metadata allocated using Arc.
-    ///
-    /// It's needed to safely express the relationship between [`CassRowsResult`][super::CassRowsResult]
-    /// and its `first_row` field. The relationship is as follows:
-    /// 1. `CassRowsResult` owns `shared_data` field, which is an `Arc<CassRowsResultSharedData>`.
-    /// 2. `CassRowsResult` owns the row (`first_row`)
-    /// 3. `CassRow` borrows from `shared_data` (serialized values bytes and metadata).
-    ///
-    /// This struct is a shared owner of the row bytes and metadata, and self-borrows this data
-    /// to the `CassRow` it contains.
-    #[derive(Debug)]
-    pub(crate) struct RowWithSelfBorrowedResultData(
-        Yoke<CassRowWrapper<'static>, Arc<CassRowsResultSharedData>>,
-    );
-
-    impl RowWithSelfBorrowedResultData {
-        /// Constructs [`RowWithSelfBorrowedResultData`] based on the first row from `raw_rows_and_metadata`.
-        pub(super) fn first_from_raw_rows_and_metadata(
-            raw_rows_and_metadata: Arc<CassRowsResultSharedData>,
-        ) -> Result<Option<Self>, Arc<CassErrorResult>> {
-            enum AttachError {
-                CassErrorResult(Arc<CassErrorResult>),
-                NoRows,
-            }
-            impl From<CassErrorResult> for AttachError {
-                fn from(err: CassErrorResult) -> Self {
-                    AttachError::CassErrorResult(Arc::new(err))
-                }
-            }
-
-            let yoke_result = Yoke::try_attach_to_cart(
-                raw_rows_and_metadata,
-                |raw_rows_and_metadata_ref| -> Result<_, AttachError> {
-                    let CassRowsResultSharedData { raw_rows, metadata } = raw_rows_and_metadata_ref;
-
-                    let raw_row_result = raw_rows
-                        .rows_iter::<CassRawRow>()
-                        // unwrap: CassRawRow always passes the typecheck.
-                        .unwrap()
-                        .next()
-                        .ok_or(AttachError::NoRows)?;
-
-                    let row_result = raw_row_result.and_then(|raw_row| {
-                        CassRow::from_raw_row_and_metadata(raw_row, metadata, None)
-                    });
-
-                    let row = row_result
-                        .map_err(CassErrorResult::from)
-                        .map_err(AttachError::from)?;
-
-                    Ok(CassRowWrapper(row))
-                },
-            );
-
-            match yoke_result {
-                Ok(yoke) => Ok(Some(Self(yoke))),
-                Err(AttachError::NoRows) => Ok(None),
-                Err(AttachError::CassErrorResult(err)) => Err(err),
-            }
-        }
-
-        pub(super) fn row(&self) -> &CassRow<'_> {
-            &self.0.get().0
-        }
     }
 }
 
@@ -1203,7 +1218,6 @@ mod tests {
     };
     use std::{ffi::c_char, ptr::addr_of_mut, sync::Arc};
 
-    use super::row_with_self_borrowed_result_data::RowWithSelfBorrowedResultData;
     use super::{
         CassResult, CassResultKind, CassResultMetadata, CassRowsResult, CassRowsResultSharedData,
         cass_result_column_count, cass_result_column_type,
@@ -1230,21 +1244,30 @@ mod tests {
         ])));
 
         let raw_rows = DeserializedMetadataAndRawRows::mock_empty();
-        let shared_data = Arc::new(CassRowsResultSharedData { raw_rows, metadata });
-        let first_row = RowWithSelfBorrowedResultData::first_from_raw_rows_and_metadata(
-            Arc::clone(&shared_data),
-        )
-        .unwrap();
+        let shared_data = CassRowsResultSharedData { raw_rows, metadata };
 
-        let result_arc = Arc::new(CassResult {
+        // Two-phase construction, same as from_result_payload.
+        let mut result_arc = Arc::new(CassResult {
             tracing_id: None,
             paging_state_response: PagingStateResponse::NoMorePages,
             kind: CassResultKind::Rows(CassRowsResult {
                 shared_data,
-                first_row,
+                first_row: None,
             }),
             coordinator: None,
         });
+
+        {
+            let result_mut =
+                Arc::get_mut(&mut result_arc).expect("sole owner of freshly created Arc");
+            let CassResultKind::Rows(ref mut rows_result) = result_mut.kind else {
+                unreachable!("We just created this with Rows variant");
+            };
+            // SAFETY: shared_data is at its final address inside the Arc.
+            unsafe {
+                rows_result.init_first_row().unwrap();
+            }
+        }
 
         result_arc
     }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -484,7 +484,7 @@ pub unsafe extern "C" fn cass_session_execute(
                     paging_state_response,
                     get_or_make_result_metadata,
                 ) {
-                    Ok(result) => Ok(CassResultValue::QueryResult(Arc::new(result))),
+                    Ok(result_arc) => Ok(CassResultValue::QueryResult(result_arc)),
                     Err(e) => Ok(CassResultValue::QueryError(e)),
                 }
             }


### PR DESCRIPTION
This PR performs 2 optimizations related to request results.

## CassRow allocation

Allocation for `Vec` in `CassRow` is reused when advancing `CassResultIterator`. Before we always dropped old `CassRow` and created new one, resulting in 1 `free` + 1 `malloc` call.
Now we take the previous `Vec`, clear it, and reuse it.
I verified with the benchmark (second commit) that allocations are really gone, and they are! Now we have no obligatory allocations per-row, only per-request.
There was no visible performance improvement in my simple test. This is most likely because libc probably optimizes a pattern of `free` + `malloc` with the same size, making them really cheap.
This may not be the case for other allocators, or in more complex scenarios (like multi-threaded programs), so I still think this opt makes sense

## Removed Arc for shared data in CassRowsResult

See the issue about this: https://github.com/scylladb/cpp-rs-driver/issues/244
This is solved by making the self-referential struct manually, without Yoke.
Unfortunately I see no way to apply it. I also see no good way to make the resulting code much more secure, or easy to understand.
I guess this is a tradeoff - allocation gone, in exchange for more dangerous and complex code.

I'll gladly accept suggestions for how to make it safer, better contained, simpler etc.
If reviewers think this tradeoff makes no sense, I can also drop this part of PR, and close the issue as `wontfix`.

Fixes: https://github.com/scylladb/cpp-rs-driver/issues/244

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have implemented Rust unit tests for the features/changes introduced.~~
- [ ] ~~I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
