### PR TITLE
ci: fail fast on integration test binary cache miss

### DIFF
--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -125,6 +125,11 @@ jobs:
         with:
           path: ${{ env.INTEGRATION_TEST_BIN }}
           key: ${{ env.INTEGRATION_TEST_BIN_CACHE_KEY }}
+          # Otherwise the binary won't be present, and test workflows will attempt to build it,
+          # failing due to build dependencies not being installed in the test workflow.
+          # It's better to fail early; this is a transient error that can be fixed by re-running
+          # the build-lint-and-unit-test job.
+          fail-on-cache-miss: true
 
       - name: Prepare environment
         run: make update-rust-tooling prepare-integration-test
@@ -213,6 +218,11 @@ jobs:
         with:
           path: ${{ env.INTEGRATION_TEST_BIN }}
           key: ${{ env.INTEGRATION_TEST_BIN_CACHE_KEY }}
+          # Otherwise the binary won't be present, and test workflows will attempt to build it,
+          # failing due to build dependencies not being installed in the test workflow.
+          # It's better to fail early; this is a transient error that can be fixed by re-running
+          # the build-lint-and-unit-test job.
+          fail-on-cache-miss: true
 
       - name: Prepare environment
         run: make update-rust-tooling prepare-integration-test


### PR DESCRIPTION
In run https://github.com/scylladb/cpp-rs-driver/actions/runs/25594930991, the build job successfully built the integration test binary but failed to save it to the GitHub Actions cache (transient cache service timeout). The test jobs then silently proceeded without the binary, and build-integration-test-bin-if-missing attempted to rebuild from source without build dependencies (libuv) installed, producing an unrelated CMake error that was difficult to diagnose.

Set `fail-on-cache-miss: true` on the cache restore steps so that test jobs fail immediately with a clear error when the binary is not available, instead of falling through to a doomed rebuild attempt.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
