### PR TITLE
Fix handling of NULL strings in user-facing APIs 

### DIFF
--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -5,22 +5,41 @@ use std::marker::PhantomData;
 use std::os::raw::c_char;
 use std::ptr::NonNull;
 use std::sync::{Arc, Weak};
+use thiserror::Error;
 
-pub unsafe fn ptr_to_cstr(ptr: *const c_char) -> Option<&'static str> {
-    if ptr.is_null() {
-        return None;
-    }
-    unsafe { CStr::from_ptr(ptr) }.to_str().ok()
+/// Error type for `ptr_to_cstr` and `ptr_to_cstr_n`, distinguishing
+/// a null pointer from invalid UTF-8 input.
+#[derive(Debug, Error)]
+pub enum PtrToStrError {
+    #[error("null string pointer")]
+    NullPointer,
+    #[error("invalid UTF-8: {0}")]
+    InvalidUtf8(std::str::Utf8Error),
 }
 
-pub unsafe fn ptr_to_cstr_n(ptr: *const c_char, size: size_t) -> Option<&'static str> {
+pub unsafe fn ptr_to_cstr(ptr: *const c_char) -> Result<&'static str, PtrToStrError> {
     if ptr.is_null() {
-        return None;
+        return Err(PtrToStrError::NullPointer);
     }
-    std::str::from_utf8(unsafe { std::slice::from_raw_parts(ptr as *const u8, size as usize) }).ok()
+    unsafe { CStr::from_ptr(ptr) }
+        .to_str()
+        .map_err(PtrToStrError::InvalidUtf8)
 }
 
-pub(crate) unsafe fn arr_to_cstr<const N: usize>(arr: &[c_char]) -> Option<&'static str> {
+pub unsafe fn ptr_to_cstr_n(
+    ptr: *const c_char,
+    size: size_t,
+) -> Result<&'static str, PtrToStrError> {
+    if ptr.is_null() {
+        return Err(PtrToStrError::NullPointer);
+    }
+    std::str::from_utf8(unsafe { std::slice::from_raw_parts(ptr as *const u8, size as usize) })
+        .map_err(PtrToStrError::InvalidUtf8)
+}
+
+pub(crate) unsafe fn arr_to_cstr<const N: usize>(
+    arr: &[c_char],
+) -> Result<&'static str, PtrToStrError> {
     let null_char = '\0' as c_char;
     let end_index = arr[..N].iter().position(|c| c == &null_char).unwrap_or(N);
     unsafe { ptr_to_cstr_n(arr.as_ptr(), end_index as size_t) }

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -7,6 +7,9 @@ use std::ptr::NonNull;
 use std::sync::{Arc, Weak};
 
 pub unsafe fn ptr_to_cstr(ptr: *const c_char) -> Option<&'static str> {
