### PR TITLE
fix: missing whitespace in api docs

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,7 @@
+/* Fix missing spaces in C/C++ API signatures.
+   The theme hides <span class="w"> whitespace elements, collapsing
+   spaces between types, pointers, and parameter names. */
+.sig.sig-object.c .w,
+.sig.sig-object.cpp .w {
+    display: inline !important;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -99,6 +99,7 @@ smv_released_pattern = r"^tags/.*$"
 smv_outputdir_format = "{ref.name}"
 # -- Options for HTML output ----------------------------------------
 
+html_static_path = ["_static"]
 
 # -- Options for Doxygen (API Reference)
 breathe_projects = {"API": "../../doxygen/xml/"}
@@ -228,6 +229,8 @@ def setup(sphinx):
         category=UserWarning,
         message=r".*Container node skipped.*",
     )
+
+    sphinx.add_css_file("custom.css")
 
     # Autogenerate API Reference
     sphinx.connect("builder-inited", generate_doxygen)


### PR DESCRIPTION
Closes https://github.com/scylladb/cpp-rs-driver/issues/430