### PR TITLE
ci: install Rust toolchain in macOS packages job

### DIFF
--- a/.github/workflows/build-cpack-packages.yml
+++ b/.github/workflows/build-cpack-packages.yml
@@ -79,21 +79,14 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build and test RPM packages
-        run: |
-          source "$HOME/.cargo/env"
-          make test-package-rpm-native SCYLLA_HOST=scylla SKIP_DOCKER_COMPOSE=1
+        run: make test-package-rpm-native SCYLLA_HOST=scylla SKIP_DOCKER_COMPOSE=1
 
       - name: Collect artifacts
         if: inputs.save-artifacts
-        run: |
-          source "$HOME/.cargo/env"
-          make collect-package-artifacts
+        run: make collect-package-artifacts
 
       - uses: actions/upload-artifact@v4
         if: inputs.save-artifacts
@@ -108,10 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install GNU make
         run: brew install make

--- a/.github/workflows/build-cpack-packages.yml
+++ b/.github/workflows/build-cpack-packages.yml
@@ -108,6 +108,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Install GNU make
         run: brew install make
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,25 @@ list(APPEND CMAKE_MODULE_PATH ${CASS_ROOT_DIR}/cmake)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-enable_language(Rust)
+# Locate the Rust toolchain (cargo, rustc, etc.) and make it available for
+# the Cargo-based build in CMakeCargo.cmake.
+#
+# Older CMake versions (< 4.0) do not recognise Rust as a built-in language,
+# so enable_language(Rust) simply loads our custom cmake/ modules -- no
+# special flags are needed.
+#
+# CMake 4.0+ ships experimental built-in Rust support behind a feature gate
+# (CMAKE_EXPERIMENTAL_RUST) whose UUID changes with every release.  Rather
+# than chasing per-version UUIDs we skip enable_language(Rust) on those
+# builds and call the custom modules directly -- the result is identical
+# because the project never uses CMake's native Rust compilation rules;
+# all real Rust compilation is driven by Cargo through CMakeCargo.cmake.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
+  find_package(Rust REQUIRED)
+  include(CMakeRustInformation)
+else()
+  enable_language(Rust)
+endif()
 include(CMakeCargo)
 
 #---------------


### PR DESCRIPTION
## Summary

Fix the macOS CI packages build failure by installing Rust explicitly and bypassing CMake's experimental Rust feature gate on CMake 4.0+.

## Context

The `build-packages / macOS packages` CI job began failing after the GitHub Actions runner image was updated from `macos-15/20250313` to `macos-15/20260330`. Two separate issues were uncovered:

1. **Missing Rust toolchain**: The new runner image no longer bundles Rust pre-installed. The Linux RPM job already handles this by installing via `rustup`, but the macOS job relied on it being pre-installed.

2. **CMake 4.0+ experimental Rust gate**: The macOS runner ships CMake 4.3.1 (via Homebrew), which includes built-in experimental Rust language support. When `enable_language(Rust)` is called, CMake checks `CMAKE_EXPERIMENTAL_RUST` *before* loading any custom modules. Without the correct version-specific UUID, CMake emits a fatal error. Since the UUID changes with every CMake release, hardcoding it is not sustainable.

## Changes

- **`.github/workflows/build-cpack-packages.yml`**: Added an `Install Rust toolchain` step to the macOS job using `rustup`, consistent with the Linux RPM job.
- **`CMakeLists.txt`**: Added a version guard around `enable_language(Rust)`. On CMake >= 4.0, the project now calls `find_package(Rust)` + `include(CMakeRustInformation)` directly instead of going through `enable_language(Rust)`. This is functionally identical because the project never uses CMake's native Rust compilation rules -- all Rust compilation is driven by Cargo through `CMakeCargo.cmake`. On CMake < 4.0, the existing `enable_language(Rust)` path is preserved.

## Testing

- `make check` passes locally (clang-format, cargo check, cargo clippy, cargo fmt)
- Full cmake configure + cargo build verified locally with CMake 4.2.0
- The fix will be validated by the CI pipeline on this PR itself

## Links

- Fixes: #436
- Failed run log: https://github.com/scylladb/cpp-rs-driver/actions/runs/23854313334/job/69542889836