+    if ptr.is_null() {
+        return None;
+    }
     unsafe { CStr::from_ptr(ptr) }.to_str().ok()
 }
 

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -328,8 +328,15 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |v, v_size, scale| {
+            |v: *const cass_byte_t, v_size, scale| {
                 use scylla::value::CqlDecimal;
+                if v.is_null() {
+                    if v_size != 0 {
+                        return Err(CassError::CASS_ERROR_LIB_BAD_PARAMS);
+                    }
+                    // cpp-driver treats NULL+0 as empty varint.
+                    return Ok(Some(Decimal(CqlDecimal::from_signed_be_bytes_slice_and_exponent(&[], scale))));
+                }
                 let varint = unsafe { std::slice::from_raw_parts(v, v_size as usize) };
                 Ok(Some(Decimal(CqlDecimal::from_signed_be_bytes_slice_and_exponent(varint, scale))))
             },

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -266,7 +266,15 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |v, v_size| {
+            |v: *const cass_byte_t, v_size| {
+                if v.is_null() {
+                    if v_size != 0 {
+                        return Err(CassError::CASS_ERROR_LIB_BAD_PARAMS);
+                    } else {
+                        // cpp-driver treats NULL+0 as empty blob, not CQL NULL.
+                        return Ok(Some(Blob(vec![])));
+                    }
+                }
                 let v_vec = unsafe { std::slice::from_raw_parts(v, v_size as usize) }.to_vec();
                 Ok(Some(Blob(v_vec)))
             },

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -88,20 +88,26 @@ macro_rules! make_name_binder {
                 tracing::error!("Provided null pointer to {}!", stringify!($fn_by_name));
                 return CassError::CASS_ERROR_LIB_BAD_PARAMS;
             };
-            // NULL or empty name is clearly a programmer error. The
-            // cpp-driver accidentally accepts both (treating NULL as
-            // an empty string via SAFE_STRLEN), but we purposefully
-            // diverge and return an error early instead of silently
-            // binding to a bogus empty-named parameter.
-            if name.is_null() {
-                tracing::error!("Provided null name pointer to {}!", stringify!($fn_by_name));
-                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
-            }
-            let name = unsafe { ptr_to_cstr(name) }.unwrap();
-            if name.is_empty() {
-                tracing::error!("Provided empty name to {}!", stringify!($fn_by_name));
-                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
-            }
+            // NULL, non-UTF8, or empty name is clearly a programmer
+            // error. The cpp-driver accidentally accepts NULL (treating
+            // it as an empty string via SAFE_STRLEN), but we
+            // purposefully diverge and return an error early instead of
+            // silently binding to a bogus empty-named parameter.
+            let name = match unsafe { ptr_to_cstr(name) } {
+                Ok(name) if !name.is_empty() => name,
+                Ok(_) => {
+                    tracing::error!("Provided empty name to {}!", stringify!($fn_by_name));
+                    return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+                }
+                Err(PtrToStrError::NullPointer) => {
+                    tracing::error!("Provided null name pointer to {}!", stringify!($fn_by_name));
+                    return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+                }
+                Err(PtrToStrError::InvalidUtf8(_)) => {
+                    tracing::error!("Provided non-UTF8 name to {}!", stringify!($fn_by_name));
+                    return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+                }
+            };
             match ($e)($($arg), *) {
                 Ok(v) => $consume_v(this, name, v),
                 Err(e) => e,
@@ -127,20 +133,26 @@ macro_rules! make_name_n_binder {
                 tracing::error!("Provided null pointer to {}!", stringify!($fn_by_name_n));
                 return CassError::CASS_ERROR_LIB_BAD_PARAMS;
             };
-            // NULL or empty name is clearly a programmer error. The
-            // cpp-driver accidentally accepts both (treating NULL as
-            // an empty string via SAFE_STRLEN), but we purposefully
-            // diverge and return an error early instead of silently
-            // binding to a bogus empty-named parameter.
-            if name.is_null() {
-                tracing::error!("Provided null name pointer to {}!", stringify!($fn_by_name_n));
-                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
-            }
-            let name = unsafe { ptr_to_cstr_n(name, name_length) }.unwrap();
-            if name.is_empty() {
-                tracing::error!("Provided empty name to {}!", stringify!($fn_by_name_n));
-                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
-            }
+            // NULL, non-UTF8, or empty name is clearly a programmer
+            // error. The cpp-driver accidentally accepts NULL (treating
+            // it as an empty string via SAFE_STRLEN), but we
+            // purposefully diverge and return an error early instead of
+            // silently binding to a bogus empty-named parameter.
+            let name = match unsafe { ptr_to_cstr_n(name, name_length) } {
+                Ok(name) if !name.is_empty() => name,
+                Ok(_) => {
+                    tracing::error!("Provided empty name to {}!", stringify!($fn_by_name_n));
+                    return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+                }
+                Err(PtrToStrError::NullPointer) => {
+                    tracing::error!("Provided null name pointer to {}!", stringify!($fn_by_name_n));
+                    return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+                }
+                Err(PtrToStrError::InvalidUtf8(_)) => {
+                    tracing::error!("Provided non-UTF8 name to {}!", stringify!($fn_by_name_n));
+                    return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+                }
+            };
             match ($e)($($arg), *) {
                 Ok(v) => $consume_v(this, name, v),
                 Err(e) => e,
@@ -261,10 +273,11 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $fn,
             |v: *const std::os::raw::c_char| {
                 // cpp-driver treats NULL as empty string (via SAFE_STRLEN).
-                if v.is_null() {
-                    return Ok(Some(Text(String::new())));
+                match unsafe { ptr_to_cstr(v) } {
+                    Ok(s) => Ok(Some(Text(s.to_string()))),
+                    Err(PtrToStrError::NullPointer) => Ok(Some(Text(String::new()))),
+                    Err(PtrToStrError::InvalidUtf8(_)) => Err(CassError::CASS_ERROR_LIB_BAD_PARAMS),
                 }
-                Ok(Some(Text(unsafe { ptr_to_cstr(v) }.unwrap().to_string())))
             },
             [v @ *const std::os::raw::c_char]
         );
@@ -276,13 +289,12 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $fn,
             |v: *const std::os::raw::c_char, n| {
                 // cpp-driver treats NULL as empty string (via SAFE_STRLEN).
-                if v.is_null() {
-                    if n != 0 {
-                        return Err(CassError::CASS_ERROR_LIB_BAD_PARAMS);
-                    }
-                    return Ok(Some(Text(String::new())));
+                match unsafe { ptr_to_cstr_n(v, n) } {
+                    Ok(s) => Ok(Some(Text(s.to_string()))),
+                    Err(PtrToStrError::NullPointer) if n != 0 => Err(CassError::CASS_ERROR_LIB_BAD_PARAMS),
+                    Err(PtrToStrError::NullPointer) => Ok(Some(Text(String::new()))),
+                    Err(PtrToStrError::InvalidUtf8(_)) => Err(CassError::CASS_ERROR_LIB_BAD_PARAMS),
                 }
-                Ok(Some(Text(unsafe { ptr_to_cstr_n(v, n) }.unwrap().to_string())))
             },
             [v @ *const std::os::raw::c_char, n @ size_t]
         );

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -88,7 +88,20 @@ macro_rules! make_name_binder {
                 tracing::error!("Provided null pointer to {}!", stringify!($fn_by_name));
                 return CassError::CASS_ERROR_LIB_BAD_PARAMS;
             };
+            // NULL or empty name is clearly a programmer error. The
+            // cpp-driver accidentally accepts both (treating NULL as
+            // an empty string via SAFE_STRLEN), but we purposefully
+            // diverge and return an error early instead of silently
+            // binding to a bogus empty-named parameter.
+            if name.is_null() {
+                tracing::error!("Provided null name pointer to {}!", stringify!($fn_by_name));
+                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            }
             let name = unsafe { ptr_to_cstr(name) }.unwrap();
+            if name.is_empty() {
+                tracing::error!("Provided empty name to {}!", stringify!($fn_by_name));
+                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            }
             match ($e)($($arg), *) {
                 Ok(v) => $consume_v(this, name, v),
                 Err(e) => e,
@@ -114,7 +127,20 @@ macro_rules! make_name_n_binder {
                 tracing::error!("Provided null pointer to {}!", stringify!($fn_by_name_n));
                 return CassError::CASS_ERROR_LIB_BAD_PARAMS;
             };
+            // NULL or empty name is clearly a programmer error. The
+            // cpp-driver accidentally accepts both (treating NULL as
+            // an empty string via SAFE_STRLEN), but we purposefully
+            // diverge and return an error early instead of silently
+            // binding to a bogus empty-named parameter.
+            if name.is_null() {
+                tracing::error!("Provided null name pointer to {}!", stringify!($fn_by_name_n));
+                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            }
             let name = unsafe { ptr_to_cstr_n(name, name_length) }.unwrap();
+            if name.is_empty() {
+                tracing::error!("Provided empty name to {}!", stringify!($fn_by_name_n));
+                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            }
             match ($e)($($arg), *) {
                 Ok(v) => $consume_v(this, name, v),
                 Err(e) => e,

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -233,7 +233,13 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |v| Ok(Some(Text(unsafe { ptr_to_cstr(v) }.unwrap().to_string()))),
+            |v: *const std::os::raw::c_char| {
+                // cpp-driver treats NULL as empty string (via SAFE_STRLEN).
+                if v.is_null() {
+                    return Ok(Some(Text(String::new())));
+                }
+                Ok(Some(Text(unsafe { ptr_to_cstr(v) }.unwrap().to_string())))
+            },
             [v @ *const std::os::raw::c_char]
         );
     };
@@ -242,7 +248,16 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |v, n| Ok(Some(Text(unsafe { ptr_to_cstr_n(v, n) }.unwrap().to_string()))),
+            |v: *const std::os::raw::c_char, n| {
+                // cpp-driver treats NULL as empty string (via SAFE_STRLEN).
+                if v.is_null() {
+                    if n != 0 {
+                        return Err(CassError::CASS_ERROR_LIB_BAD_PARAMS);
+                    }
+                    return Ok(Some(Text(String::new())));
+                }
+                Ok(Some(Text(unsafe { ptr_to_cstr_n(v, n) }.unwrap().to_string())))
+            },
             [v @ *const std::os::raw::c_char, n @ size_t]
         );
     };

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -4,7 +4,9 @@ use crate::cass_host_listener_types::CassHostListenerCallback;
 use crate::config_value::MaybeUnsetConfig;
 use crate::cql_types::CassConsistency;
 use crate::cql_types::uuid::CassUuid;
-use crate::exec_profile::{CassExecProfile, ExecProfileName, exec_profile_builder_modify};
+use crate::exec_profile::{
+    CassExecProfile, EmptyProfileName, ExecProfileName, exec_profile_builder_modify,
+};
 use crate::host_listener::CCallbackBasedHostListener;
 use crate::load_balancing::{
     CassHostFilter, DcRestriction, LoadBalancingConfig, LoadBalancingKind,
@@ -427,15 +429,12 @@ where
 {
     // item_ptr is null if the user provided a null string.
     // null string is equivalent to empty string in this case - it clears the list.
-    let item_str = if item_ptr.is_null() {
-        None
-    } else {
-        match unsafe { ptr_to_cstr_n(item_ptr, item_length) } {
-            Some(h) => Some(h),
-            None => {
-                tracing::error!("Provided non-utf8 string representing a comma-delimited list");
-                return Err(CassError::CASS_ERROR_LIB_BAD_PARAMS);
-            }
+    let item_str = match unsafe { ptr_to_cstr_n(item_ptr, item_length) } {
+        Ok(h) => Some(h),
+        Err(PtrToStrError::NullPointer) => None,
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 string representing a comma-delimited list");
+            return Err(CassError::CASS_ERROR_LIB_BAD_PARAMS);
         }
     };
 
@@ -481,9 +480,19 @@ pub unsafe extern "C" fn cass_cluster_set_application_name_n(
         tracing::error!("Provided null cluster pointer to cass_cluster_set_application_name_n!");
         return;
     };
-    let app_name = unsafe { ptr_to_cstr_n(app_name, app_name_len) }
-        .unwrap()
-        .to_string();
+    let app_name = match unsafe { ptr_to_cstr_n(app_name, app_name_len) } {
+        Ok(s) => s.to_string(),
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!(
+                "Provided null app name pointer to cass_cluster_set_application_name(_n)!"
+            );
+            return;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 app name to cass_cluster_set_application_name(_n)!");
+            return;
+        }
+    };
 
     cluster
         .session_builder
@@ -510,9 +519,21 @@ pub unsafe extern "C" fn cass_cluster_set_application_version_n(
         tracing::error!("Provided null cluster pointer to cass_cluster_set_application_version_n!");
         return;
     };
-    let app_version = unsafe { ptr_to_cstr_n(app_version, app_version_len) }
-        .unwrap()
-        .to_string();
+    let app_version = match unsafe { ptr_to_cstr_n(app_version, app_version_len) } {
+        Ok(s) => s.to_string(),
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!(
+                "Provided null app version pointer to cass_cluster_set_application_version(_n)!"
+            );
+            return;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 app version to cass_cluster_set_application_version(_n)!"
+            );
+            return;
+        }
+    };
 
     cluster
         .session_builder
@@ -862,22 +883,21 @@ pub unsafe extern "C" fn cass_cluster_set_local_address_n(
 
     // Semantics from cpp-driver - if pointer is null or length is 0, use the
     // arbitrary address (INADDR_ANY, or in6addr_any).
-    let local_addr: Option<IpAddr> = if ip.is_null() || ip_length == 0 {
-        None
-    } else {
-        // SAFETY: We assume that user provides valid pointer and length.
-        match unsafe { ptr_to_cstr_n(ip, ip_length) } {
-            Some(ip_str) => match IpAddr::from_str(ip_str) {
-                Ok(addr) => Some(addr),
-                Err(err) => {
-                    tracing::error!("Failed to parse ip address <{}>: {}", ip_str, err);
-                    return CassError::CASS_ERROR_LIB_BAD_PARAMS;
-                }
-            },
-            None => {
-                tracing::error!("Provided non-utf8 ip string to cass_cluster_set_local_address_n!");
+    //
+    // SAFETY: We assume that user provides valid pointer and length.
+    let local_addr: Option<IpAddr> = match unsafe { ptr_to_cstr_n(ip, ip_length) } {
+        Ok(_) if ip_length == 0 => None,
+        Ok(ip_str) => match IpAddr::from_str(ip_str) {
+            Ok(addr) => Some(addr),
+            Err(err) => {
+                tracing::error!("Failed to parse ip address <{}>: {}", ip_str, err);
                 return CassError::CASS_ERROR_LIB_BAD_PARAMS;
             }
+        },
+        Err(PtrToStrError::NullPointer) => None,
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 ip string to cass_cluster_set_local_address_n!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
         }
     };
 
@@ -956,9 +976,28 @@ pub unsafe extern "C" fn cass_cluster_set_credentials_n(
         tracing::error!("Provided null cluster pointer to cass_cluster_set_credentials_n!");
         return;
     };
-    // TODO: string error handling
-    let username = unsafe { ptr_to_cstr_n(username_raw, username_length) }.unwrap();
-    let password = unsafe { ptr_to_cstr_n(password_raw, password_length) }.unwrap();
+    let username = match unsafe { ptr_to_cstr_n(username_raw, username_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Provided null username pointer to cass_cluster_set_credentials(_n)!");
+            return;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 username to cass_cluster_set_credentials(_n)!");
+            return;
+        }
+    };
+    let password = match unsafe { ptr_to_cstr_n(password_raw, password_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Provided null password pointer to cass_cluster_set_credentials(_n)!");
+            return;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 password to cass_cluster_set_credentials(_n)!");
+            return;
+        }
+    };
 
     cluster.auth_username = Some(username.to_string());
     cluster.auth_password = Some(password.to_string());
@@ -1003,11 +1042,18 @@ pub(crate) unsafe fn set_load_balance_dc_aware_n(
     used_hosts_per_remote_dc: c_uint,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
-    let Some(local_dc) = (unsafe { ptr_to_cstr_n(local_dc_raw, local_dc_length) }) else {
-        tracing::error!(
-            "Provided null or non-UTF-8 local DC name to cass_*_set_load_balance_dc_aware(_n)!"
-        );
-        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    let local_dc = match unsafe { ptr_to_cstr_n(local_dc_raw, local_dc_length) } {
+        Ok(dc) => dc,
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Provided null local DC name to cass_*_set_load_balance_dc_aware(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 local DC name to cass_*_set_load_balance_dc_aware(_n)!"
+            );
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
     };
 
     if local_dc_length == 0 {
@@ -1125,12 +1171,10 @@ pub(crate) unsafe fn set_load_balance_rack_aware_n(
         unsafe { ptr_to_cstr_n(local_dc_raw, local_dc_length) },
         unsafe { ptr_to_cstr_n(local_rack_raw, local_rack_length) },
     ) {
-        (Some(local_dc_str), Some(local_rack_str))
-            if local_dc_length > 0 && local_rack_length > 0 =>
-        {
+        (Ok(local_dc_str), Ok(local_rack_str)) if local_dc_length > 0 && local_rack_length > 0 => {
             (local_dc_str.to_owned(), local_rack_str.to_owned())
         }
-        // One of them either is a null pointer, is an empty string or is not a proper utf-8.
+        // One of them either is a null pointer, is an empty string or is not a proper UTF-8.
         _ => {
             tracing::error!(
                 "Provided local_dc or local_rack that is null, empty or non-UTF-8 to cass_*_set_load_balance_rack_aware(_n)!"
@@ -1603,16 +1647,28 @@ pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let name = if let Some(name) =
-        unsafe { ptr_to_cstr_n(name, name_length) }.and_then(|name| name.to_owned().try_into().ok())
-    {
-        name
-    } else {
-        // Got NULL or empty string, which is invalid name for a profile.
-        tracing::error!(
-            "Provided null or empty profile name to cass_cluster_set_execution_profile(_n)!"
-        );
-        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    let name = match unsafe { ptr_to_cstr_n(name, name_length) } {
+        Ok(name) => match name.to_owned().try_into() {
+            Ok(name) => name,
+            Err(EmptyProfileName) => {
+                tracing::error!(
+                    "Provided empty profile name to cass_cluster_set_execution_profile(_n)!"
+                );
+                return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+            }
+        },
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!(
+                "Provided null profile name to cass_cluster_set_execution_profile(_n)!"
+            );
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 profile name to cass_cluster_set_execution_profile(_n)!"
+            );
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
     };
 
     cluster.execution_profile_map.insert(name, profile.clone());

--- a/scylla-rust-wrapper/src/cql_types/data_type.rs
+++ b/scylla-rust-wrapper/src/cql_types/data_type.rs
@@ -572,9 +572,17 @@ pub unsafe extern "C" fn cass_data_type_set_type_name_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let type_name_string = unsafe { ptr_to_cstr_n(type_name, type_name_length) }
-        .unwrap()
-        .to_string();
+    let type_name_string = match unsafe { ptr_to_cstr_n(type_name, type_name_length) } {
+        Ok(s) => s.to_string(),
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Provided null type name pointer to cass_data_type_set_type_name(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 type name to cass_data_type_set_type_name(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+    };
 
     match unsafe { data_type.get_mut_unchecked() } {
         CassDataTypeInner::Udt(udt_data_type) => {
@@ -624,9 +632,17 @@ pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let keyspace_string = unsafe { ptr_to_cstr_n(keyspace, keyspace_length) }
-        .unwrap()
-        .to_string();
+    let keyspace_string = match unsafe { ptr_to_cstr_n(keyspace, keyspace_length) } {
+        Ok(s) => s.to_string(),
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Provided null keyspace pointer to cass_data_type_set_keyspace(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 keyspace to cass_data_type_set_keyspace(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+    };
 
     match unsafe { data_type.get_mut_unchecked() } {
         CassDataTypeInner::Udt(udt_data_type) => {
@@ -676,9 +692,19 @@ pub unsafe extern "C" fn cass_data_type_set_class_name_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let class_string = unsafe { ptr_to_cstr_n(class_name, class_name_length) }
-        .unwrap()
-        .to_string();
+    let class_string = match unsafe { ptr_to_cstr_n(class_name, class_name_length) } {
+        Ok(s) => s.to_string(),
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!(
+                "Provided null class name pointer to cass_data_type_set_class_name(_n)!"
+            );
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 class name to cass_data_type_set_class_name(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+    };
     match unsafe { data_type.get_mut_unchecked() } {
         CassDataTypeInner::Custom(name) => {
             *name = class_string;
@@ -761,7 +787,19 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n(
         return ArcFFI::null();
     };
 
-    let name_str = unsafe { ptr_to_cstr_n(name, name_length) }.unwrap();
+    let name_str = match unsafe { ptr_to_cstr_n(name, name_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!(
+                "Provided null name pointer to cass_data_type_sub_data_type_by_name(_n)!"
+            );
+            return ArcFFI::null();
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 name to cass_data_type_sub_data_type_by_name(_n)!");
+            return ArcFFI::null();
+        }
+    };
     match unsafe { data_type.get_unchecked() } {
         CassDataTypeInner::Udt(udt) => match udt.get_field_by_name(name_str) {
             None => ArcFFI::null(),
@@ -844,9 +882,19 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let name_string = unsafe { ptr_to_cstr_n(name, name_length) }
-        .unwrap()
-        .to_string();
+    let name_string = match unsafe { ptr_to_cstr_n(name, name_length) } {
+        Ok(s) => s.to_string(),
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!(
+                "Provided null name pointer to cass_data_type_add_sub_type_by_name(_n)!"
+            );
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 name to cass_data_type_add_sub_type_by_name(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+    };
 
     match unsafe { data_type.get_mut_unchecked() } {
         CassDataTypeInner::Udt(udt_data_type) => {

--- a/scylla-rust-wrapper/src/cql_types/inet.rs
+++ b/scylla-rust-wrapper/src/cql_types/inet.rs
@@ -96,9 +96,16 @@ pub unsafe extern "C" fn cass_inet_from_string_n(
     input_length: size_t,
     inet_raw: *mut CassInet,
 ) -> CassError {
-    let Some(input_str) = (unsafe { ptr_to_cstr_n(input_raw, input_length) }) else {
-        tracing::error!("Provided null input string to cass_inet_from_string(_n)!");
-        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    let input_str = match unsafe { ptr_to_cstr_n(input_raw, input_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Provided null input string to cass_inet_from_string(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 input string to cass_inet_from_string(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
     };
 
     let Ok(ip_addr) = IpAddr::from_str(input_str) else {

--- a/scylla-rust-wrapper/src/cql_types/uuid.rs
+++ b/scylla-rust-wrapper/src/cql_types/uuid.rs
@@ -251,9 +251,16 @@ pub unsafe extern "C" fn cass_uuid_from_string_n(
     value_length: size_t,
     output: *mut CassUuid,
 ) -> CassError {
-    let Some(value_str) = (unsafe { ptr_to_cstr_n(value, value_length) }) else {
-        tracing::error!("Provided null or invalid string pointer to cass_uuid_from_string(_n)!");
-        return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+    let value_str = match unsafe { ptr_to_cstr_n(value, value_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Provided null string pointer to cass_uuid_from_string(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 string to cass_uuid_from_string(_n)!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
     };
     Uuid::parse_str(value_str).map_or(CassError::CASS_ERROR_LIB_BAD_PARAMS, |parsed_uuid| {
         unsafe { std::ptr::write(output, parsed_uuid.into()) };

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -16,7 +16,7 @@ use scylla::statement::{Consistency, SerialConsistency};
 
 use crate::argconv::{
     ArcFFI, BoxFFI, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr, CassOwnedExclusivePtr,
-    FFI, FromBox, ptr_to_cstr_n, strlen,
+    FFI, FromBox, PtrToStrError, ptr_to_cstr_n, strlen,
 };
 use crate::cass_error::CassError;
 use crate::cluster::{
@@ -277,8 +277,17 @@ pub unsafe extern "C" fn cass_statement_set_execution_profile_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let name: Option<ExecProfileName> = unsafe { ptr_to_cstr_n(name, name_length) }
-        .and_then(|name| name.to_owned().try_into().ok());
+    let name: Option<ExecProfileName> = match unsafe { ptr_to_cstr_n(name, name_length) } {
+        Ok(name) => name.to_owned().try_into().ok(),
+        // NULL or empty name clears the profile — intentional.
+        Err(PtrToStrError::NullPointer) => None,
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 profile name to cass_statement_set_execution_profile(_n)!"
+            );
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+    };
     statement.exec_profile = name.map(PerStatementExecProfile::new_unresolved);
 
     CassError::CASS_OK
@@ -303,8 +312,17 @@ pub unsafe extern "C" fn cass_batch_set_execution_profile_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let name: Option<ExecProfileName> = unsafe { ptr_to_cstr_n(name, name_length) }
-        .and_then(|name| name.to_owned().try_into().ok());
+    let name: Option<ExecProfileName> = match unsafe { ptr_to_cstr_n(name, name_length) } {
+        Ok(name) => name.to_owned().try_into().ok(),
+        // NULL or empty name clears the profile — intentional.
+        Err(PtrToStrError::NullPointer) => None,
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 profile name to cass_batch_set_execution_profile(_n)!"
+            );
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+    };
     batch.exec_profile = name.map(PerStatementExecProfile::new_unresolved);
 
     CassError::CASS_OK

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -76,15 +76,19 @@ pub(crate) unsafe extern "C" fn stderr_log_callback(
     message: CassBorrowedSharedPtr<CassLogMessage, CConst>,
     _data: *mut c_void,
 ) {
-    let message = RefFFI::as_ref(message).unwrap();
+    let message =
+        RefFFI::as_ref(message).expect("message pointer is always valid; set by on_event");
 
     eprintln!(
         "{} [{}] ({}:{}) {}",
         message.time_ms,
-        unsafe { ptr_to_cstr(cass_log_level_string(message.severity)) }.unwrap(),
-        unsafe { ptr_to_cstr(message.file) }.unwrap(),
+        unsafe { ptr_to_cstr(cass_log_level_string(message.severity)) }
+            .expect("cass_log_level_string always returns a valid UTF-8 c-string literal"),
+        unsafe { ptr_to_cstr(message.file) }
+            .expect("file is set to a null-terminated Rust string by on_event"),
         message.line,
-        unsafe { arr_to_cstr::<{ CASS_LOG_MAX_MESSAGE_SIZE }>(&message.message) }.unwrap(),
+        unsafe { arr_to_cstr::<{ CASS_LOG_MAX_MESSAGE_SIZE }>(&message.message) }
+            .expect("message is populated from a Rust String via str_to_arr"),
     )
 }
 

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -144,11 +144,16 @@ pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name_n(
         );
         return RefFFI::null();
     };
-    if keyspace_name.is_null() {
-        return RefFFI::null();
-    }
-
-    let keyspace = unsafe { ptr_to_cstr_n(keyspace_name, keyspace_name_length) }.unwrap();
+    let keyspace = match unsafe { ptr_to_cstr_n(keyspace_name, keyspace_name_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => return RefFFI::null(),
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 keyspace name to cass_schema_meta_keyspace_by_name(_n)!"
+            );
+            return RefFFI::null();
+        }
+    };
 
     let keyspace_meta = metadata.keyspaces.get(keyspace);
 
@@ -192,11 +197,16 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
         );
         return ArcFFI::null();
     };
-    if type_.is_null() {
-        return ArcFFI::null();
-    }
-
-    let user_type_name = unsafe { ptr_to_cstr_n(type_, type_length) }.unwrap();
+    let user_type_name = match unsafe { ptr_to_cstr_n(type_, type_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => return ArcFFI::null(),
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 type name to cass_keyspace_meta_user_type_by_name(_n)!"
+            );
+            return ArcFFI::null();
+        }
+    };
 
     match keyspace_meta
         .user_defined_type_data_type
@@ -227,11 +237,16 @@ pub unsafe extern "C" fn cass_keyspace_meta_table_by_name_n(
         );
         return RefFFI::null();
     };
-    if table.is_null() {
-        return RefFFI::null();
-    }
-
-    let table_name = unsafe { ptr_to_cstr_n(table, table_length) }.unwrap();
+    let table_name = match unsafe { ptr_to_cstr_n(table, table_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => return RefFFI::null(),
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 table name to cass_keyspace_meta_table_by_name(_n)!"
+            );
+            return RefFFI::null();
+        }
+    };
 
     let table_meta = keyspace_meta.tables.get(table_name);
 
@@ -409,11 +424,14 @@ pub unsafe extern "C" fn cass_table_meta_column_by_name_n(
         );
         return RefFFI::null();
     };
-    if column.is_null() {
-        return RefFFI::null();
-    }
-
-    let column_name = unsafe { ptr_to_cstr_n(column, column_length) }.unwrap();
+    let column_name = match unsafe { ptr_to_cstr_n(column, column_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => return RefFFI::null(),
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 column name to cass_table_meta_column_by_name(_n)!");
+            return RefFFI::null();
+        }
+    };
 
     match table_meta.columns_metadata.get(column_name) {
         Some(column_meta) => RefFFI::as_ptr(column_meta),
@@ -479,11 +497,16 @@ pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name_n(
         );
         return RefFFI::null();
     };
-    if view.is_null() {
-        return RefFFI::null();
-    }
-
-    let view_name = unsafe { ptr_to_cstr_n(view, view_length).unwrap() };
+    let view_name = match unsafe { ptr_to_cstr_n(view, view_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => return RefFFI::null(),
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 view name to cass_keyspace_meta_materialized_view_by_name(_n)!"
+            );
+            return RefFFI::null();
+        }
+    };
 
     match keyspace_meta.views.get(view_name) {
         Some(view_meta) => RefFFI::as_ptr(view_meta.as_ref()),
@@ -511,11 +534,16 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name_n(
         );
         return RefFFI::null();
     };
-    if view.is_null() {
-        return RefFFI::null();
-    }
-
-    let view_name = unsafe { ptr_to_cstr_n(view, view_length).unwrap() };
+    let view_name = match unsafe { ptr_to_cstr_n(view, view_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => return RefFFI::null(),
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 view name to cass_table_meta_materialized_view_by_name(_n)!"
+            );
+            return RefFFI::null();
+        }
+    };
 
     match table_meta.views.get(view_name) {
         Some(view_meta) => RefFFI::as_ptr(view_meta.as_ref()),
@@ -576,11 +604,16 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name_n(
         return RefFFI::null();
     };
 
-    if column.is_null() {
-        return RefFFI::null();
-    }
-
-    let column_name = unsafe { ptr_to_cstr_n(column, column_length).unwrap() };
+    let column_name = match unsafe { ptr_to_cstr_n(column, column_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => return RefFFI::null(),
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!(
+                "Provided non-UTF8 column name to cass_materialized_view_meta_column_by_name(_n)!"
+            );
+            return RefFFI::null();
+        }
+    };
 
     match view_meta.view_metadata.columns_metadata.get(column_name) {
         Some(column_meta) => RefFFI::as_ptr(column_meta),

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -565,13 +565,7 @@ pub unsafe extern "C" fn cass_row_get_column_by_name<'result>(
     row: CassBorrowedSharedPtr<'result, CassRow<'result>, CConst>,
     name: *const c_char,
 ) -> CassBorrowedSharedPtr<'result, CassValue<'result>, CConst> {
-    let Some(name_str) = (unsafe { ptr_to_cstr(name) }) else {
-        tracing::error!("Provided null name pointer to cass_row_get_column_by_name!");
-        return RefFFI::null();
-    };
-    let name_length = name_str.len();
-
-    unsafe { cass_row_get_column_by_name_n(row, name, name_length as size_t) }
+    unsafe { cass_row_get_column_by_name_n(row, name, strlen(name)) }
 }
 
 #[unsafe(no_mangle)]
@@ -585,9 +579,16 @@ pub unsafe extern "C" fn cass_row_get_column_by_name_n<'result>(
         return RefFFI::null();
     };
 
-    let Some(name_str) = (unsafe { ptr_to_cstr_n(name, name_length) }) else {
-        tracing::error!("Provided null name pointer to cass_row_get_column_by_name_n!");
-        return RefFFI::null();
+    let name_str = match unsafe { ptr_to_cstr_n(name, name_length) } {
+        Ok(s) => s,
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Provided null name pointer to cass_row_get_column_by_name_n!");
+            return RefFFI::null();
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 name to cass_row_get_column_by_name_n!");
+            return RefFFI::null();
+        }
     };
     let mut name_str = name_str;
     let mut is_case_sensitive = false;
@@ -1294,7 +1295,7 @@ mod tests {
             )
         };
         assert_eq!(CassError::CASS_OK, cass_err);
-        unsafe { ptr_to_cstr_n(name_ptr, name_length) }
+        unsafe { ptr_to_cstr_n(name_ptr, name_length).ok() }
     }
 
     #[test]

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -565,7 +565,10 @@ pub unsafe extern "C" fn cass_row_get_column_by_name<'result>(
     row: CassBorrowedSharedPtr<'result, CassRow<'result>, CConst>,
     name: *const c_char,
 ) -> CassBorrowedSharedPtr<'result, CassValue<'result>, CConst> {
-    let name_str = unsafe { ptr_to_cstr(name) }.unwrap();
+    let Some(name_str) = (unsafe { ptr_to_cstr(name) }) else {
+        tracing::error!("Provided null name pointer to cass_row_get_column_by_name!");
+        return RefFFI::null();
+    };
     let name_length = name_str.len();
 
     unsafe { cass_row_get_column_by_name_n(row, name, name_length as size_t) }
@@ -582,7 +585,11 @@ pub unsafe extern "C" fn cass_row_get_column_by_name_n<'result>(
         return RefFFI::null();
     };
 
-    let mut name_str = unsafe { ptr_to_cstr_n(name, name_length).unwrap() };
+    let Some(name_str) = (unsafe { ptr_to_cstr_n(name, name_length) }) else {
+        tracing::error!("Provided null name pointer to cass_row_get_column_by_name_n!");
+        return RefFFI::null();
+    };
+    let mut name_str = name_str;
     let mut is_case_sensitive = false;
 
     if name_str.starts_with('\"') && name_str.ends_with('\"') {
@@ -1207,7 +1214,7 @@ mod tests {
     use scylla::response::query_result::ColumnSpecs;
 
     use crate::argconv::{CConst, CassBorrowedSharedPtr, ptr_to_cstr_n};
-    use crate::cql_types::data_type::{CassDataType, CassDataTypeInner};
+    use crate::cql_types::data_type::{CassColumnSpec, CassDataType, CassDataTypeInner};
     use crate::{
         argconv::{ArcFFI, RefFFI},
         cass_error::CassError,
@@ -1406,6 +1413,53 @@ mod tests {
                 );
                 assert_eq!(CassError::CASS_ERROR_LIB_BAD_PARAMS, cass_err);
             }
+        }
+    }
+
+    #[test]
+    fn test_cass_row_get_column_by_name_null_and_empty() {
+        let metadata = CassResultMetadata {
+            col_specs: vec![CassColumnSpec {
+                name: FIRST_COLUMN_NAME.to_owned(),
+                data_type: Arc::new(CassDataType::new(CassDataTypeInner::Value(
+                    CassValueType::CASS_VALUE_TYPE_BIGINT,
+                ))),
+            }],
+        };
+        let row = super::CassRow {
+            columns: Vec::new(),
+            result_metadata: &metadata,
+        };
+        let row_ptr = RefFFI::as_ptr(&row);
+
+        unsafe {
+            // -- non-_n variant --
+            // NULL name: caught by ptr_to_cstr before touching the row.
+            let value = super::cass_row_get_column_by_name(row_ptr.borrow(), std::ptr::null());
+            assert!(RefFFI::is_null(&value));
+
+            // Empty name: no column has an empty name, so returns null.
+            let value = super::cass_row_get_column_by_name(row_ptr.borrow(), c"".as_ptr());
+            assert!(RefFFI::is_null(&value));
+
+            // Nonexistent name: returns null.
+            let value =
+                super::cass_row_get_column_by_name(row_ptr.borrow(), c"no_such_col".as_ptr());
+            assert!(RefFFI::is_null(&value));
+
+            // -- _n variant (needs a real row to reach name checking) --
+            // NULL name: caught by ptr_to_cstr_n.
+            let value = super::cass_row_get_column_by_name_n(row_ptr.borrow(), std::ptr::null(), 0);
+            assert!(RefFFI::is_null(&value));
+
+            // Empty name (zero length): no match, returns null.
+            let value = super::cass_row_get_column_by_name_n(row_ptr.borrow(), c"x".as_ptr(), 0);
+            assert!(RefFFI::is_null(&value));
+
+            // Nonexistent name: returns null.
+            let value =
+                super::cass_row_get_column_by_name_n(row_ptr.borrow(), c"no_such_col".as_ptr(), 11);
+            assert!(RefFFI::is_null(&value));
         }
     }
 }

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -277,7 +277,14 @@ pub unsafe extern "C" fn cass_session_connect_keyspace_n(
         tracing::error!("Provided null cluster pointer to cass_session_connect_keyspace_n!");
         return ArcFFI::null();
     };
-    let keyspace = unsafe { ptr_to_cstr_n(keyspace, keyspace_length) }.map(ToOwned::to_owned);
+    let keyspace = match unsafe { ptr_to_cstr_n(keyspace, keyspace_length) } {
+        Ok(ks) => Some(ks.to_owned()),
+        Err(PtrToStrError::NullPointer) => None,
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 keyspace to cass_session_connect_keyspace_n!");
+            return ArcFFI::null();
+        }
+    };
 
     CassConnectedSession::connect(session, cluster, keyspace)
 }
@@ -581,12 +588,18 @@ pub unsafe extern "C" fn cass_session_prepare_n(
         return ArcFFI::null();
     };
 
-    let query_str = unsafe { ptr_to_cstr_n(query, query_length) }
+    let query_str = match unsafe { ptr_to_cstr_n(query, query_length) } {
+        Ok(s) => s,
         // Apparently nullptr denotes an empty statement string.
         // It seems to be intended (for some weird reason, why not save a round-trip???)
         // to receive a server error in such case (CASS_ERROR_SERVER_SYNTAX_ERROR).
         // There is a test for this: `NullStringApiArgsTest.Integration_Cassandra_PrepareNullQuery`.
-        .unwrap_or_default();
+        Err(PtrToStrError::NullPointer) => "",
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 query to cass_session_prepare(_n)!");
+            return ArcFFI::null();
+        }
+    };
 
     let Ok(session_guard) = cass_session.try_read_owned() else {
         return CassFuture::make_ready_raw(Err((

--- a/scylla-rust-wrapper/src/statements/prepared.rs
+++ b/scylla-rust-wrapper/src/statements/prepared.rs
@@ -274,8 +274,17 @@ pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name_n(
         return ArcFFI::null();
     };
 
-    let parameter_name =
-        unsafe { ptr_to_cstr_n(name, name_length).expect("Prepared parameter name is not UTF-8") };
+    let parameter_name = match unsafe { ptr_to_cstr_n(name, name_length) } {
+        Ok(name) => name,
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Prepared parameter name pointer is null");
+            return ArcFFI::null();
+        }
+        Err(PtrToStrError::InvalidUtf8(err)) => {
+            tracing::error!("Prepared parameter name is not valid UTF-8. Error: {err}");
+            return ArcFFI::null();
+        }
+    };
 
     let data_type = prepared.get_variable_data_type_by_name(parameter_name);
     match data_type {

--- a/scylla-rust-wrapper/src/statements/statement.rs
+++ b/scylla-rust-wrapper/src/statements/statement.rs
@@ -300,8 +300,15 @@ pub unsafe extern "C" fn cass_statement_new_n(
     parameter_count: size_t,
 ) -> CassOwnedExclusivePtr<CassStatement, CMut> {
     let query_str = match unsafe { ptr_to_cstr_n(query, query_length) } {
-        Some(v) => v,
-        None => return BoxFFI::null_mut(),
+        Ok(v) => v,
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Provided null query pointer to cass_statement_new(_n)!");
+            return BoxFFI::null_mut();
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 query to cass_statement_new(_n)!");
+            return BoxFFI::null_mut();
+        }
     };
 
     let query = Statement::new(query_str.to_string());
@@ -500,9 +507,13 @@ pub unsafe extern "C" fn cass_statement_set_host_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
     let host = match unsafe { ptr_to_cstr_n(host, host_length) } {
-        Some(v) => v,
-        None => {
-            tracing::error!("Provided null or non-utf8 host pointer to cass_statement_set_host_n!");
+        Ok(v) => v,
+        Err(PtrToStrError::NullPointer) => {
+            tracing::error!("Provided null host pointer to cass_statement_set_host_n!");
+            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+        }
+        Err(PtrToStrError::InvalidUtf8(_)) => {
+            tracing::error!("Provided non-UTF8 host pointer to cass_statement_set_host_n!");
             return CassError::CASS_ERROR_LIB_BAD_PARAMS;
         }
     };

--- a/scylla-rust-wrapper/src/statements/statement.rs
+++ b/scylla-rust-wrapper/src/statements/statement.rs
@@ -1066,4 +1066,35 @@ mod tests {
             cass_statement_free(statement_raw);
         }
     }
+
+    #[test]
+    fn test_bind_bytes_null_pointer() {
+        unsafe {
+            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+
+            // NULL pointer with size 0 produces empty blob (matching cpp-driver).
+            assert_cass_error_eq!(
+                CassError::CASS_OK,
+                super::cass_statement_bind_bytes(
+                    statement_raw.borrow_mut(),
+                    0,
+                    std::ptr::null(),
+                    0
+                )
+            );
+
+            // NULL pointer with non-zero size is an error.
+            assert_cass_error_eq!(
+                CassError::CASS_ERROR_LIB_BAD_PARAMS,
+                super::cass_statement_bind_bytes(
+                    statement_raw.borrow_mut(),
+                    0,
+                    std::ptr::null(),
+                    5
+                )
+            );
+
+            cass_statement_free(statement_raw);
+        }
+    }
 }

--- a/scylla-rust-wrapper/src/statements/statement.rs
+++ b/scylla-rust-wrapper/src/statements/statement.rs
@@ -1097,4 +1097,37 @@ mod tests {
             cass_statement_free(statement_raw);
         }
     }
+
+    #[test]
+    fn test_bind_decimal_null_pointer() {
+        unsafe {
+            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+
+            // NULL pointer with size 0 produces empty varint decimal.
+            assert_cass_error_eq!(
+                CassError::CASS_OK,
+                super::cass_statement_bind_decimal(
+                    statement_raw.borrow_mut(),
+                    0,
+                    std::ptr::null(),
+                    0,
+                    0
+                )
+            );
+
+            // NULL pointer with non-zero size is an error.
+            assert_cass_error_eq!(
+                CassError::CASS_ERROR_LIB_BAD_PARAMS,
+                super::cass_statement_bind_decimal(
+                    statement_raw.borrow_mut(),
+                    0,
+                    std::ptr::null(),
+                    5,
+                    0
+                )
+            );
+
+            cass_statement_free(statement_raw);
+        }
+    }
 }

--- a/scylla-rust-wrapper/src/statements/statement.rs
+++ b/scylla-rust-wrapper/src/statements/statement.rs
@@ -1130,4 +1130,64 @@ mod tests {
             cass_statement_free(statement_raw);
         }
     }
+
+    #[test]
+    fn test_bind_by_name_null_name() {
+        unsafe {
+            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+
+            // NULL name pointer should not crash — returns BAD_PARAMS.
+            assert_cass_error_eq!(
+                CassError::CASS_ERROR_LIB_BAD_PARAMS,
+                super::cass_statement_bind_int32_by_name(
+                    statement_raw.borrow_mut(),
+                    std::ptr::null(),
+                    42
+                )
+            );
+
+            // Same for the _n variant.
+            assert_cass_error_eq!(
+                CassError::CASS_ERROR_LIB_BAD_PARAMS,
+                super::cass_statement_bind_int32_by_name_n(
+                    statement_raw.borrow_mut(),
+                    std::ptr::null(),
+                    0,
+                    42
+                )
+            );
+
+            cass_statement_free(statement_raw);
+        }
+    }
+
+    #[test]
+    fn test_bind_by_name_empty_name() {
+        unsafe {
+            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+
+            // Empty name is a programmer error — returns BAD_PARAMS.
+            assert_cass_error_eq!(
+                CassError::CASS_ERROR_LIB_BAD_PARAMS,
+                super::cass_statement_bind_int32_by_name(
+                    statement_raw.borrow_mut(),
+                    c"".as_ptr(),
+                    42
+                )
+            );
+
+            // Same for the _n variant with non-null pointer and length 0.
+            assert_cass_error_eq!(
+                CassError::CASS_ERROR_LIB_BAD_PARAMS,
+                super::cass_statement_bind_int32_by_name_n(
+                    statement_raw.borrow_mut(),
+                    c"x".as_ptr(),
+                    0,
+                    42
+                )
+            );
+
+            cass_statement_free(statement_raw);
+        }
+    }
 }

--- a/scylla-rust-wrapper/src/statements/statement.rs
+++ b/scylla-rust-wrapper/src/statements/statement.rs
@@ -1020,4 +1020,50 @@ mod tests {
             cass_statement_free(statement_raw);
         }
     }
+
+    #[test]
+    fn test_bind_string_null_pointer() {
+        unsafe {
+            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+
+            // NULL pointer to cass_statement_bind_string produces empty string, not a crash.
+            assert_cass_error_eq!(
+                CassError::CASS_OK,
+                super::cass_statement_bind_string(statement_raw.borrow_mut(), 0, std::ptr::null())
+            );
+
+            cass_statement_free(statement_raw);
+        }
+    }
+
+    #[test]
+    fn test_bind_string_n_null_pointer() {
+        unsafe {
+            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+
+            // NULL pointer with size 0 produces empty string.
+            assert_cass_error_eq!(
+                CassError::CASS_OK,
+                super::cass_statement_bind_string_n(
+                    statement_raw.borrow_mut(),
+                    0,
+                    std::ptr::null(),
+                    0
+                )
+            );
+
+            // NULL pointer with non-zero size is an error.
+            assert_cass_error_eq!(
+                CassError::CASS_ERROR_LIB_BAD_PARAMS,
+                super::cass_statement_bind_string_n(
+                    statement_raw.borrow_mut(),
+                    0,
+                    std::ptr::null(),
+                    5
+                )
+            );
+
+            cass_statement_free(statement_raw);
+        }
+    }
 }

--- a/scylla-rust-wrapper/src/testing/utils.rs
+++ b/scylla-rust-wrapper/src/testing/utils.rs
@@ -50,7 +50,7 @@ macro_rules! assert_cass_future_error_message_eq {
         let mut ___message: *const c_char = ::std::ptr::null();
         let mut ___msg_len: size_t = 0;
         cass_future_error_message($cass_fut.borrow(), &mut ___message, &mut ___msg_len);
-        assert_eq!(ptr_to_cstr_n(___message, ___msg_len), $error_msg_opt);
+        assert_eq!(ptr_to_cstr_n(___message, ___msg_len).ok(), $error_msg_opt);
     };
 }
 pub(crate) use assert_cass_future_error_message_eq;
@@ -61,7 +61,7 @@ pub(crate) unsafe fn cass_future_wait_check_and_free(fut: CassOwnedSharedPtr<Cas
         let mut message: *const c_char = std::ptr::null();
         let mut message_len: size_t = 0;
         unsafe { cass_future_error_message(fut.borrow(), &mut message, &mut message_len) };
-        eprintln!("{:?}", unsafe { ptr_to_cstr_n(message, message_len) });
+        eprintln!("{:?}", unsafe { ptr_to_cstr_n(message, message_len).ok() });
     }
     unsafe {
         assert_cass_error_eq!(cass_future_error_code(fut.borrow()), CassError::CASS_OK);


### PR DESCRIPTION
Fixes: #446
Ref: #301

#446 revealed issues with our handling of NULL string pointers in user-facing APIs. Together with Claude Opus, I examined vulnerable spots in the code:
1. Fixed UB in `binding.rs` - variations of the originally reported issue.
2. Fixed UB/panics in `cass_row_get_column_by_name[_n]` upon null name provided.
3. Fixed `ptr_to_cstr` to return `None` on NULL pointers instead of UB. This made behaviour consistent with `ptr_to_cstr_n`.
4. Refactored `ptr_to_cstr[_n]` to return `Result<&'static str, PtrToStrError>`, with `PtrToStrError` differentiating between null pointer provided and invalid UTF-8 encoding. Migrated all callers carefully.

### Further plans

I'm going to address #301 fully soon, by introducing borrowed `CassStr*` FFI types: #449

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
- [x] I added appropriate `Fixes:` annotations to PR description.
