### PR TITLE
Add milestone sync workflow

### DIFF
--- a/.github/workflows/milestone-sync.yml
+++ b/.github/workflows/milestone-sync.yml
@@ -1,0 +1,38 @@
+name: Milestone Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      milestone:
+        description: GitHub milestone number or exact title
+        required: true
+        type: string
+  milestone:
+    types: [created, edited, opened, closed]
+  issues:
+    types: [opened, closed, reopened, milestoned, demilestoned]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  sync-manual:
+    if: github.event_name == 'workflow_dispatch'
+    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@main
+    with:
+      milestone: ${{ inputs.milestone }}
+      config-path: milestone-sync/config.yaml
+    secrets:
+      USER_AND_KEY_FOR_JIRA_AUTOMATION: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+
+  sync-automatic:
+    if: github.event_name != 'workflow_dispatch'
+    uses: scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@main
+    with:
+      config-path: milestone-sync/config.yaml
+      github-event-name: ${{ github.event_name }}
+      github-event-payload: ${{ toJson(github.event) }}
+    secrets:
+      USER_AND_KEY_FOR_JIRA_AUTOMATION: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}

--- a/milestone-sync/config.yaml
+++ b/milestone-sync/config.yaml
@@ -1,0 +1,5 @@
+# Minimal milestone-sync config for scylladb/cpp-rs-driver.
+# Add optional Jira fields here after their exact values are confirmed.
+Project: "DRIVER"
+Issue Type: "Epic"
+Summary Prefix: "cpp-rs-driver:"

--- a/milestone-sync/config.yaml
+++ b/milestone-sync/config.yaml
@@ -2,6 +2,6 @@
 Project: "DRIVER"
 Issue Type: "Epic"
 Summary Prefix: "cpp-rs-driver:"
-Scylla Components: "Driver - nodejs-rs-driver"
+Scylla Components: "Driver - cpp-rs-driver"
 Assignee: "Wojciech Przytuła"
 Team: "Drivers Team"

--- a/milestone-sync/config.yaml
+++ b/milestone-sync/config.yaml
@@ -1,5 +1,7 @@
-# Minimal milestone-sync config for scylladb/cpp-rs-driver.
-# Add optional Jira fields here after their exact values are confirmed.
+# Milestone-sync config for scylladb/cpp-rs-driver.
 Project: "DRIVER"
 Issue Type: "Epic"
 Summary Prefix: "cpp-rs-driver:"
+Scylla Components: "Driver - nodejs-rs-driver"
+Assignee: "Wojciech Przytuła"
+Team: "Drivers Team"


### PR DESCRIPTION
## Summary
- add a caller workflow that uses `scylladb-actions/workflows/.github/workflows/milestone-sync-reusable.yml@main`
- support both manual milestone sync and automatic sync from milestone and issue events
- add `milestone-sync/config.yaml` for the C++ RS driver with the provided Jira mapping values

## Notes
- repository admins still need to provide the `USER_AND_KEY_FOR_JIRA_AUTOMATION` secret for the workflow to run successfully
