### PR TITLE
fix: resolve static linking failures with OpenSSL and duplicate symbols

### DIFF
--- a/.github/workflows/build-cpack-packages.yml
+++ b/.github/workflows/build-cpack-packages.yml
@@ -44,8 +44,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
       - name: Build and test DEB packages
-        run: make test-package-deb
+        run: make test-package-deb SCYLLA_SMOKE_BUILD_STATIC=ON
+
+      - name: Verify static linking builds (regression test for issue #164)
+        run: |
+          sudo apt-get update -y
+          make install-build-dependencies
+          make build-static-integration-test-bin
+          rm -rf build-static
 
       - name: Collect artifacts
         if: inputs.save-artifacts
@@ -75,14 +84,14 @@ jobs:
           --health-retries 60
     steps:
       - name: Install dependencies
-        run: dnf -y install git make cmake gcc-c++ findutils rpm-build ninja-build pkgconf-pkg-config openssl-devel clang
+        run: dnf -y install git make cmake gcc-c++ findutils rpm-build ninja-build pkgconf-pkg-config openssl-devel zlib-devel clang
 
       - uses: actions/checkout@v4
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build and test RPM packages
-        run: make test-package-rpm-native SCYLLA_HOST=scylla SKIP_DOCKER_COMPOSE=1
+        run: make test-package-rpm-native SCYLLA_HOST=scylla SKIP_DOCKER_COMPOSE=1 SCYLLA_SMOKE_BUILD_STATIC=ON
 
       - name: Collect artifacts
         if: inputs.save-artifacts
@@ -107,7 +116,12 @@ jobs:
         run: brew install make
 
       - name: Build and test macOS packages (PKG + DMG)
-        run: gmake test-package-macos
+        run: gmake test-package-macos SCYLLA_SMOKE_BUILD_STATIC=ON
+
+      - name: Verify static linking builds (regression test for issue #164)
+        run: |
+          gmake build-static-integration-test-bin
+          rm -rf build-static
 
       - name: Collect artifacts
         if: inputs.save-artifacts
@@ -126,8 +140,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
       - name: Build and test Windows packages (MSI)
-        run: make test-package-windows
+        run: make test-package-windows SCYLLA_SMOKE_BUILD_STATIC=ON
+
+      - name: Verify static linking builds (regression test for issue #164)
+        run: |
+          make build-static-integration-test-bin
+          if (Test-Path 'build-static') { Remove-Item -Recurse -Force 'build-static' }
+        shell: pwsh
 
       - name: Collect artifacts
         if: inputs.save-artifacts

--- a/.github/workflows/build-cpack-packages.yml
+++ b/.github/workflows/build-cpack-packages.yml
@@ -47,7 +47,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build and test DEB packages
-        run: make test-package-deb SCYLLA_SMOKE_BUILD_STATIC=ON
+        run: make test-package-deb
+
+      - name: Verify static package smoke test
+        run: make test-package-deb-static-smoke
 
       - name: Verify static linking builds (regression test for issue #164)
         run: |
@@ -91,7 +94,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build and test RPM packages
-        run: make test-package-rpm-native SCYLLA_HOST=scylla SKIP_DOCKER_COMPOSE=1 SCYLLA_SMOKE_BUILD_STATIC=ON
+        run: make test-package-rpm-native SCYLLA_HOST=scylla SKIP_DOCKER_COMPOSE=1
+
+      - name: Verify static package smoke test
+        run: make test-package-rpm-native-static-smoke SCYLLA_HOST=scylla SKIP_DOCKER_COMPOSE=1
 
       - name: Collect artifacts
         if: inputs.save-artifacts
@@ -116,7 +122,10 @@ jobs:
         run: brew install make
 
       - name: Build and test macOS packages (PKG + DMG)
-        run: gmake test-package-macos SCYLLA_SMOKE_BUILD_STATIC=ON
+        run: gmake test-package-macos
+
+      - name: Verify static package smoke test
+        run: gmake test-package-macos-static-smoke
 
       - name: Verify static linking builds (regression test for issue #164)
         run: |
@@ -143,7 +152,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build and test Windows packages (MSI)
-        run: make test-package-windows SCYLLA_SMOKE_BUILD_STATIC=ON
+        run: make test-package-windows
+
+      - name: Verify static package smoke test
+        run: make test-package-windows-static-smoke
 
       - name: Verify static linking builds (regression test for issue #164)
         run: |

--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -9,7 +9,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Should include `INTEGRATION_TEST_BIN` from the `Makefile`
-  # TODO: Remove `build/libscylla-cpp-driver.*` after https://github.com/scylladb/cpp-rs-driver/issues/164 is fixed.
   INTEGRATION_TEST_BIN: |
     build/cassandra-integration-tests
     build/libscylla-cpp-driver.*
@@ -44,6 +43,11 @@ jobs:
       - name: Build integration test binary
         id: build-integration-test-bin
         run: make build-integration-test-bin
+
+      - name: Verify static linking builds (regression test for issue #164)
+        run: |
+          make build-static-integration-test-bin
+          rm -rf build-static
 
       - name: Save integration test binary
         uses: actions/cache/save@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/
 .zed
 build/
+build-static/
 build-macos/
 **/build/
 **/build-macos/

--- a/Makefile
+++ b/Makefile
@@ -193,10 +193,11 @@ endif
 FULL_RUSTFLAGS := --cfg scylla_unstable --cfg cpp_integration_testing
 
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-BUILD_DIR := "${CURRENT_DIR}build"
+BUILD_DIR := $(CURRENT_DIR)build
 INTEGRATION_TEST_BIN := ${BUILD_DIR}/cassandra-integration-tests
 CMAKE_FLAGS ?=
 CMAKE_BUILD_TYPE ?= Release
+OPENSSL_WIN_VERSION ?= 1.1.1u
 
 ifeq ($(OS_TYPE),macos)
   CMAKE_INSTALL_PREFIX ?= /usr/local
@@ -213,7 +214,7 @@ else
 endif
 
 clean:
-	rm -rf "${BUILD_DIR}"
+	rm -rf "${BUILD_DIR}" "${STATIC_BUILD_DIR}"
 
 update-apt-cache-if-needed:
 	@# It searches for a file that is at most one day old.
@@ -273,6 +274,55 @@ build-integration-test-bin-if-missing:
 	@mkdir "${BUILD_DIR}" >/dev/null 2>&1 || true
 	@cd "${BUILD_DIR}"
 	cmake -DCASS_BUILD_INTEGRATION_TESTS=ON -DCMAKE_BUILD_TYPE=Release .. && (make -j 4 || make)
+
+STATIC_BUILD_DIR := $(CURRENT_DIR)build-static
+
+build-static-integration-test-bin:
+ifeq ($(OS_TYPE),windows)
+	$(MAKE) .package-build-prepare-windows
+	cmake -S . -B build-static -G "Visual Studio 17 2022" -A x64 -DCASS_BUILD_INTEGRATION_TESTS=ON -DCASS_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DOPENSSL_VERSION=$(OPENSSL_WIN_VERSION)
+	@pwsh -NoProfile -Command "\
+		$$useExternalOpenSSL = ((Select-String -Path 'build-static\\CMakeCache.txt' -Pattern '^SCYLLA_OPENSSL_EXTERNAL_PROJECT:BOOL=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
+		$$externalOpenSSLTarget = ((Select-String -Path 'build-static\\CMakeCache.txt' -Pattern '^SCYLLA_OPENSSL_EXTERNAL_TARGET:STRING=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
+		if ($$useExternalOpenSSL -eq 'ON' -and $$externalOpenSSLTarget) { \
+			cmake --build build-static --config Release --target $$externalOpenSSLTarget; \
+			if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE } \
+		}; \
+		$$opensslIncDir = ((Select-String -Path 'build-static\\CMakeCache.txt' -Pattern '^OPENSSL_INCLUDE_DIR:PATH=' | Select-Object -First 1).Line -split '=', 2)[1]; \
+		$$opensslSslLibPath = ((Select-String -Path 'build-static\\CMakeCache.txt' -Pattern '^OPENSSL_SSL_LIBRARY(_RELEASE)?:FILEPATH=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
+		$$opensslCryptoLibPath = ((Select-String -Path 'build-static\\CMakeCache.txt' -Pattern '^OPENSSL_CRYPTO_LIBRARY(_RELEASE)?:FILEPATH=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
+		if ($$opensslIncDir) { \
+			$$env:OPENSSL_DIR = (Split-Path $$opensslIncDir -Parent); \
+			$$env:OPENSSL_INCLUDE_DIR = $$opensslIncDir; \
+			if (-not $$opensslSslLibPath) { \
+				$$opensslSslLibPath = (Get-ChildItem -Path $$env:OPENSSL_DIR -Recurse -Include 'libssl*.lib','ssleay32*.lib' -File -ErrorAction SilentlyContinue | Select-Object -First 1).FullName; \
+			} \
+			if (-not $$opensslCryptoLibPath) { \
+				$$opensslCryptoLibPath = (Get-ChildItem -Path $$env:OPENSSL_DIR -Recurse -Include 'libcrypto*.lib','libeay32*.lib' -File -ErrorAction SilentlyContinue | Select-Object -First 1).FullName; \
+			} \
+			$$opensslLibPath = if ($$opensslSslLibPath) { $$opensslSslLibPath } elseif ($$opensslCryptoLibPath) { $$opensslCryptoLibPath } else { '' }; \
+			if ($$opensslLibPath) { \
+				$$env:OPENSSL_LIB_DIR = Split-Path $$opensslLibPath -Parent; \
+			} else { \
+				$$env:OPENSSL_LIB_DIR = Join-Path $$env:OPENSSL_DIR 'lib'; \
+			} \
+			if ($$opensslSslLibPath -and $$opensslCryptoLibPath) { \
+				$$opensslSslLibName = [System.IO.Path]::GetFileNameWithoutExtension($$opensslSslLibPath); \
+				$$opensslCryptoLibName = [System.IO.Path]::GetFileNameWithoutExtension($$opensslCryptoLibPath); \
+				$$env:OPENSSL_LIBS = \"$$opensslSslLibName`:`$$opensslCryptoLibName\"; \
+			} \
+		}; \
+		cmake --build build-static --config Release; \
+		if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE } \
+	"
+	build-static\Release\cassandra-integration-tests.exe --gtest_list_tests > NUL
+else
+	@echo "Building integration test binary with STATIC linking to ${STATIC_BUILD_DIR}"
+	@mkdir "${STATIC_BUILD_DIR}" >/dev/null 2>&1 || true
+	@cd "${STATIC_BUILD_DIR}"
+	cmake -DCASS_BUILD_INTEGRATION_TESTS=ON -DCASS_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release .. && (make -j 4 || make)
+	"${STATIC_BUILD_DIR}/cassandra-integration-tests" --gtest_list_tests > /dev/null
+endif
 
 build-examples:
 	@echo "Building examples to ${EXAMPLES_DIR}"
@@ -345,14 +395,47 @@ endif
 
 .package-configure: .package-build-prepare
 ifeq ($(OS_TYPE),windows)
-	cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DOPENSSL_VERSION=1.1.1u $(CMAKE_FLAGS)
+	cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DOPENSSL_VERSION=$(OPENSSL_WIN_VERSION) $(CMAKE_FLAGS)
 else
 	cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX) $(CMAKE_FLAGS)
 endif
 
 build-driver: .package-configure
 ifeq ($(OS_TYPE),windows)
-	@pwsh -NoProfile -Command "$$opensslVersion = ((Select-String -Path 'build\\CMakeCache.txt' -Pattern '^OPENSSL_VERSION:STRING=' | Select-Object -First 1).Line -split '=', 2)[1]; $$opensslTarget = \"openssl-$${opensslVersion}-library\"; cmake --build build --config $(CMAKE_BUILD_TYPE) --target $$opensslTarget; $$env:OPENSSL_DIR = (Resolve-Path 'build\\libs\\openssl').Path; $$env:OPENSSL_INCLUDE_DIR = \"$$env:OPENSSL_DIR\\include\"; $$env:OPENSSL_LIB_DIR = \"$$env:OPENSSL_DIR\\lib\"; cmake --build build --config $(CMAKE_BUILD_TYPE)"
+	@pwsh -NoProfile -Command "\
+		$$useExternalOpenSSL = ((Select-String -Path 'build\\CMakeCache.txt' -Pattern '^SCYLLA_OPENSSL_EXTERNAL_PROJECT:BOOL=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
+		$$externalOpenSSLTarget = ((Select-String -Path 'build\\CMakeCache.txt' -Pattern '^SCYLLA_OPENSSL_EXTERNAL_TARGET:STRING=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
+		if ($$useExternalOpenSSL -eq 'ON' -and $$externalOpenSSLTarget) { \
+			cmake --build build --config $(CMAKE_BUILD_TYPE) --target $$externalOpenSSLTarget; \
+			if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE } \
+		}; \
+		$$opensslIncDir = ((Select-String -Path 'build\\CMakeCache.txt' -Pattern '^OPENSSL_INCLUDE_DIR:PATH=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
+		$$opensslSslLibPath = ((Select-String -Path 'build\\CMakeCache.txt' -Pattern '^OPENSSL_SSL_LIBRARY(_RELEASE)?:FILEPATH=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
+		$$opensslCryptoLibPath = ((Select-String -Path 'build\\CMakeCache.txt' -Pattern '^OPENSSL_CRYPTO_LIBRARY(_RELEASE)?:FILEPATH=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
+		if ($$opensslIncDir) { \
+			$$env:OPENSSL_DIR = (Split-Path $$opensslIncDir -Parent); \
+			$$env:OPENSSL_INCLUDE_DIR = $$opensslIncDir; \
+			if (-not $$opensslSslLibPath) { \
+				$$opensslSslLibPath = (Get-ChildItem -Path $$env:OPENSSL_DIR -Recurse -Include 'libssl*.lib','ssleay32*.lib' -File -ErrorAction SilentlyContinue | Select-Object -First 1).FullName; \
+			} \
+			if (-not $$opensslCryptoLibPath) { \
+				$$opensslCryptoLibPath = (Get-ChildItem -Path $$env:OPENSSL_DIR -Recurse -Include 'libcrypto*.lib','libeay32*.lib' -File -ErrorAction SilentlyContinue | Select-Object -First 1).FullName; \
+			} \
+			$$opensslLibPath = if ($$opensslSslLibPath) { $$opensslSslLibPath } elseif ($$opensslCryptoLibPath) { $$opensslCryptoLibPath } else { '' }; \
+			if ($$opensslLibPath) { \
+				$$env:OPENSSL_LIB_DIR = Split-Path $$opensslLibPath -Parent; \
+			} else { \
+				$$env:OPENSSL_LIB_DIR = Join-Path $$env:OPENSSL_DIR 'lib'; \
+			} \
+			if ($$opensslSslLibPath -and $$opensslCryptoLibPath) { \
+				$$opensslSslLibName = [System.IO.Path]::GetFileNameWithoutExtension($$opensslSslLibPath); \
+				$$opensslCryptoLibName = [System.IO.Path]::GetFileNameWithoutExtension($$opensslCryptoLibPath); \
+				$$env:OPENSSL_LIBS = \"$$opensslSslLibName`:`$$opensslCryptoLibName\"; \
+			} \
+		}; \
+		cmake --build build --config $(CMAKE_BUILD_TYPE); \
+		if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE } \
+	"
 else
 	cmake --build build --config $(CMAKE_BUILD_TYPE)
 endif
@@ -524,15 +607,20 @@ endif
 # =============================================================================
 
 SMOKE_TEST_DIR := packaging/smoke-test-app
+SCYLLA_SMOKE_BUILD_STATIC ?= OFF
+SMOKE_TEST_CMAKE_FLAGS :=
+ifeq ($(SCYLLA_SMOKE_BUILD_STATIC),ON)
+SMOKE_TEST_CMAKE_FLAGS += -DSCYLLA_SMOKE_BUILD_STATIC=ON
+endif
 
 # DEB package testing (Ubuntu/Debian)
 test-package-deb: build-package
 	@echo "=== Testing DEB packages ==="
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev-deb
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-deb
-	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=DEB
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-app-deb
-	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package
+	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=DEB SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
+	$(MAKE) -C $(SMOKE_TEST_DIR) install-app-deb SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
+	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
 	@echo "=== DEB package test completed successfully ==="
 	$(MAKE) -C $(SMOKE_TEST_DIR) remove-app-deb || true
 	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-deb || true
@@ -549,7 +637,7 @@ test-package-rpm: build-package
 		fedora:latest \
 		bash -c ' \
 			set -euo pipefail; \
-			dnf -y install make cmake gcc-c++ findutils rpm-build; \
+			dnf -y install make cmake gcc-c++ findutils rpm-build zlib-devel; \
 			$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev-rpm; \
 			$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-rpm; \
 			pc_file=$$(find /usr -name "scylla-cpp-driver.pc" 2>/dev/null | head -1); \
@@ -561,14 +649,22 @@ test-package-rpm: build-package
 			if [ -n "$$lib_dir" ]; then \
 				export LD_LIBRARY_PATH="$${lib_dir}:$${LD_LIBRARY_PATH:-}"; \
 			fi; \
-			$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=RPM; \
+			$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=RPM SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"; \
 			$(MAKE) -C $(SMOKE_TEST_DIR) install-app-rpm; \
 			smoke_bin=$$(find /usr -name "scylla-cpp-driver-smoke-test" -type f 2>/dev/null | head -1); \
 			if [ -z "$$smoke_bin" ]; then \
 				echo "ERROR: smoke-test binary not found"; \
 				exit 1; \
 			fi; \
-			"$$smoke_bin" 127.0.0.1 \
+			"$$smoke_bin" 127.0.0.1; \
+			if [ "$(SCYLLA_SMOKE_BUILD_STATIC)" = "ON" ]; then \
+				smoke_static_bin=$$(find /usr -name "scylla-cpp-driver-smoke-test-static" -type f 2>/dev/null | head -1); \
+				if [ -z "$$smoke_static_bin" ]; then \
+					echo "ERROR: static smoke-test binary not found"; \
+					exit 1; \
+				fi; \
+				"$$smoke_static_bin" 127.0.0.1; \
+			fi \
 		'
 	@echo "=== RPM package test completed successfully ==="
 	docker compose -f $(SMOKE_TEST_DIR)/docker-compose.yml down --remove-orphans || true
@@ -582,9 +678,9 @@ test-package-rpm-native: build-package
 	@echo "=== Testing RPM packages (native) ==="
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev-rpm
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-rpm
-	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=RPM
+	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=RPM SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-app-rpm
-	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_HOST=$(SCYLLA_HOST) SKIP_DOCKER_COMPOSE=$(SKIP_DOCKER_COMPOSE)
+	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_HOST=$(SCYLLA_HOST) SKIP_DOCKER_COMPOSE=$(SKIP_DOCKER_COMPOSE) SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
 	@echo "=== RPM package test completed successfully ==="
 	$(MAKE) -C $(SMOKE_TEST_DIR) remove-app-rpm || true
 	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-rpm || true
@@ -595,9 +691,9 @@ test-package-pkg: build-package
 	@echo "=== Testing PKG packages ==="
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev-pkg
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-pkg
-	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=productbuild
+	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=productbuild SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-app-pkg
-	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package
+	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
 	@echo "=== PKG package test completed successfully ==="
 	$(MAKE) -C $(SMOKE_TEST_DIR) remove-app-pkg || true
 	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-pkg || true
@@ -608,9 +704,9 @@ test-package-dmg: build-package
 	@echo "=== Testing DMG packages ==="
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev-dmg
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dmg
-	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=DragNDrop
+	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=DragNDrop SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-app-dmg
-	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package
+	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
 	@echo "=== DMG package test completed successfully ==="
 	$(MAKE) -C $(SMOKE_TEST_DIR) remove-app-dmg || true
 	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-dmg || true
@@ -621,9 +717,9 @@ test-package-msi: .windows-setup-wix build-package
 	@echo "=== Testing MSI packages ==="
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver
-	$(MAKE) -C $(SMOKE_TEST_DIR) build-package
+	$(MAKE) -C $(SMOKE_TEST_DIR) build-package SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
 	$(MAKE) -C $(SMOKE_TEST_DIR) install-app
-	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package
+	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
 	@echo "=== MSI package test completed successfully ==="
 
 # Combined Linux package testing (DEB + RPM)

--- a/Makefile
+++ b/Makefile
@@ -624,32 +624,119 @@ endif
 # Usage:
 #   make test-package              # Test default package format(s) for current OS
 #   make test-package-deb          # Test DEB packages (Linux)
+#   make build-package-deb-static-smoke-app  # Build and install the DEB static smoke app
+#   make run-package-deb-static-smoke        # Run the installed DEB static smoke app tests
+#   make test-package-deb-static-smoke       # Build, run, and clean up the DEB static smoke app
 #   make test-package-rpm          # Test RPM packages (Linux, uses Fedora container via Docker)
 #   make test-package-rpm-native   # Test RPM packages (native Fedora, for CI runners)
+#   make build-package-rpm-native-static-smoke-app  # Build and install the native RPM static smoke app
+#   make run-package-rpm-native-static-smoke        # Run the installed native RPM static smoke app tests
+#   make test-package-rpm-native-static-smoke       # Build, run, and clean up the native RPM static smoke app
 #   make test-package-pkg          # Test PKG packages (macOS)
 #   make test-package-dmg          # Test DMG packages (macOS)
+#   make build-package-pkg-static-smoke-app  # Build and install the PKG static smoke app
+#   make run-package-pkg-static-smoke        # Run the installed PKG static smoke app tests
+#   make build-package-dmg-static-smoke-app  # Build and install the DMG static smoke app
+#   make run-package-dmg-static-smoke        # Run the installed DMG static smoke app tests
+#   make test-package-macos-static-smoke     # Build, run, and clean up the macOS static smoke apps
 #   make test-package-msi          # Test MSI packages (Windows)
+#   make build-package-windows-static-smoke-app  # Build and install the Windows static smoke app
+#   make run-package-windows-static-smoke        # Run the installed Windows static smoke app tests
+#   make test-package-windows-static-smoke       # Build, run, and clean up the Windows static smoke app
 # =============================================================================
 
 SMOKE_TEST_DIR := packaging/smoke-test-app
+SMOKE_TEST_MAKE := $(MAKE) -C $(SMOKE_TEST_DIR)
 SCYLLA_SMOKE_BUILD_STATIC ?= OFF
+SCYLLA_SMOKE_ONLY_STATIC ?= OFF
 SMOKE_TEST_CMAKE_FLAGS :=
 ifeq ($(SCYLLA_SMOKE_BUILD_STATIC),ON)
 SMOKE_TEST_CMAKE_FLAGS += -DSCYLLA_SMOKE_BUILD_STATIC=ON
 endif
+SMOKE_TEST_STATIC_CMAKE_FLAGS := -DSCYLLA_SMOKE_BUILD_STATIC=ON
+SMOKE_TEST_BUILD_FLAGS := SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
+SMOKE_TEST_RUN_FLAGS := $(SMOKE_TEST_BUILD_FLAGS) SCYLLA_SMOKE_ONLY_STATIC=$(SCYLLA_SMOKE_ONLY_STATIC)
+SMOKE_TEST_STATIC_BUILD_FLAGS := SCYLLA_SMOKE_BUILD_STATIC=ON
+SMOKE_TEST_STATIC_RUN_FLAGS := $(SMOKE_TEST_STATIC_BUILD_FLAGS) SCYLLA_SMOKE_ONLY_STATIC=ON
+
+define smoke_test_build_package
+	$(SMOKE_TEST_MAKE) build-package CPACK_GENERATORS=$(1) $(SMOKE_TEST_BUILD_FLAGS) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
+endef
+
+define smoke_test_build_package_static
+	$(SMOKE_TEST_MAKE) build-package CPACK_GENERATORS=$(1) $(SMOKE_TEST_STATIC_BUILD_FLAGS) CMAKE_FLAGS="$(SMOKE_TEST_STATIC_CMAKE_FLAGS)"
+endef
+
+define smoke_test_run_package
+	$(SMOKE_TEST_MAKE) test-app-package $(1) $(SMOKE_TEST_RUN_FLAGS)
+endef
+
+define smoke_test_run_package_static
+	$(SMOKE_TEST_MAKE) test-app-package $(1) $(SMOKE_TEST_STATIC_RUN_FLAGS)
+endef
+
+define smoke_test_cleanup_deb
+	$(SMOKE_TEST_MAKE) remove-app-deb || true
+	$(SMOKE_TEST_MAKE) remove-driver-deb || true
+	$(SMOKE_TEST_MAKE) remove-driver-dev-deb || true
+endef
+
+define smoke_test_cleanup_rpm
+	$(SMOKE_TEST_MAKE) remove-app-rpm || true
+	$(SMOKE_TEST_MAKE) remove-driver-rpm || true
+	$(SMOKE_TEST_MAKE) remove-driver-dev-rpm || true
+endef
+
+define smoke_test_cleanup_pkg
+	$(SMOKE_TEST_MAKE) remove-app-pkg || true
+	$(SMOKE_TEST_MAKE) remove-driver-pkg || true
+	$(SMOKE_TEST_MAKE) remove-driver-dev-pkg || true
+endef
+
+define smoke_test_cleanup_dmg
+	$(SMOKE_TEST_MAKE) remove-app-dmg || true
+	$(SMOKE_TEST_MAKE) remove-driver-dmg || true
+	$(SMOKE_TEST_MAKE) remove-driver-dev-dmg || true
+endef
+
+define smoke_test_cleanup_msi
+	$(SMOKE_TEST_MAKE) remove-app || true
+	$(SMOKE_TEST_MAKE) remove-driver || true
+	$(SMOKE_TEST_MAKE) remove-driver-dev || true
+endef
 
 # DEB package testing (Ubuntu/Debian)
 test-package-deb: build-package
 	@echo "=== Testing DEB packages ==="
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev-deb
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-deb
-	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=DEB SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-app-deb SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
-	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
+	$(SMOKE_TEST_MAKE) install-driver-dev-deb
+	$(SMOKE_TEST_MAKE) install-driver-deb
+	$(call smoke_test_build_package,DEB)
+	$(SMOKE_TEST_MAKE) install-app-deb
+	$(call smoke_test_run_package,)
 	@echo "=== DEB package test completed successfully ==="
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-app-deb || true
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-deb || true
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-dev-deb || true
+	$(SMOKE_TEST_MAKE) remove-app-deb || true
+	$(SMOKE_TEST_MAKE) remove-driver-deb || true
+	$(SMOKE_TEST_MAKE) remove-driver-dev-deb || true
+
+build-package-deb-static-smoke-app:
+	@echo "=== Building DEB static smoke app ==="
+	$(SMOKE_TEST_MAKE) install-driver-dev-deb
+	$(SMOKE_TEST_MAKE) install-driver-deb
+	$(call smoke_test_build_package_static,DEB)
+	$(SMOKE_TEST_MAKE) install-app-deb
+
+run-package-deb-static-smoke:
+	@echo "=== Running DEB static smoke test ==="
+	$(call smoke_test_run_package_static,)
+
+cleanup-package-deb-static-smoke:
+	$(call smoke_test_cleanup_deb)
+
+test-package-deb-static-smoke:
+	$(MAKE) build-package-deb-static-smoke-app
+	$(MAKE) run-package-deb-static-smoke
+	@echo "=== DEB static smoke test completed successfully ==="
+	$(MAKE) cleanup-package-deb-static-smoke
 
 # RPM package testing (runs in Fedora container for compatibility)
 test-package-rpm: build-package
@@ -663,8 +750,8 @@ test-package-rpm: build-package
 		bash -c ' \
 			set -euo pipefail; \
 			dnf -y install make cmake gcc-c++ findutils rpm-build zlib-devel; \
-			$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev-rpm; \
-			$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-rpm; \
+			$(SMOKE_TEST_MAKE) install-driver-dev-rpm; \
+			$(SMOKE_TEST_MAKE) install-driver-rpm; \
 			pc_file=$$(find /usr -name "scylla-cpp-driver.pc" 2>/dev/null | head -1); \
 			if [ -n "$$pc_file" ]; then \
 				pc_dir=$$(dirname "$$pc_file"); \
@@ -674,8 +761,8 @@ test-package-rpm: build-package
 			if [ -n "$$lib_dir" ]; then \
 				export LD_LIBRARY_PATH="$${lib_dir}:$${LD_LIBRARY_PATH:-}"; \
 			fi; \
-			$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=RPM SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"; \
-			$(MAKE) -C $(SMOKE_TEST_DIR) install-app-rpm; \
+			$(call smoke_test_build_package,RPM); \
+			$(SMOKE_TEST_MAKE) install-app-rpm; \
 			smoke_bin=$$(find /usr -name "scylla-cpp-driver-smoke-test" -type f 2>/dev/null | head -1); \
 			if [ -z "$$smoke_bin" ]; then \
 				echo "ERROR: smoke-test binary not found"; \
@@ -701,51 +788,131 @@ SCYLLA_HOST ?= 127.0.0.1
 SKIP_DOCKER_COMPOSE ?=
 test-package-rpm-native: build-package
 	@echo "=== Testing RPM packages (native) ==="
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev-rpm
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-rpm
-	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=RPM SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-app-rpm
-	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_HOST=$(SCYLLA_HOST) SKIP_DOCKER_COMPOSE=$(SKIP_DOCKER_COMPOSE) SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
+	$(SMOKE_TEST_MAKE) install-driver-dev-rpm
+	$(SMOKE_TEST_MAKE) install-driver-rpm
+	$(call smoke_test_build_package,RPM)
+	$(SMOKE_TEST_MAKE) install-app-rpm
+	$(call smoke_test_run_package,SCYLLA_HOST=$(SCYLLA_HOST) SKIP_DOCKER_COMPOSE=$(SKIP_DOCKER_COMPOSE))
 	@echo "=== RPM package test completed successfully ==="
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-app-rpm || true
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-rpm || true
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-dev-rpm || true
+	$(SMOKE_TEST_MAKE) remove-app-rpm || true
+	$(SMOKE_TEST_MAKE) remove-driver-rpm || true
+	$(SMOKE_TEST_MAKE) remove-driver-dev-rpm || true
+
+build-package-rpm-native-static-smoke-app:
+	@echo "=== Building RPM packages (native static smoke app) ==="
+	$(SMOKE_TEST_MAKE) install-driver-dev-rpm
+	$(SMOKE_TEST_MAKE) install-driver-rpm
+	$(call smoke_test_build_package_static,RPM)
+	$(SMOKE_TEST_MAKE) install-app-rpm
+
+run-package-rpm-native-static-smoke:
+	@echo "=== Running RPM packages (native static smoke test) ==="
+	$(call smoke_test_run_package_static,SCYLLA_HOST=$(SCYLLA_HOST) SKIP_DOCKER_COMPOSE=$(SKIP_DOCKER_COMPOSE))
+
+cleanup-package-rpm-native-static-smoke:
+	$(call smoke_test_cleanup_rpm)
+
+test-package-rpm-native-static-smoke:
+	$(MAKE) build-package-rpm-native-static-smoke-app
+	$(MAKE) run-package-rpm-native-static-smoke
+	@echo "=== RPM native static smoke test completed successfully ==="
+	$(MAKE) cleanup-package-rpm-native-static-smoke
 
 # macOS PKG package testing
 test-package-pkg: build-package
 	@echo "=== Testing PKG packages ==="
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev-pkg
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-pkg
-	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=productbuild SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-app-pkg
-	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
+	$(SMOKE_TEST_MAKE) install-driver-dev-pkg
+	$(SMOKE_TEST_MAKE) install-driver-pkg
+	$(call smoke_test_build_package,productbuild)
+	$(SMOKE_TEST_MAKE) install-app-pkg
+	$(call smoke_test_run_package,)
 	@echo "=== PKG package test completed successfully ==="
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-app-pkg || true
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-pkg || true
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-dev-pkg || true
+	$(SMOKE_TEST_MAKE) remove-app-pkg || true
+	$(SMOKE_TEST_MAKE) remove-driver-pkg || true
+	$(SMOKE_TEST_MAKE) remove-driver-dev-pkg || true
+
+build-package-pkg-static-smoke-app:
+	@echo "=== Building PKG static smoke app ==="
+	$(SMOKE_TEST_MAKE) install-driver-dev-pkg
+	$(SMOKE_TEST_MAKE) install-driver-pkg
+	$(call smoke_test_build_package_static,productbuild)
+	$(SMOKE_TEST_MAKE) install-app-pkg
+
+run-package-pkg-static-smoke:
+	@echo "=== Running PKG static smoke test ==="
+	$(call smoke_test_run_package_static,)
+
+cleanup-package-pkg-static-smoke:
+	$(call smoke_test_cleanup_pkg)
+
+test-package-pkg-static-smoke:
+	$(MAKE) build-package-pkg-static-smoke-app
+	$(MAKE) run-package-pkg-static-smoke
+	@echo "=== PKG static smoke test completed successfully ==="
+	$(MAKE) cleanup-package-pkg-static-smoke
 
 # macOS DMG package testing
 test-package-dmg: build-package
 	@echo "=== Testing DMG packages ==="
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev-dmg
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dmg
-	$(MAKE) -C $(SMOKE_TEST_DIR) build-package CPACK_GENERATORS=DragNDrop SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-app-dmg
-	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
+	$(SMOKE_TEST_MAKE) install-driver-dev-dmg
+	$(SMOKE_TEST_MAKE) install-driver-dmg
+	$(call smoke_test_build_package,DragNDrop)
+	$(SMOKE_TEST_MAKE) install-app-dmg
+	$(call smoke_test_run_package,)
 	@echo "=== DMG package test completed successfully ==="
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-app-dmg || true
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-dmg || true
-	$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-dev-dmg || true
+	$(SMOKE_TEST_MAKE) remove-app-dmg || true
+	$(SMOKE_TEST_MAKE) remove-driver-dmg || true
+	$(SMOKE_TEST_MAKE) remove-driver-dev-dmg || true
+
+build-package-dmg-static-smoke-app:
+	@echo "=== Building DMG static smoke app ==="
+	$(SMOKE_TEST_MAKE) install-driver-dev-dmg
+	$(SMOKE_TEST_MAKE) install-driver-dmg
+	$(call smoke_test_build_package_static,DragNDrop)
+	$(SMOKE_TEST_MAKE) install-app-dmg
+
+run-package-dmg-static-smoke:
+	@echo "=== Running DMG static smoke test ==="
+	$(call smoke_test_run_package_static,)
+
+cleanup-package-dmg-static-smoke:
+	$(call smoke_test_cleanup_dmg)
+
+test-package-dmg-static-smoke:
+	$(MAKE) build-package-dmg-static-smoke-app
+	$(MAKE) run-package-dmg-static-smoke
+	@echo "=== DMG static smoke test completed successfully ==="
+	$(MAKE) cleanup-package-dmg-static-smoke
 
 # Windows MSI package testing
 test-package-msi: .windows-setup-wix build-package
 	@echo "=== Testing MSI packages ==="
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver-dev
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-driver
-	$(MAKE) -C $(SMOKE_TEST_DIR) build-package SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
-	$(MAKE) -C $(SMOKE_TEST_DIR) install-app
-	$(MAKE) -C $(SMOKE_TEST_DIR) test-app-package SCYLLA_SMOKE_BUILD_STATIC=$(SCYLLA_SMOKE_BUILD_STATIC)
+	$(SMOKE_TEST_MAKE) install-driver-dev
+	$(SMOKE_TEST_MAKE) install-driver
+	$(SMOKE_TEST_MAKE) build-package $(SMOKE_TEST_BUILD_FLAGS) CMAKE_FLAGS="$(SMOKE_TEST_CMAKE_FLAGS)"
+	$(SMOKE_TEST_MAKE) install-app
+	$(call smoke_test_run_package,)
 	@echo "=== MSI package test completed successfully ==="
+
+build-package-msi-static-smoke-app: .windows-setup-wix
+	@echo "=== Building MSI static smoke app ==="
+	$(SMOKE_TEST_MAKE) install-driver-dev
+	$(SMOKE_TEST_MAKE) install-driver
+	$(SMOKE_TEST_MAKE) build-package $(SMOKE_TEST_STATIC_BUILD_FLAGS) CMAKE_FLAGS="$(SMOKE_TEST_STATIC_CMAKE_FLAGS)"
+	$(SMOKE_TEST_MAKE) install-app
+
+run-package-msi-static-smoke:
+	@echo "=== Running MSI static smoke test ==="
+	$(call smoke_test_run_package_static,)
+
+cleanup-package-msi-static-smoke:
+	$(call smoke_test_cleanup_msi)
+
+test-package-msi-static-smoke:
+	$(MAKE) build-package-msi-static-smoke-app
+	$(MAKE) run-package-msi-static-smoke
+	@echo "=== MSI static smoke test completed successfully ==="
+	$(MAKE) cleanup-package-msi-static-smoke
 
 # Combined Linux package testing (DEB + RPM)
 test-package-linux:
@@ -756,11 +923,24 @@ test-package-linux:
 # Windows package testing (MSI)
 test-package-windows: test-package-msi
 
+build-package-windows-static-smoke-app: build-package-msi-static-smoke-app
+
+run-package-windows-static-smoke: run-package-msi-static-smoke
+
+cleanup-package-windows-static-smoke: cleanup-package-msi-static-smoke
+
+test-package-windows-static-smoke: test-package-msi-static-smoke
+
 # Combined macOS package testing (PKG + DMG)
 test-package-macos:
 	$(MAKE) test-package-pkg
 	rm -rf $(SMOKE_TEST_DIR)/build
 	$(MAKE) test-package-dmg
+
+test-package-macos-static-smoke:
+	$(MAKE) test-package-pkg-static-smoke
+	rm -rf $(SMOKE_TEST_DIR)/build
+	$(MAKE) test-package-dmg-static-smoke
 
 # OS-specific default test-package target
 ifeq ($(OS_TYPE),macos)

--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ ifeq ($(OS_TYPE),windows)
 			if ($$opensslSslLibPath -and $$opensslCryptoLibPath) { \
 				$$opensslSslLibName = [System.IO.Path]::GetFileNameWithoutExtension($$opensslSslLibPath); \
 				$$opensslCryptoLibName = [System.IO.Path]::GetFileNameWithoutExtension($$opensslCryptoLibPath); \
-				$$env:OPENSSL_LIBS = \"$$opensslSslLibName`:`$$opensslCryptoLibName\"; \
+				$$env:OPENSSL_LIBS = [string]::Join(':', @($$opensslSslLibName, $$opensslCryptoLibName)); \
 			} \
 		}; \
 		cmake --build build-static --config Release; \
@@ -430,7 +430,7 @@ ifeq ($(OS_TYPE),windows)
 			if ($$opensslSslLibPath -and $$opensslCryptoLibPath) { \
 				$$opensslSslLibName = [System.IO.Path]::GetFileNameWithoutExtension($$opensslSslLibPath); \
 				$$opensslCryptoLibName = [System.IO.Path]::GetFileNameWithoutExtension($$opensslCryptoLibPath); \
-				$$env:OPENSSL_LIBS = \"$$opensslSslLibName`:`$$opensslCryptoLibName\"; \
+				$$env:OPENSSL_LIBS = [string]::Join(':', @($$opensslSslLibName, $$opensslCryptoLibName)); \
 			} \
 		}; \
 		cmake --build build --config $(CMAKE_BUILD_TYPE); \

--- a/Makefile
+++ b/Makefile
@@ -276,11 +276,16 @@ build-integration-test-bin-if-missing:
 	cmake -DCASS_BUILD_INTEGRATION_TESTS=ON -DCMAKE_BUILD_TYPE=Release .. && (make -j 4 || make)
 
 STATIC_BUILD_DIR := $(CURRENT_DIR)build-static
-
-build-static-integration-test-bin:
+STATIC_BUILD_CMAKE_FLAGS := -DCASS_BUILD_INTEGRATION_TESTS=ON -DCASS_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release
+STATIC_INTEGRATION_TEST_TARGET := cassandra-integration-tests
 ifeq ($(OS_TYPE),windows)
-	$(MAKE) .package-build-prepare-windows
-	cmake -S . -B build-static -G "Visual Studio 17 2022" -A x64 -DCASS_BUILD_INTEGRATION_TESTS=ON -DCASS_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DOPENSSL_VERSION=$(OPENSSL_WIN_VERSION)
+STATIC_DRIVER_COPY_TARGET := scylla-cpp-driver_static.lib_copy
+else
+STATIC_DRIVER_COPY_TARGET := libscylla-cpp-driver_static.a_copy
+endif
+STATIC_DRIVER_BUILD_TARGETS := scylla_cpp_driver_target $(STATIC_DRIVER_COPY_TARGET)
+
+define build-static-windows-targets
 	@pwsh -NoProfile -Command "\
 		$$useExternalOpenSSL = ((Select-String -Path 'build-static\\CMakeCache.txt' -Pattern '^SCYLLA_OPENSSL_EXTERNAL_PROJECT:BOOL=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
 		$$externalOpenSSLTarget = ((Select-String -Path 'build-static\\CMakeCache.txt' -Pattern '^SCYLLA_OPENSSL_EXTERNAL_TARGET:STRING=' -ErrorAction SilentlyContinue | Select-Object -First 1).Line -split '=', 2)[1]; \
@@ -312,15 +317,35 @@ ifeq ($(OS_TYPE),windows)
 				$$env:OPENSSL_LIBS = [string]::Join(':', @($$opensslSslLibName, $$opensslCryptoLibName)); \
 			} \
 		}; \
-		cmake --build build-static --config Release; \
+		cmake --build build-static --config Release --target $(1); \
 		if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE } \
 	"
+endef
+
+.configure-static-build-dir:
+ifeq ($(OS_TYPE),windows)
+	$(MAKE) .package-build-prepare-windows
+	cmake -S . -B build-static -G "Visual Studio 17 2022" -A x64 $(STATIC_BUILD_CMAKE_FLAGS) -DOPENSSL_VERSION=$(OPENSSL_WIN_VERSION)
+else
+	@mkdir "${STATIC_BUILD_DIR}" >/dev/null 2>&1 || true
+	cmake -S . -B "${STATIC_BUILD_DIR}" $(STATIC_BUILD_CMAKE_FLAGS)
+endif
+
+build-static-driver: .configure-static-build-dir
+ifeq ($(OS_TYPE),windows)
+	$(call build-static-windows-targets,$(STATIC_DRIVER_BUILD_TARGETS))
+else
+	@echo "Building static driver artifacts in ${STATIC_BUILD_DIR}"
+	cmake --build "${STATIC_BUILD_DIR}" --target $(STATIC_DRIVER_BUILD_TARGETS)
+endif
+
+build-static-integration-test-bin: build-static-driver
+ifeq ($(OS_TYPE),windows)
+	$(call build-static-windows-targets,$(STATIC_INTEGRATION_TEST_TARGET))
 	build-static\Release\cassandra-integration-tests.exe --gtest_list_tests > NUL
 else
 	@echo "Building integration test binary with STATIC linking to ${STATIC_BUILD_DIR}"
-	@mkdir "${STATIC_BUILD_DIR}" >/dev/null 2>&1 || true
-	@cd "${STATIC_BUILD_DIR}"
-	cmake -DCASS_BUILD_INTEGRATION_TESTS=ON -DCASS_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release .. && (make -j 4 || make)
+	cmake --build "${STATIC_BUILD_DIR}" --target $(STATIC_INTEGRATION_TEST_TARGET)
 	"${STATIC_BUILD_DIR}/cassandra-integration-tests" --gtest_list_tests > /dev/null
 endif
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -67,6 +67,11 @@ endif()
 #------------------------
 
 if(CASS_USE_OPENSSL)
+  set(SCYLLA_OPENSSL_EXTERNAL_PROJECT OFF CACHE BOOL
+    "Whether Scylla builds OpenSSL via ExternalProject" FORCE)
+  set(SCYLLA_OPENSSL_EXTERNAL_TARGET "" CACHE STRING
+    "Name of the ExternalProject target that builds OpenSSL" FORCE)
+
   if(NOT WIN32)
     set(_OPENSSL_ROOT_PATHS "${PROJECT_SOURCE_DIR}/lib/openssl/")
     set(_OPENSSL_ROOT_HINTS ${OPENSSL_ROOT_DIR} $ENV{OPENSSL_ROOT_DIR})
@@ -148,4 +153,3 @@ if(CASS_USE_BOOST_ATOMIC)
     add_definitions(-Wno-missing-field-initializers)
   endif()
 endif()
-

--- a/cmake/ExternalProject-OpenSSL.cmake
+++ b/cmake/ExternalProject-OpenSSL.cmake
@@ -44,6 +44,10 @@ endif()
 
 # OpenSSL external project variables
 set(OPENSSL_LIBRARY_NAME "openssl-${OPENSSL_VERSION}-library")
+set(SCYLLA_OPENSSL_EXTERNAL_PROJECT ON CACHE BOOL
+  "Whether Scylla builds OpenSSL via ExternalProject" FORCE)
+set(SCYLLA_OPENSSL_EXTERNAL_TARGET "${OPENSSL_LIBRARY_NAME}" CACHE STRING
+  "Name of the ExternalProject target that builds OpenSSL" FORCE)
 set(OPENSSL_PROJECT_PREFIX ${CMAKE_BINARY_DIR}/external/openssl)
 set(OPENSSL_ARCHIVE_URL_PREFIX "https://github.com/openssl/openssl/archive/")
 set(OPENSSL_ARCHIVE_URL_SUFFIX ".tar.gz")

--- a/cmake/FindOPENSSL.cmake
+++ b/cmake/FindOPENSSL.cmake
@@ -132,18 +132,24 @@ if(WIN32 AND NOT CYGWIN)
     # Since OpenSSL 1.1, lib names are like libcrypto32MTd.lib and libssl32MTd.lib
     if( "${CMAKE_SIZEOF_VOID_P}" STREQUAL "8" )
         set(_OPENSSL_MSVC_ARCH_SUFFIX "64")
+        set(_OPENSSL_MSVC_ARCH_DIR "x64")
     else()
         set(_OPENSSL_MSVC_ARCH_SUFFIX "32")
+        set(_OPENSSL_MSVC_ARCH_DIR "x86")
     endif()
 
     if(OPENSSL_USE_STATIC_LIBS)
       set(_OPENSSL_PATH_SUFFIXES
+        "lib/VC/${_OPENSSL_MSVC_ARCH_DIR}/MT"
+        "VC/${_OPENSSL_MSVC_ARCH_DIR}/MT"
         "lib/VC/static"
         "VC/static"
         "lib"
         )
     else()
       set(_OPENSSL_PATH_SUFFIXES
+        "lib/VC/${_OPENSSL_MSVC_ARCH_DIR}/${_OPENSSL_MSVC_RT_MODE}"
+        "VC/${_OPENSSL_MSVC_ARCH_DIR}/${_OPENSSL_MSVC_RT_MODE}"
         "lib/VC"
         "VC"
         "lib"

--- a/packaging/smoke-test-app/CMakeLists.txt
+++ b/packaging/smoke-test-app/CMakeLists.txt
@@ -108,10 +108,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_executable(scylla-cpp-driver-smoke-test
   src/smoke_test.c)
+target_include_directories(scylla-cpp-driver-smoke-test PRIVATE
+  ${SCYLLA_CPP_DRIVER_INCLUDE_DIRS})
 
 set(_smoke_link_target "PkgConfig::SCYLLA_CPP_DRIVER")
 set(_smoke_use_static TRUE)
-set(_smoke_extra_link_libraries "")
 if(WIN32)
   set(_smoke_use_static FALSE)
 else()
@@ -144,9 +145,6 @@ if(_smoke_use_static)
     message(STATUS
       "scylla-cpp-driver shared library not found; linking smoke test statically")
     set(_smoke_link_target "PkgConfig::SCYLLA_CPP_DRIVER_STATIC")
-    if(NOT WIN32)
-      list(APPEND _smoke_extra_link_libraries m)
-    endif()
   else()
     message(FATAL_ERROR
       "scylla-cpp-driver shared library not found and static package metadata unavailable; cannot link smoke test")
@@ -160,9 +158,7 @@ unset(_smoke_shared_patterns)
 unset(_smoke_use_static)
 
 target_link_libraries(scylla-cpp-driver-smoke-test PRIVATE
-  ${_smoke_link_target}
-  ${_smoke_extra_link_libraries})
-unset(_smoke_extra_link_libraries)
+  ${_smoke_link_target})
 unset(_smoke_link_target)
 
 if(APPLE)
@@ -190,6 +186,17 @@ if(SCYLLA_SMOKE_BUILD_STATIC)
   if(NOT PKG_CONFIG_EXECUTABLE)
     message(FATAL_ERROR "pkg-config executable not available for static linkage")
   endif()
+
+  execute_process(
+    COMMAND ${PKG_CONFIG_EXECUTABLE} --cflags scylla-cpp-driver_static
+    OUTPUT_VARIABLE _smoke_static_cflags_output
+    RESULT_VARIABLE _smoke_static_cflags_result
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT _smoke_static_cflags_result EQUAL 0)
+    message(FATAL_ERROR
+      "Unable to resolve static compile flags from scylla-cpp-driver_static pkg-config metadata")
+  endif()
+
   execute_process(
     COMMAND ${PKG_CONFIG_EXECUTABLE} --libs --static scylla-cpp-driver_static
     OUTPUT_VARIABLE _smoke_static_libs_output
@@ -199,14 +206,88 @@ if(SCYLLA_SMOKE_BUILD_STATIC)
     message(FATAL_ERROR
       "Unable to resolve static link flags from scylla-cpp-driver_static pkg-config metadata")
   endif()
-  separate_arguments(_smoke_static_link_libraries UNIX_COMMAND "${_smoke_static_libs_output}")
-  if(NOT WIN32)
-    list(APPEND _smoke_static_link_libraries m)
+
+  set(_smoke_static_cflags "")
+  if(NOT _smoke_static_cflags_output STREQUAL "")
+    separate_arguments(_smoke_static_cflags UNIX_COMMAND "${_smoke_static_cflags_output}")
+  endif()
+  separate_arguments(_smoke_static_link_items UNIX_COMMAND "${_smoke_static_libs_output}")
+
+  set(_smoke_static_include_dirs "")
+  set(_smoke_static_compile_options "")
+  foreach(_smoke_static_cflag IN LISTS _smoke_static_cflags)
+    if(_smoke_static_cflag MATCHES "^-I(.+)")
+      list(APPEND _smoke_static_include_dirs "${CMAKE_MATCH_1}")
+    else()
+      list(APPEND _smoke_static_compile_options "${_smoke_static_cflag}")
+    endif()
+  endforeach()
+  if(NOT _smoke_static_include_dirs)
+    set(_smoke_static_include_dirs ${SCYLLA_CPP_DRIVER_STATIC_INCLUDE_DIRS})
+  endif()
+  if(NOT _smoke_static_include_dirs)
+    set(_smoke_static_include_dirs ${SCYLLA_CPP_DRIVER_INCLUDE_DIRS})
+  endif()
+
+  set(_smoke_static_link_directories "")
+  set(_smoke_static_link_libraries "")
+  set(_smoke_static_link_options "")
+  set(_smoke_expect_framework_name OFF)
+  foreach(_smoke_static_link_item IN LISTS _smoke_static_link_items)
+    if(_smoke_expect_framework_name)
+      list(APPEND _smoke_static_link_options
+        "SHELL:-framework ${_smoke_static_link_item}")
+      set(_smoke_expect_framework_name OFF)
+    elseif(_smoke_static_link_item STREQUAL "-framework")
+      set(_smoke_expect_framework_name ON)
+    elseif(_smoke_static_link_item MATCHES "^-L(.+)")
+      list(APPEND _smoke_static_link_directories "${CMAKE_MATCH_1}")
+    elseif(_smoke_static_link_item MATCHES "^-l.+")
+      list(APPEND _smoke_static_link_libraries "${_smoke_static_link_item}")
+    elseif(_smoke_static_link_item MATCHES "^-")
+      list(APPEND _smoke_static_link_options "${_smoke_static_link_item}")
+    else()
+      list(APPEND _smoke_static_link_libraries "${_smoke_static_link_item}")
+    endif()
+  endforeach()
+  if(_smoke_expect_framework_name)
+    message(FATAL_ERROR
+      "Incomplete -framework flag sequence in scylla-cpp-driver_static pkg-config metadata")
+  endif()
+
+  if(_smoke_static_include_dirs)
+    target_include_directories(scylla-cpp-driver-smoke-test-static PRIVATE
+      ${_smoke_static_include_dirs})
+  endif()
+  if(_smoke_static_compile_options)
+    target_compile_options(scylla-cpp-driver-smoke-test-static PRIVATE
+      ${_smoke_static_compile_options})
+  endif()
+  if(_smoke_static_link_directories)
+    target_link_directories(scylla-cpp-driver-smoke-test-static PRIVATE
+      ${_smoke_static_link_directories})
+  endif()
+  if(_smoke_static_link_options)
+    target_link_options(scylla-cpp-driver-smoke-test-static PRIVATE
+      ${_smoke_static_link_options})
   endif()
   target_link_libraries(scylla-cpp-driver-smoke-test-static PRIVATE
     ${_smoke_static_link_libraries})
+
+  unset(_smoke_expect_framework_name)
+  unset(_smoke_static_cflag)
+  unset(_smoke_static_cflags)
+  unset(_smoke_static_cflags_output)
+  unset(_smoke_static_cflags_result)
+  unset(_smoke_static_compile_options)
+  unset(_smoke_static_include_dirs)
   unset(_smoke_static_libs_output)
+  unset(_smoke_static_libs_result)
+  unset(_smoke_static_link_directories)
+  unset(_smoke_static_link_item)
+  unset(_smoke_static_link_items)
   unset(_smoke_static_link_libraries)
+  unset(_smoke_static_link_options)
 endif()
 
 set(SMOKE_APP_COMPONENT_NAME "")

--- a/packaging/smoke-test-app/Makefile
+++ b/packaging/smoke-test-app/Makefile
@@ -11,6 +11,7 @@ INSTALL_TARGET ?= /
 DRIVER_BUILD_DIR ?= ${MAKEFILE_PATH}/../../build
 DRIVER_INSTALL_PATH ?= C:/Program Files/ScyllaDB/Scylla CPP Driver
 SMOKE_TEST_INSTALL_PATH ?= C:/Program Files/ScyllaDB/Scylla CPP Driver Smoke Test
+SCYLLA_SMOKE_BUILD_STATIC ?= OFF
 
 CMAKE_GENERATOR_FLAG :=
 ifneq ($(strip $(CMAKE_GENERATOR)),)
@@ -343,6 +344,7 @@ remove-driver-dmg:
 
 remove-app-dmg:
 	sudo rm -f /usr/local/bin/scylla-cpp-driver-smoke-test 2>/dev/null || true
+	sudo rm -f /usr/local/bin/scylla-cpp-driver-smoke-test-static 2>/dev/null || true
 
 remove-app-msi:
 	@pwsh.exe -NoProfile -Command "\$$ErrorActionPreference = 'Stop'; \$$productName = 'Scylla CPP Driver Smoke Test'; \$$product = Get-CimInstance -ClassName Win32_Product | Where-Object { \$$_.Name -like \"*\$$productName*\" }; if (\$$product) { \$$product | ForEach-Object { \$$_.Uninstall() | Out-Null }; Write-Host \"Uninstalled \$$productName\" } else { Write-Host \"\$$productName not found - nothing to uninstall\" }"
@@ -379,35 +381,62 @@ SKIP_DOCKER_COMPOSE ?=
 
 ifeq ($(OS_TYPE),windows)
 test-app-package: .prepare-for-test
-	@pwsh.exe -NoProfile -Command "\$$ErrorActionPreference = 'Stop'; \$$composeFile = '${MAKEFILE_PATH}/../../tests/examples_cluster/docker-compose.yml'; function Cleanup { docker compose -f \$$composeFile down --remove-orphans 2>\$$null | Out-Null }; try { \$$dockerService = Get-Service -Name docker -ErrorAction SilentlyContinue; if (\$$dockerService -and \$$dockerService.Status -ne 'Running') { Start-Service docker }; docker compose -f \$$composeFile up -d --wait; \$$smokePath = '$(SMOKE_TEST_INSTALL_PATH)\bin\scylla-cpp-driver-smoke-test.exe'; if (-not (Test-Path \$$smokePath)) { throw 'Smoke-test binary not found at \$$smokePath' }; & \$$smokePath 172.43.0.2 } finally { Cleanup }"
+	@pwsh.exe -NoProfile -Command "\
+		\$$ErrorActionPreference = 'Stop'; \
+		\$$composeFile = '${MAKEFILE_PATH}/../../tests/examples_cluster/docker-compose.yml'; \
+		\$$smokePaths = @('$(SMOKE_TEST_INSTALL_PATH)\bin\scylla-cpp-driver-smoke-test.exe'); \
+		if ('$(SCYLLA_SMOKE_BUILD_STATIC)' -eq 'ON') { \
+			\$$smokePaths += '$(SMOKE_TEST_INSTALL_PATH)\bin\scylla-cpp-driver-smoke-test-static.exe'; \
+		}; \
+		function Cleanup { docker compose -f \$$composeFile down --remove-orphans 2>\$$null | Out-Null }; \
+		try { \
+			\$$dockerService = Get-Service -Name docker -ErrorAction SilentlyContinue; \
+			if (\$$dockerService -and \$$dockerService.Status -ne 'Running') { Start-Service docker }; \
+			docker compose -f \$$composeFile up -d --wait; \
+			foreach (\$$smokePath in \$$smokePaths) { \
+				if (-not (Test-Path \$$smokePath)) { throw \"Smoke-test binary not found at \$$smokePath\" }; \
+				& \$$smokePath 172.43.0.2; \
+			} \
+		} finally { Cleanup }"
 else
 test-app-package: .prepare-for-test
-	@smoke_bin="$$(command -v scylla-cpp-driver-smoke-test || true)";\
-	if [ -z "$$smoke_bin" ] && [ "$(OS_TYPE)" = "macos" ] && command -v pkgutil >/dev/null 2>&1; then\
-		pkg_id="com.scylladb.cpp-rs-driver.smoke-app";\
-		pkg_ids="$$pkg_id $$(pkgutil --pkgs 2>/dev/null | awk '/scylla/ && /smoke/ {print}')";\
-		for candidate in $$pkg_ids; do\
-			pkg_path="$$(pkgutil --files "$$candidate" 2>/dev/null | awk '/scylla-cpp-driver-smoke-test$$/ {print "/"$$0; exit}')";\
-			if [ -n "$$pkg_path" ] && [ -x "$$pkg_path" ]; then\
-				smoke_bin="$$pkg_path";\
-				break;\
-			fi;\
-		done;\
-	fi;\
-	if [ -z "$$smoke_bin" ] && [ "$(OS_TYPE)" = "macos" ]; then\
-		for candidate in /usr/local/bin/scylla-cpp-driver-smoke-test /opt/homebrew/bin/scylla-cpp-driver-smoke-test /usr/bin/scylla-cpp-driver-smoke-test /usr/local/sbin/scylla-cpp-driver-smoke-test /opt/homebrew/sbin/scylla-cpp-driver-smoke-test; do\
-			if [ -x "$$candidate" ]; then\
-				smoke_bin="$$candidate";\
-				break;\
-			fi;\
-		done;\
-	fi;\
-	if [ -z "$$smoke_bin" ]; then\
-		echo "scylla-cpp-driver-smoke-test not found in PATH";\
-		exit 1;\
+	@resolve_smoke_binary() {\
+		binary_name="$$1";\
+		smoke_bin="$$(command -v "$$binary_name" || true)";\
+		if [ -z "$$smoke_bin" ] && [ "$(OS_TYPE)" = "macos" ] && command -v pkgutil >/dev/null 2>&1; then\
+			pkg_id="com.scylladb.cpp-rs-driver.smoke-app";\
+			pkg_ids="$$pkg_id $$(pkgutil --pkgs 2>/dev/null | awk '/scylla/ && /smoke/ {print}')";\
+			for candidate in $$pkg_ids; do\
+				pkg_path="$$(pkgutil --files "$$candidate" 2>/dev/null | awk -v binary_name="$$binary_name" '$$0 ~ binary_name "$$" {print "/"$$0; exit}')";\
+				if [ -n "$$pkg_path" ] && [ -x "$$pkg_path" ]; then\
+					smoke_bin="$$pkg_path";\
+					break;\
+				fi;\
+			done;\
+		fi;\
+		if [ -z "$$smoke_bin" ] && [ "$(OS_TYPE)" = "macos" ]; then\
+			for candidate_dir in /usr/local/bin /opt/homebrew/bin /usr/bin /usr/local/sbin /opt/homebrew/sbin; do\
+				candidate="$$candidate_dir/$$binary_name";\
+				if [ -x "$$candidate" ]; then\
+					smoke_bin="$$candidate";\
+					break;\
+				fi;\
+			done;\
+		fi;\
+		if [ -z "$$smoke_bin" ]; then\
+			echo "$$binary_name not found in PATH";\
+			exit 1;\
+		fi;\
+		printf '%s\n' "$$smoke_bin";\
+	};\
+	smoke_bins=("$$(resolve_smoke_binary scylla-cpp-driver-smoke-test)");\
+	if [ "$(SCYLLA_SMOKE_BUILD_STATIC)" = "ON" ]; then\
+		smoke_bins+=("$$(resolve_smoke_binary scylla-cpp-driver-smoke-test-static)");\
 	fi;\
 	if [ -n "$(SKIP_DOCKER_COMPOSE)" ]; then\
-		"$$smoke_bin" $(SCYLLA_HOST);\
+		for smoke_bin in "$${smoke_bins[@]}"; do\
+			"$$smoke_bin" $(SCYLLA_HOST);\
+		done;\
 	else\
 		dc="";\
 		if docker compose version >/dev/null 2>&1; then\
@@ -425,6 +454,8 @@ test-app-package: .prepare-for-test
 		};\
 		trap cleanup EXIT;\
 		sudo $$dc -f ${MAKEFILE_PATH}/docker-compose.yml up -d --wait;\
-		"$$smoke_bin" $(SCYLLA_HOST);\
+		for smoke_bin in "$${smoke_bins[@]}"; do\
+			"$$smoke_bin" $(SCYLLA_HOST);\
+		done;\
 	fi
 endif

--- a/packaging/smoke-test-app/Makefile
+++ b/packaging/smoke-test-app/Makefile
@@ -12,6 +12,7 @@ DRIVER_BUILD_DIR ?= ${MAKEFILE_PATH}/../../build
 DRIVER_INSTALL_PATH ?= C:/Program Files/ScyllaDB/Scylla CPP Driver
 SMOKE_TEST_INSTALL_PATH ?= C:/Program Files/ScyllaDB/Scylla CPP Driver Smoke Test
 SCYLLA_SMOKE_BUILD_STATIC ?= OFF
+SCYLLA_SMOKE_ONLY_STATIC ?= OFF
 
 CMAKE_GENERATOR_FLAG :=
 ifneq ($(strip $(CMAKE_GENERATOR)),)
@@ -384,9 +385,14 @@ test-app-package: .prepare-for-test
 	@pwsh.exe -NoProfile -Command "\
 		\$$ErrorActionPreference = 'Stop'; \
 		\$$composeFile = '${MAKEFILE_PATH}/../../tests/examples_cluster/docker-compose.yml'; \
-		\$$smokePaths = @('$(SMOKE_TEST_INSTALL_PATH)\bin\scylla-cpp-driver-smoke-test.exe'); \
+		\$$smokePaths = @(); \
+		if ('$(SCYLLA_SMOKE_ONLY_STATIC)' -ne 'ON') { \
+			\$$smokePaths += '$(SMOKE_TEST_INSTALL_PATH)\bin\scylla-cpp-driver-smoke-test.exe'; \
+		}; \
 		if ('$(SCYLLA_SMOKE_BUILD_STATIC)' -eq 'ON') { \
 			\$$smokePaths += '$(SMOKE_TEST_INSTALL_PATH)\bin\scylla-cpp-driver-smoke-test-static.exe'; \
+		} elseif ('$(SCYLLA_SMOKE_ONLY_STATIC)' -eq 'ON') { \
+			throw 'SCYLLA_SMOKE_ONLY_STATIC requires SCYLLA_SMOKE_BUILD_STATIC=ON'; \
 		}; \
 		function Cleanup { docker compose -f \$$composeFile down --remove-orphans 2>\$$null | Out-Null }; \
 		try { \
@@ -429,9 +435,15 @@ test-app-package: .prepare-for-test
 		fi;\
 		printf '%s\n' "$$smoke_bin";\
 	};\
-	smoke_bins=("$$(resolve_smoke_binary scylla-cpp-driver-smoke-test)");\
+	smoke_bins=();\
+	if [ "$(SCYLLA_SMOKE_ONLY_STATIC)" != "ON" ]; then\
+		smoke_bins+=("$$(resolve_smoke_binary scylla-cpp-driver-smoke-test)");\
+	fi;\
 	if [ "$(SCYLLA_SMOKE_BUILD_STATIC)" = "ON" ]; then\
 		smoke_bins+=("$$(resolve_smoke_binary scylla-cpp-driver-smoke-test-static)");\
+	elif [ "$(SCYLLA_SMOKE_ONLY_STATIC)" = "ON" ]; then\
+		echo "SCYLLA_SMOKE_ONLY_STATIC requires SCYLLA_SMOKE_BUILD_STATIC=ON";\
+		exit 1;\
 	fi;\
 	if [ -n "$(SKIP_DOCKER_COMPOSE)" ]; then\
 		for smoke_bin in "$${smoke_bins[@]}"; do\

--- a/scylla-rust-wrapper/CMakeLists.txt
+++ b/scylla-rust-wrapper/CMakeLists.txt
@@ -79,6 +79,88 @@ if(CASS_BUILD_STATIC)
   add_library(scylla-cpp-driver_static STATIC IMPORTED GLOBAL)
   add_dependencies(scylla-cpp-driver_static scylla-cpp-driver_static_target)
   set_target_properties(scylla-cpp-driver_static PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/${INSTALL_NAME_STATIC})
+
+  # The Rust staticlib contains unresolved references to OpenSSL and system
+  # libraries.  Declare them as transitive (INTERFACE) dependencies so that
+  # any target linking against scylla-cpp-driver_static automatically pulls
+  # in the required symbols in the correct order.
+  #
+  # NOTE: Some of these libraries (e.g. OpenSSL, ws2_32, crypt32, userenv on
+  # Windows) also appear in CASS_LIBS (populated by cmake/Dependencies.cmake).
+  # This causes them to appear twice on the linker command line, which is
+  # intentional and harmless -- linkers silently ignore duplicate inputs --
+  # but it keeps the static target self-contained so it works correctly even
+  # when linked outside the integration-test build where CASS_LIBS is set.
+  set(_STATIC_INTERFACE_LIBS "")
+  set(scylla_cpp_driver_static_requires_private "")
+  set(scylla_cpp_driver_static_libs_private "")
+  if(CASS_USE_OPENSSL AND OPENSSL_LIBRARIES)
+    list(APPEND _STATIC_INTERFACE_LIBS ${OPENSSL_LIBRARIES})
+    list(APPEND scylla_cpp_driver_static_requires_private openssl)
+  endif()
+  if(WIN32)
+    # Windows system libraries required by Rust runtime and its dependencies
+    list(APPEND _STATIC_INTERFACE_LIBS ws2_32 bcrypt ntdll userenv crypt32 secur32 ncrypt)
+    list(APPEND scylla_cpp_driver_static_libs_private
+      "-lws2_32" "-lbcrypt" "-lntdll" "-luserenv" "-lcrypt32" "-lsecur32" "-lncrypt")
+  elseif(APPLE)
+    list(APPEND _STATIC_INTERFACE_LIBS ${CMAKE_DL_LIBS} m)
+    if(CMAKE_DL_LIBS)
+      list(APPEND scylla_cpp_driver_static_libs_private "-l${CMAKE_DL_LIBS}")
+    endif()
+    list(APPEND scylla_cpp_driver_static_libs_private "-lm")
+    find_package(Threads)
+    if(Threads_FOUND)
+      list(APPEND _STATIC_INTERFACE_LIBS Threads::Threads)
+      if(CMAKE_THREAD_LIBS_INIT)
+        list(APPEND scylla_cpp_driver_static_libs_private "${CMAKE_THREAD_LIBS_INIT}")
+      endif()
+    endif()
+    # CoreFoundation is needed by the iana-time-zone crate on macOS
+    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+    if(COREFOUNDATION_LIBRARY)
+      list(APPEND _STATIC_INTERFACE_LIBS ${COREFOUNDATION_LIBRARY})
+      list(APPEND scylla_cpp_driver_static_libs_private "-framework CoreFoundation")
+    endif()
+    # SystemConfiguration and Security may also be needed on macOS
+    find_library(SYSTEMCONFIGURATION_LIBRARY SystemConfiguration)
+    if(SYSTEMCONFIGURATION_LIBRARY)
+      list(APPEND _STATIC_INTERFACE_LIBS ${SYSTEMCONFIGURATION_LIBRARY})
+      list(APPEND scylla_cpp_driver_static_libs_private "-framework SystemConfiguration")
+    endif()
+    find_library(SECURITY_LIBRARY Security)
+    if(SECURITY_LIBRARY)
+      list(APPEND _STATIC_INTERFACE_LIBS ${SECURITY_LIBRARY})
+      list(APPEND scylla_cpp_driver_static_libs_private "-framework Security")
+    endif()
+  else()
+    list(APPEND _STATIC_INTERFACE_LIBS ${CMAKE_DL_LIBS} m)
+    if(CMAKE_DL_LIBS)
+      list(APPEND scylla_cpp_driver_static_libs_private "-l${CMAKE_DL_LIBS}")
+    endif()
+    list(APPEND scylla_cpp_driver_static_libs_private "-lm")
+    find_package(Threads)
+    if(Threads_FOUND)
+      list(APPEND _STATIC_INTERFACE_LIBS Threads::Threads)
+      if(CMAKE_THREAD_LIBS_INIT)
+        list(APPEND scylla_cpp_driver_static_libs_private "${CMAKE_THREAD_LIBS_INIT}")
+      endif()
+    endif()
+  endif()
+  if(_STATIC_INTERFACE_LIBS)
+    set_target_properties(scylla-cpp-driver_static PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${_STATIC_INTERFACE_LIBS}")
+  endif()
+  if(scylla_cpp_driver_static_requires_private)
+    list(REMOVE_DUPLICATES scylla_cpp_driver_static_requires_private)
+    string(JOIN " " scylla_cpp_driver_static_requires_private
+      ${scylla_cpp_driver_static_requires_private})
+  endif()
+  if(scylla_cpp_driver_static_libs_private)
+    list(REMOVE_DUPLICATES scylla_cpp_driver_static_libs_private)
+    string(JOIN " " scylla_cpp_driver_static_libs_private
+      ${scylla_cpp_driver_static_libs_private})
+  endif()
 endif()
 
 #-------------------------------------

--- a/scylla-rust-wrapper/scylla-cpp-driver_static.pc.in
+++ b/scylla-rust-wrapper/scylla-cpp-driver_static.pc.in
@@ -6,7 +6,8 @@ includedir=@includedir@
 Name: scylla-cpp-rs-driver
 Description: ScyllaDB CPP RS Driver
 Version: @version@
-Requires: openssl
+Requires.private: @scylla_cpp_driver_static_requires_private@
 Libs: -L${libdir} -lscylla-cpp-driver_static
+Libs.private: @scylla_cpp_driver_static_libs_private@
 Cflags: -I${includedir}
 URL: https://github.com/scylladb/cpp-rs-driver/

--- a/src/testing_unimplemented.cpp
+++ b/src/testing_unimplemented.cpp
@@ -26,10 +26,6 @@ CASS_EXPORT const CassValue*
 cass_aggregate_meta_init_cond(const CassAggregateMeta* aggregate_meta) {
   throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_init_cond\n");
 }
-CASS_EXPORT void cass_aggregate_meta_name(const CassAggregateMeta* aggregate_meta,
-                                          const char** name, size_t* name_length) {
-  throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_name\n");
-}
 CASS_EXPORT const CassDataType*
 cass_aggregate_meta_return_type(const CassAggregateMeta* aggregate_meta) {
   throw std::runtime_error("UNIMPLEMENTED cass_aggregate_meta_return_type\n");
@@ -47,11 +43,6 @@ CASS_EXPORT void cass_authenticator_set_error(CassAuthenticator* auth, const cha
 }
 CASS_EXPORT CassError cass_batch_set_keyspace(CassBatch* batch, const char* keyspace) {
   throw std::runtime_error("UNIMPLEMENTED cass_batch_set_keyspace\n");
-}
-CASS_EXPORT CassError cass_cluster_set_authenticator_callbacks(
-    CassCluster* cluster, const CassAuthenticatorCallbacks* exchange_callbacks,
-    CassAuthenticatorDataCleanupCallback cleanup_callback, void* data) {
-  throw std::runtime_error("UNIMPLEMENTED cass_cluster_set_authenticator_callbacks\n");
 }
 CASS_EXPORT CassError cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init(
     CassCluster* cluster, const char* path) {
@@ -117,10 +108,6 @@ CASS_EXPORT void cass_function_meta_language(const CassFunctionMeta* function_me
                                              const char** language, size_t* language_length) {
   throw std::runtime_error("UNIMPLEMENTED cass_function_meta_language\n");
 }
-CASS_EXPORT void cass_function_meta_name(const CassFunctionMeta* function_meta, const char** name,
-                                         size_t* name_length) {
-  throw std::runtime_error("UNIMPLEMENTED cass_function_meta_name\n");
-}
 CASS_EXPORT const CassDataType*
 cass_function_meta_return_type(const CassFunctionMeta* function_meta) {
   throw std::runtime_error("UNIMPLEMENTED cass_function_meta_return_type\n");
@@ -129,19 +116,9 @@ CASS_EXPORT const CassValue* cass_index_meta_field_by_name(const CassIndexMeta* 
                                                            const char* name) {
   throw std::runtime_error("UNIMPLEMENTED cass_index_meta_field_by_name\n");
 }
-CASS_EXPORT const CassAggregateMeta*
-cass_keyspace_meta_aggregate_by_name(const CassKeyspaceMeta* keyspace_meta, const char* name,
-                                     const char* arguments) {
-  throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_aggregate_by_name\n");
-}
 CASS_EXPORT const CassValue* cass_keyspace_meta_field_by_name(const CassKeyspaceMeta* keyspace_meta,
                                                               const char* name) {
   throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_field_by_name\n");
-}
-CASS_EXPORT const CassFunctionMeta*
-cass_keyspace_meta_function_by_name(const CassKeyspaceMeta* keyspace_meta, const char* name,
-                                    const char* arguments) {
-  throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_function_by_name\n");
 }
 CASS_EXPORT cass_bool_t cass_keyspace_meta_is_virtual(const CassKeyspaceMeta* keyspace_meta) {
   throw std::runtime_error("UNIMPLEMENTED cass_keyspace_meta_is_virtual\n");
@@ -151,16 +128,10 @@ cass_materialized_view_meta_field_by_name(const CassMaterializedViewMeta* view_m
                                           const char* name) {
   throw std::runtime_error("UNIMPLEMENTED cass_materialized_view_meta_field_by_name\n");
 }
-CASS_EXPORT CassVersion cass_schema_meta_version(const CassSchemaMeta* schema_meta) {
-  throw std::runtime_error("UNIMPLEMENTED cass_schema_meta_version\n");
-}
 CASS_EXPORT void
 cass_session_get_speculative_execution_metrics(const CassSession* session,
                                                CassSpeculativeExecutionMetrics* output) {
   throw std::runtime_error("UNIMPLEMENTED cass_session_get_speculative_execution_metrics\n");
-}
-CASS_EXPORT CassError cass_statement_add_key_index(CassStatement* statement, size_t index) {
-  throw std::runtime_error("UNIMPLEMENTED cass_statement_add_key_index\n");
 }
 CASS_EXPORT CassError cass_statement_bind_custom(CassStatement* statement, size_t index,
                                                  const char* class_name, const cass_byte_t* value,
@@ -176,9 +147,6 @@ CASS_EXPORT CassError cass_statement_bind_custom_by_name(CassStatement* statemen
 CASS_EXPORT CassError cass_statement_set_custom_payload(CassStatement* statement,
                                                         const CassCustomPayload* payload) {
   throw std::runtime_error("UNIMPLEMENTED cass_statement_set_custom_payload\n");
-}
-CASS_EXPORT CassError cass_statement_set_keyspace(CassStatement* statement, const char* keyspace) {
-  throw std::runtime_error("UNIMPLEMENTED cass_statement_set_keyspace\n");
 }
 CASS_EXPORT CassClusteringOrder
 cass_table_meta_clustering_key_order(const CassTableMeta* table_meta, size_t index) {

--- a/tests/src/integration/CMakeLists.txt
+++ b/tests/src/integration/CMakeLists.txt
@@ -62,8 +62,8 @@ target_include_directories(cassandra-integration-tests PRIVATE
   ${CASS_INCLUDES})
 
 target_link_libraries(cassandra-integration-tests
-  ${CASS_LIBS}
   ${PROJECT_LIB_NAME_TARGET}
+  ${CASS_LIBS}
   ${INTEGRATION_TESTS_LIBSSH2_LIBRARIES})
 
 set_target_properties(cassandra-integration-tests PROPERTIES
@@ -83,4 +83,7 @@ set_target_properties(cassandra-integration-tests PROPERTIES
 
 if(LIBSSH2_LIBRARY_NAME) # Handle ExternalProject dependency
   add_dependencies(cassandra-integration-tests ${LIBSSH2_LIBRARY_NAME})
+endif()
+if(LIBUV_LIBRARY_NAME) # Handle ExternalProject dependency
+  add_dependencies(cassandra-integration-tests ${LIBUV_LIBRARY_NAME})
 endif()


### PR DESCRIPTION
## Summary

Fix the static-linking regressions behind `#164` at the installed-package boundary, not just for the in-tree integration binary. The branch now publishes the static driver's transitive link requirements through pkg-config, teaches the package smoke app to consume that metadata safely, removes duplicate testing stubs from the C++ side, and keeps the package CI coverage readable with dedicated static-smoke targets.

Fixes: #164

## What Changed

1. Support installed static consumers and package checks
- publish transitive static-link dependencies in `scylla-cpp-driver_static.pc`
- resolve static pkg-config compile/link flags in the smoke app, including Apple framework flags
- keep the Windows external OpenSSL path explicit when the static integration build falls back to the vendored project
- align the package/static-integration checks with the installed artifacts rather than only the in-tree target

2. Remove duplicate static-integration stubs
- drop the C++ stubs from `src/testing_unimplemented.cpp` that are already provided by the Rust integration layer during `cpp_integration_testing`

3. Fix Windows `OPENSSL_LIBS` assembly
- build `OPENSSL_LIBS` with an explicit join so `openssl-sys` receives real library names in package and static-integration builds

4. Split static package smoke checks into dedicated CI targets
- add dedicated make targets for static smoke builds/runs
- call those targets directly from the package workflow instead of threading `SCYLLA_SMOKE_BUILD_STATIC=ON` through CI YAML

## Commit Structure

- `c1eeee8` `static linking: support installed consumers and package checks`
- `61d6d5f` `testing: remove duplicate static-integration stubs`
- `1dd2538` `windows: assemble OPENSSL_LIBS from discovered libraries`
- `08cec82` `ci: split static package smoke checks into dedicated targets`
- `5f4f201` `gitignore: ignore build_static`

## Testing

- `cmake -S . -B /tmp/cpp-rs-driver-cmake-check -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `make check`
- `make run-test-unit`
- `cmake -S . -B /tmp/cpp-rs-driver-install-build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/tmp/cpp-rs-driver-install-prefix && cmake --build /tmp/cpp-rs-driver-install-build -j 4 && cmake --install /tmp/cpp-rs-driver-install-build`
- `PKG_CONFIG_PATH=/tmp/cpp-rs-driver-install-prefix/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig cmake -S packaging/smoke-test-app -B /tmp/cpp-rs-driver-smoke-build -G Ninja -DCMAKE_BUILD_TYPE=Release -DSCYLLA_SMOKE_BUILD_STATIC=ON && PKG_CONFIG_PATH=/tmp/cpp-rs-driver-install-prefix/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig cmake --build /tmp/cpp-rs-driver-smoke-build -j 4`
- `cmake --build build_static -j 4 --target cassandra-integration-tests`
- `make -n OS=Windows_NT build-driver CMAKE_BUILD_TYPE=Release | rg "OPENSSL_LIBS|Join\(':', @\("`
- `make -n OS=Windows_NT build-static-integration-test-bin | rg "OPENSSL_LIBS|Join\(':', @\("`
- `make -n test-package-deb-static-smoke`
- `make -n test-package-rpm-native-static-smoke SCYLLA_HOST=scylla SKIP_DOCKER_COMPOSE=1`
- `make -n test-package-macos-static-smoke`

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- [ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
- [x] I added appropriate `Fixes:` annotations to PR description.
