### PR TITLE
Introduce `CassStr*` abstractions

### DIFF
--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -7,7 +7,7 @@ use std::ptr::NonNull;
 use std::sync::{Arc, Weak};
 use thiserror::Error;
 
-/// Error type for `ptr_to_cstr` and `ptr_to_cstr_n`, distinguishing
+/// Error type for C string pointer conversions, distinguishing
 /// a null pointer from invalid UTF-8 input.
 #[derive(Debug, Error)]
 pub enum PtrToStrError {
@@ -37,12 +37,13 @@ pub unsafe fn ptr_to_cstr_n(
         .map_err(PtrToStrError::InvalidUtf8)
 }
 
-pub(crate) unsafe fn arr_to_cstr<const N: usize>(
-    arr: &[c_char],
-) -> Result<&'static str, PtrToStrError> {
+pub(crate) unsafe fn arr_to_cstr<const N: usize>(arr: &[c_char]) -> Result<&str, PtrToStrError> {
     let null_char = '\0' as c_char;
     let end_index = arr[..N].iter().position(|c| c == &null_char).unwrap_or(N);
-    unsafe { ptr_to_cstr_n(arr.as_ptr(), end_index as size_t) }
+    unsafe {
+        CassStrLenDelimited::from_raw(arr.as_ptr())
+            .to_str(CassStrLen::from_raw(end_index as size_t))
+    }
 }
 
 pub(crate) fn str_to_arr<const N: usize>(s: &str) -> [c_char; N] {
@@ -76,6 +77,205 @@ pub(crate) unsafe fn strlen(ptr: *const c_char) -> size_t {
     unsafe { libc::strlen(ptr) as size_t }
 }
 
+/// A null-terminated C string pointer with lifetime tracking.
+///
+/// ABI-compatible with `*const c_char` thanks to `#[repr(transparent)]`.
+/// Can be used directly as an FFI function parameter — the C caller passes
+/// a `const char*`, and Rust receives a `CassStrNulTerminated<'_>`.
+///
+/// Must be paired with [`CassStrNulTerminated::to_str`] to obtain a `&str`.
+#[repr(transparent)]
+pub struct CassStrNulTerminated<'a> {
+    ptr: CassBorrowedSharedPtr<'a, c_char, CConst>,
+}
+
+impl Clone for CassStrNulTerminated<'_> {
+    fn clone(&self) -> Self {
+        Self {
+            ptr: CassBorrowedSharedPtr {
+                ptr: self.ptr.ptr,
+                _phantom: PhantomData,
+            },
+        }
+    }
+}
+
+impl<'a> CassStrNulTerminated<'a> {
+    pub fn is_null(&self) -> bool {
+        self.ptr.is_null()
+    }
+
+    /// Creates a `CassStrNulTerminated` from a raw pointer.
+    // The pointer is not dereferenced here, just stored.
+    #[expect(clippy::not_unsafe_ptr_arg_deref)]
+    pub const fn from_raw(ptr: *const c_char) -> Self {
+        CassStrNulTerminated {
+            // SAFETY: CassStrNulTerminated existence does not guarantee that the pointer
+            // is valid. CassStrNulTerminated::to_str() is the only method that requires
+            // a valid pointer and it's `unsafe`, and it is the user's responsibility to ensure
+            // that the pointer is valid when calling that method.
+            ptr: unsafe { CassBorrowedSharedPtr::from_raw(ptr) },
+        }
+    }
+
+    /// Creates a `CassStrNulTerminated` from a `&CStr`.
+    ///
+    /// This is the safe alternative to [`from_raw`](Self::from_raw).
+    pub const fn from_cstr(cstr: &'a CStr) -> Self {
+        // SAFETY: CStr guarantees that the pointer is valid, null-terminated,
+        // and the lifetime parameter flows through.
+        CassStrNulTerminated {
+            ptr: unsafe { CassBorrowedSharedPtr::from_raw(cstr.as_ptr()) },
+        }
+    }
+
+    /// Converts the pointer to a `&str` by scanning for a null terminator
+    /// and validating UTF-8.
+    ///
+    /// # Safety
+    ///
+    /// If the pointer is non-null, the caller must ensure it points to valid,
+    /// readable, null-terminated memory.
+    ///
+    /// Unlike [`CassPtr::into_ref`], which is safe because `CassPtr` wraps
+    /// pointers to **driver-allocated** objects (via `Box`/`Arc`) whose validity
+    /// is established at construction by the driver itself, this type wraps
+    /// pointers to **user-allocated** C strings. The driver has no control over
+    /// the pointed-to memory, so the actual unsafe operation ([`CStr::from_ptr`],
+    /// which scans for a null terminator) is deferred to this method rather than
+    /// being absorbed at construction time.
+    pub unsafe fn to_str(&self) -> Result<&'a str, PtrToStrError> {
+        let Some(non_null_ptr) = self.ptr.to_raw() else {
+            return Err(PtrToStrError::NullPointer);
+        };
+        unsafe { CStr::from_ptr(non_null_ptr) }
+            .to_str()
+            .map_err(PtrToStrError::InvalidUtf8)
+    }
+
+    /// Converts a null-terminated string to a length-delimited string and its
+    /// length, for forwarding non-`_n` functions to their `_n` variants.
+    ///
+    /// Returns a null `CassStrLenDelimited` and zero `CassStrLen` if the
+    /// pointer is null, preserving null semantics for the `_n` callee.
+    ///
+    /// # Safety
+    ///
+    /// If the pointer is non-null, the caller must ensure it points to valid,
+    /// readable, null-terminated memory (same as [`CassStrNulTerminated::to_str`]).
+    pub unsafe fn as_len_delimited(&self) -> (CassStrLenDelimited<'a>, CassStrLen) {
+        let Some(non_null_ptr) = self.ptr.to_raw() else {
+            return (
+                CassStrLenDelimited::from_raw(std::ptr::null()),
+                CassStrLen::from_raw(0),
+            );
+        };
+        let len = unsafe { strlen(non_null_ptr) };
+        (
+            CassStrLenDelimited::from_raw(non_null_ptr),
+            CassStrLen::from_raw(len),
+        )
+    }
+}
+
+/// A length-delimited C string pointer with lifetime tracking (no null
+/// terminator required).
+///
+/// ABI-compatible with `*const c_char` thanks to `#[repr(transparent)]`.
+/// Can be used directly as an FFI function parameter — the C caller passes
+/// a `const char*`, and Rust receives a `CassStrLenDelimited<'_>`.
+///
+/// Must be paired with a [`CassStrLen`] parameter to convert to `&str`
+/// via [`CassStrLenDelimited::to_str`].
+#[repr(transparent)]
+pub struct CassStrLenDelimited<'a> {
+    ptr: CassBorrowedSharedPtr<'a, c_char, CConst>,
+}
+
+impl Clone for CassStrLenDelimited<'_> {
+    fn clone(&self) -> Self {
+        Self {
+            ptr: CassBorrowedSharedPtr {
+                ptr: self.ptr.ptr,
+                _phantom: PhantomData,
+            },
+        }
+    }
+}
+
+impl<'a> CassStrLenDelimited<'a> {
+    pub fn is_null(&self) -> bool {
+        self.ptr.is_null()
+    }
+
+    /// Creates a `CassStrLenDelimited` from a raw pointer.
+    // The pointer is not dereferenced here, just stored.
+    #[expect(clippy::not_unsafe_ptr_arg_deref)]
+    pub fn from_raw(ptr: *const c_char) -> Self {
+        CassStrLenDelimited {
+            // SAFETY: CassStrLenDelimited existence does not guarantee that the pointer
+            // is valid. CassStrLenDelimited::to_str() is the only method that requires
+            // a valid pointer.
+            ptr: unsafe { CassBorrowedSharedPtr::from_raw(ptr) },
+        }
+    }
+
+    /// Converts the pointer to a `&str` using the provided length
+    /// and validating UTF-8.
+    ///
+    /// # Safety
+    ///
+    /// If the pointer is non-null, the caller must ensure it points to valid,
+    /// readable memory of at least `len` bytes.
+    ///
+    /// Unlike [`CassPtr::into_ref`], which is safe because `CassPtr` wraps
+    /// pointers to **driver-allocated** objects (via `Box`/`Arc`) whose validity
+    /// is established at construction by the driver itself, this type wraps
+    /// pointers to **user-allocated** C strings. The driver has no control over
+    /// the pointed-to memory, so the actual unsafe operation
+    /// ([`std::slice::from_raw_parts`]) is deferred to this method rather than
+    /// being absorbed at construction time.
+    pub unsafe fn to_str(&self, len: CassStrLen) -> Result<&'a str, PtrToStrError> {
+        let Some(non_null_ptr) = self.ptr.to_raw() else {
+            return Err(PtrToStrError::NullPointer);
+        };
+        std::str::from_utf8(unsafe {
+            std::slice::from_raw_parts(non_null_ptr as *const u8, len.len as usize)
+        })
+        .map_err(PtrToStrError::InvalidUtf8)
+    }
+
+    #[cfg(test)]
+    #[expect(dead_code, reason = "used after call-site migration")]
+    pub(crate) fn null() -> CassStrLenDelimited<'a> {
+        Self {
+            ptr: CassBorrowedSharedPtr::null(),
+        }
+    }
+}
+
+/// The length component for [`CassStrLenDelimited`].
+///
+/// ABI-compatible with `size_t` thanks to `#[repr(transparent)]`.
+/// Can be used directly as an FFI function parameter — the C caller passes
+/// a `size_t`, and Rust receives a `CassStrLen`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct CassStrLen {
+    len: size_t,
+}
+
+impl CassStrLen {
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Creates a `CassStrLen` from a raw `size_t`.
+    pub fn from_raw(len: size_t) -> Self {
+        CassStrLen { len }
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn str_to_c_str_n(s: &str) -> (*const c_char, size_t) {
     let mut c_str = std::ptr::null();
@@ -90,7 +290,7 @@ pub(crate) fn str_to_c_str_n(s: &str) -> (*const c_char, size_t) {
 #[cfg(test)]
 macro_rules! make_c_str {
     ($str:literal) => {
-        concat!($str, "\0").as_ptr() as *const c_char
+        concat!($str, "\0").as_ptr() as *const std::ffi::c_char
     };
 }
 
@@ -278,7 +478,7 @@ impl<T: Sized, P: Properties> CassPtr<'_, T, P> {
     /// User needs to ensure that the pointer is **valid**.
     /// User is also responsible for picking correct ownership property and lifetime
     /// of the created pointer. For more information, see the documentation of [`CassPtr`].
-    unsafe fn from_raw(raw: *const T) -> Self {
+    const unsafe fn from_raw(raw: *const T) -> Self {
         CassPtr {
             ptr: NonNull::new(raw as *mut T),
             _phantom: PhantomData,

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -17,26 +17,6 @@ pub enum PtrToStrError {
     InvalidUtf8(std::str::Utf8Error),
 }
 
-pub unsafe fn ptr_to_cstr(ptr: *const c_char) -> Result<&'static str, PtrToStrError> {
-    if ptr.is_null() {
-        return Err(PtrToStrError::NullPointer);
-    }
-    unsafe { CStr::from_ptr(ptr) }
-        .to_str()
-        .map_err(PtrToStrError::InvalidUtf8)
-}
-
-pub unsafe fn ptr_to_cstr_n(
-    ptr: *const c_char,
-    size: size_t,
-) -> Result<&'static str, PtrToStrError> {
-    if ptr.is_null() {
-        return Err(PtrToStrError::NullPointer);
-    }
-    std::str::from_utf8(unsafe { std::slice::from_raw_parts(ptr as *const u8, size as usize) })
-        .map_err(PtrToStrError::InvalidUtf8)
-}
-
 pub(crate) unsafe fn arr_to_cstr<const N: usize>(arr: &[c_char]) -> Result<&str, PtrToStrError> {
     let null_char = '\0' as c_char;
     let end_index = arr[..N].iter().position(|c| c == &null_char).unwrap_or(N);
@@ -246,7 +226,6 @@ impl<'a> CassStrLenDelimited<'a> {
     }
 
     #[cfg(test)]
-    #[expect(dead_code, reason = "used after call-site migration")]
     pub(crate) fn null() -> CassStrLenDelimited<'a> {
         Self {
             ptr: CassBorrowedSharedPtr::null(),

--- a/scylla-rust-wrapper/src/argconv.rs
+++ b/scylla-rust-wrapper/src/argconv.rs
@@ -17,15 +17,6 @@ pub enum PtrToStrError {
     InvalidUtf8(std::str::Utf8Error),
 }
 
-pub(crate) unsafe fn arr_to_cstr<const N: usize>(arr: &[c_char]) -> Result<&str, PtrToStrError> {
-    let null_char = '\0' as c_char;
-    let end_index = arr[..N].iter().position(|c| c == &null_char).unwrap_or(N);
-    unsafe {
-        CassStrLenDelimited::from_raw(arr.as_ptr())
-            .to_str(CassStrLen::from_raw(end_index as size_t))
-    }
-}
-
 pub(crate) fn str_to_arr<const N: usize>(s: &str) -> [c_char; N] {
     let mut result = ['\0' as c_char; N];
 

--- a/scylla-rust-wrapper/src/binding.rs
+++ b/scylla-rust-wrapper/src/binding.rs
@@ -78,7 +78,7 @@ macro_rules! make_name_binder {
         #[allow(clippy::redundant_closure_call)]
         pub unsafe extern "C" fn $fn_by_name(
             this: CassBorrowedExclusivePtr<$this, CMut>,
-            name: *const c_char,
+            name: CassStrNulTerminated<'_>,
             $($arg: $t), *
         ) -> CassError {
             // For some reason detected as unused, which is not true
@@ -93,7 +93,7 @@ macro_rules! make_name_binder {
             // it as an empty string via SAFE_STRLEN), but we
             // purposefully diverge and return an error early instead of
             // silently binding to a bogus empty-named parameter.
-            let name = match unsafe { ptr_to_cstr(name) } {
+            let name = match unsafe { name.to_str() } {
                 Ok(name) if !name.is_empty() => name,
                 Ok(_) => {
                     tracing::error!("Provided empty name to {}!", stringify!($fn_by_name));
@@ -122,8 +122,8 @@ macro_rules! make_name_n_binder {
         #[allow(clippy::redundant_closure_call)]
         pub unsafe extern "C" fn $fn_by_name_n(
             this: CassBorrowedExclusivePtr<$this, CMut>,
-            name: *const c_char,
-            name_length: size_t,
+            name: CassStrLenDelimited<'_>,
+            name_length: CassStrLen,
             $($arg: $t), *
         ) -> CassError {
             // For some reason detected as unused, which is not true
@@ -138,7 +138,7 @@ macro_rules! make_name_n_binder {
             // it as an empty string via SAFE_STRLEN), but we
             // purposefully diverge and return an error early instead of
             // silently binding to a bogus empty-named parameter.
-            let name = match unsafe { ptr_to_cstr_n(name, name_length) } {
+            let name = match unsafe { name.to_str(name_length) } {
                 Ok(name) if !name.is_empty() => name,
                 Ok(_) => {
                     tracing::error!("Provided empty name to {}!", stringify!($fn_by_name_n));
@@ -271,15 +271,15 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |v: *const std::os::raw::c_char| {
+            |v: CassStrNulTerminated<'_>| {
                 // cpp-driver treats NULL as empty string (via SAFE_STRLEN).
-                match unsafe { ptr_to_cstr(v) } {
+                match unsafe { v.to_str() } {
                     Ok(s) => Ok(Some(Text(s.to_string()))),
                     Err(PtrToStrError::NullPointer) => Ok(Some(Text(String::new()))),
                     Err(PtrToStrError::InvalidUtf8(_)) => Err(CassError::CASS_ERROR_LIB_BAD_PARAMS),
                 }
             },
-            [v @ *const std::os::raw::c_char]
+            [v @ CassStrNulTerminated<'_>]
         );
     };
     (string_n, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {
@@ -287,16 +287,17 @@ macro_rules! invoke_binder_maker_macro_with_type {
             $this,
             $consume_v,
             $fn,
-            |v: *const std::os::raw::c_char, n| {
-                // cpp-driver treats NULL as empty string (via SAFE_STRLEN).
-                match unsafe { ptr_to_cstr_n(v, n) } {
+            |v: CassStrLenDelimited<'_>, n: CassStrLen| {
+                match unsafe { v.to_str(n) } {
                     Ok(s) => Ok(Some(Text(s.to_string()))),
-                    Err(PtrToStrError::NullPointer) if n != 0 => Err(CassError::CASS_ERROR_LIB_BAD_PARAMS),
-                    Err(PtrToStrError::NullPointer) => Ok(Some(Text(String::new()))),
+                    // cpp-driver treats NULL+0 as empty string (via SAFE_STRLEN).
+                    Err(PtrToStrError::NullPointer) if n.is_empty() => Ok(Some(Text(String::new()))),
+                    // NULL+n>0 is clearly a programmer error.
+                    Err(PtrToStrError::NullPointer) => Err(CassError::CASS_ERROR_LIB_BAD_PARAMS),
                     Err(PtrToStrError::InvalidUtf8(_)) => Err(CassError::CASS_ERROR_LIB_BAD_PARAMS),
                 }
             },
-            [v @ *const std::os::raw::c_char, n @ size_t]
+            [v @ CassStrLenDelimited<'_>, n @ CassStrLen]
         );
     };
     (bytes, $macro_name:ident, $this:ty, $consume_v:expr, $fn:ident) => {

--- a/scylla-rust-wrapper/src/cass_error.rs
+++ b/scylla-rust-wrapper/src/cass_error.rs
@@ -1,7 +1,6 @@
 use crate::argconv::*;
 use crate::cql_types::{CassConsistency, CassWriteType};
 use crate::types::*;
-use libc::c_char;
 use scylla::deserialize::DeserializationError;
 use scylla::errors::{
     BadKeyspaceName, BadQuery, ConnectionPoolError, DbError, ExecutionError, MetadataError,
@@ -670,7 +669,7 @@ pub unsafe extern "C" fn cass_error_result_arg_type(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_error_desc(error: CassError) -> *const c_char {
+pub unsafe extern "C" fn cass_error_desc(error: CassError) -> CassStrNulTerminated<'static> {
     let desc = match error {
         CassError::CASS_ERROR_LIB_BAD_PARAMS => c"Bad parameters",
         CassError::CASS_ERROR_LIB_NO_STREAMS => c"No streams available",
@@ -741,5 +740,5 @@ pub unsafe extern "C" fn cass_error_desc(error: CassError) -> *const c_char {
         _ => c"",
     };
 
-    desc.as_ptr()
+    CassStrNulTerminated::from_cstr(desc)
 }

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -38,7 +38,7 @@ use std::convert::TryInto;
 use std::future::Future;
 use std::net::IpAddr;
 use std::num::{NonZero, NonZeroUsize};
-use std::os::raw::{c_char, c_int, c_uint, c_void};
+use std::os::raw::{c_int, c_uint, c_void};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -379,16 +379,17 @@ pub unsafe extern "C" fn cass_cluster_free(cluster: CassOwnedExclusivePtr<CassCl
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_contact_points(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    contact_points: *const c_char,
+    contact_points: CassStrNulTerminated<'_>,
 ) -> CassError {
-    unsafe { cass_cluster_set_contact_points_n(cluster, contact_points, strlen(contact_points)) }
+    let (contact_points, contact_points_length) = unsafe { contact_points.as_len_delimited() };
+    unsafe { cass_cluster_set_contact_points_n(cluster, contact_points, contact_points_length) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_contact_points_n(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    contact_points: *const c_char,
-    contact_points_length: size_t,
+    contact_points: CassStrLenDelimited<'_>,
+    contact_points_length: CassStrLen,
 ) -> CassError {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster) else {
         tracing::error!("Provided null cluster pointer to cass_cluster_set_contact_points_n!");
@@ -420,8 +421,8 @@ pub unsafe extern "C" fn cass_cluster_set_contact_points_n(
 /// `convert` function should filter out invalid items - they will be ignored.
 pub(crate) unsafe fn update_comma_delimited_list<T, F>(
     list: &mut Vec<T>,
-    item_ptr: *const c_char,
-    item_length: size_t,
+    item_ptr: CassStrLenDelimited<'_>,
+    item_length: CassStrLen,
     convert: F,
 ) -> Result<(), CassError>
 where
@@ -429,7 +430,7 @@ where
 {
     // item_ptr is null if the user provided a null string.
     // null string is equivalent to empty string in this case - it clears the list.
-    let item_str = match unsafe { ptr_to_cstr_n(item_ptr, item_length) } {
+    let item_str = match unsafe { item_ptr.to_str(item_length) } {
         Ok(h) => Some(h),
         Err(PtrToStrError::NullPointer) => None,
         Err(PtrToStrError::InvalidUtf8(_)) => {
@@ -465,22 +466,23 @@ where
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_application_name(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    app_name: *const c_char,
+    app_name: CassStrNulTerminated<'_>,
 ) {
-    unsafe { cass_cluster_set_application_name_n(cluster_raw, app_name, strlen(app_name)) }
+    let (app_name, app_name_len) = unsafe { app_name.as_len_delimited() };
+    unsafe { cass_cluster_set_application_name_n(cluster_raw, app_name, app_name_len) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_application_name_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    app_name: *const c_char,
-    app_name_len: size_t,
+    app_name: CassStrLenDelimited<'_>,
+    app_name_len: CassStrLen,
 ) {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
         tracing::error!("Provided null cluster pointer to cass_cluster_set_application_name_n!");
         return;
     };
-    let app_name = match unsafe { ptr_to_cstr_n(app_name, app_name_len) } {
+    let app_name = match unsafe { app_name.to_str(app_name_len) } {
         Ok(s) => s.to_string(),
         Err(PtrToStrError::NullPointer) => {
             tracing::error!(
@@ -504,22 +506,23 @@ pub unsafe extern "C" fn cass_cluster_set_application_name_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_application_version(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    app_version: *const c_char,
+    app_version: CassStrNulTerminated<'_>,
 ) {
-    unsafe { cass_cluster_set_application_version_n(cluster_raw, app_version, strlen(app_version)) }
+    let (app_version, app_version_len) = unsafe { app_version.as_len_delimited() };
+    unsafe { cass_cluster_set_application_version_n(cluster_raw, app_version, app_version_len) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_application_version_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    app_version: *const c_char,
-    app_version_len: size_t,
+    app_version: CassStrLenDelimited<'_>,
+    app_version_len: CassStrLen,
 ) {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
         tracing::error!("Provided null cluster pointer to cass_cluster_set_application_version_n!");
         return;
     };
-    let app_version = match unsafe { ptr_to_cstr_n(app_version, app_version_len) } {
+    let app_version = match unsafe { app_version.to_str(app_version_len) } {
         Ok(s) => s.to_string(),
         Err(PtrToStrError::NullPointer) => {
             tracing::error!(
@@ -864,17 +867,17 @@ pub unsafe extern "C" fn cass_cluster_set_port(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_local_address(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    ip: *const c_char,
+    ip: CassStrNulTerminated<'_>,
 ) -> CassError {
-    // Safety: We assume that string is null-terminated.
-    unsafe { cass_cluster_set_local_address_n(cluster_raw, ip, strlen(ip)) }
+    let (ip, ip_length) = unsafe { ip.as_len_delimited() };
+    unsafe { cass_cluster_set_local_address_n(cluster_raw, ip, ip_length) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_local_address_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    ip: *const c_char,
-    ip_length: size_t,
+    ip: CassStrLenDelimited<'_>,
+    ip_length: CassStrLen,
 ) -> CassError {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
         tracing::error!("Provided null cluster pointer to cass_cluster_set_local_address_n!");
@@ -883,21 +886,23 @@ pub unsafe extern "C" fn cass_cluster_set_local_address_n(
 
     // Semantics from cpp-driver - if pointer is null or length is 0, use the
     // arbitrary address (INADDR_ANY, or in6addr_any).
-    //
-    // SAFETY: We assume that user provides valid pointer and length.
-    let local_addr: Option<IpAddr> = match unsafe { ptr_to_cstr_n(ip, ip_length) } {
-        Ok(_) if ip_length == 0 => None,
-        Ok(ip_str) => match IpAddr::from_str(ip_str) {
-            Ok(addr) => Some(addr),
-            Err(err) => {
-                tracing::error!("Failed to parse ip address <{}>: {}", ip_str, err);
+    let local_addr: Option<IpAddr> = if ip_length.is_empty() {
+        None
+    } else {
+        // SAFETY: We assume that user provides valid pointer and length.
+        match unsafe { ip.to_str(ip_length) } {
+            Ok(ip_str) => match IpAddr::from_str(ip_str) {
+                Ok(addr) => Some(addr),
+                Err(err) => {
+                    tracing::error!("Failed to parse ip address <{}>: {}", ip_str, err);
+                    return CassError::CASS_ERROR_LIB_BAD_PARAMS;
+                }
+            },
+            Err(PtrToStrError::NullPointer) => None,
+            Err(PtrToStrError::InvalidUtf8(_)) => {
+                tracing::error!("Provided non-UTF8 ip string to cass_cluster_set_local_address_n!");
                 return CassError::CASS_ERROR_LIB_BAD_PARAMS;
             }
-        },
-        Err(PtrToStrError::NullPointer) => None,
-        Err(PtrToStrError::InvalidUtf8(_)) => {
-            tracing::error!("Provided non-UTF8 ip string to cass_cluster_set_local_address_n!");
-            return CassError::CASS_ERROR_LIB_BAD_PARAMS;
         }
     };
 
@@ -950,16 +955,18 @@ pub unsafe extern "C" fn cass_cluster_set_local_port_range(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_credentials(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    username: *const c_char,
-    password: *const c_char,
+    username: CassStrNulTerminated<'_>,
+    password: CassStrNulTerminated<'_>,
 ) {
+    let (username, username_length) = unsafe { username.as_len_delimited() };
+    let (password, password_length) = unsafe { password.as_len_delimited() };
     unsafe {
         cass_cluster_set_credentials_n(
             cluster,
             username,
-            strlen(username),
+            username_length,
             password,
-            strlen(password),
+            password_length,
         )
     }
 }
@@ -967,16 +974,16 @@ pub unsafe extern "C" fn cass_cluster_set_credentials(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_credentials_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    username_raw: *const c_char,
-    username_length: size_t,
-    password_raw: *const c_char,
-    password_length: size_t,
+    username_raw: CassStrLenDelimited<'_>,
+    username_length: CassStrLen,
+    password_raw: CassStrLenDelimited<'_>,
+    password_length: CassStrLen,
 ) {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
         tracing::error!("Provided null cluster pointer to cass_cluster_set_credentials_n!");
         return;
     };
-    let username = match unsafe { ptr_to_cstr_n(username_raw, username_length) } {
+    let username = match unsafe { username_raw.to_str(username_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Provided null username pointer to cass_cluster_set_credentials(_n)!");
@@ -987,7 +994,7 @@ pub unsafe extern "C" fn cass_cluster_set_credentials_n(
             return;
         }
     };
-    let password = match unsafe { ptr_to_cstr_n(password_raw, password_length) } {
+    let password = match unsafe { password_raw.to_str(password_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Provided null password pointer to cass_cluster_set_credentials(_n)!");
@@ -1020,15 +1027,16 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_round_robin(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    local_dc: *const c_char,
+    local_dc: CassStrNulTerminated<'_>,
     used_hosts_per_remote_dc: c_uint,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
+    let (local_dc, local_dc_length) = unsafe { local_dc.as_len_delimited() };
     unsafe {
         cass_cluster_set_load_balance_dc_aware_n(
             cluster,
             local_dc,
-            strlen(local_dc),
+            local_dc_length,
             used_hosts_per_remote_dc,
             allow_remote_dcs_for_local_cl,
         )
@@ -1037,12 +1045,12 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware(
 
 pub(crate) unsafe fn set_load_balance_dc_aware_n(
     load_balancing_config: &mut LoadBalancingConfig,
-    local_dc_raw: *const c_char,
-    local_dc_length: size_t,
+    local_dc_raw: CassStrLenDelimited<'_>,
+    local_dc_length: CassStrLen,
     used_hosts_per_remote_dc: c_uint,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
-    let local_dc = match unsafe { ptr_to_cstr_n(local_dc_raw, local_dc_length) } {
+    let local_dc = match unsafe { local_dc_raw.to_str(local_dc_length) } {
         Ok(dc) => dc,
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Provided null local DC name to cass_*_set_load_balance_dc_aware(_n)!");
@@ -1056,7 +1064,7 @@ pub(crate) unsafe fn set_load_balance_dc_aware_n(
         }
     };
 
-    if local_dc_length == 0 {
+    if local_dc_length.is_empty() {
         tracing::error!("Provided empty local DC name to cass_*_set_load_balance_dc_aware(_n)!");
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     }
@@ -1094,8 +1102,8 @@ pub(crate) unsafe fn set_load_balance_dc_aware_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    local_dc_raw: *const c_char,
-    local_dc_length: size_t,
+    local_dc_raw: CassStrLenDelimited<'_>,
+    local_dc_length: CassStrLen,
     used_hosts_per_remote_dc: c_uint,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
@@ -1120,16 +1128,18 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_dc_aware_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    local_dc_raw: *const c_char,
-    local_rack_raw: *const c_char,
+    local_dc_raw: CassStrNulTerminated<'_>,
+    local_rack_raw: CassStrNulTerminated<'_>,
 ) -> CassError {
+    let (local_dc, local_dc_length) = unsafe { local_dc_raw.as_len_delimited() };
+    let (local_rack, local_rack_length) = unsafe { local_rack_raw.as_len_delimited() };
     unsafe {
         cass_cluster_set_load_balance_rack_aware_n(
             cluster_raw,
-            local_dc_raw,
-            strlen(local_dc_raw),
-            local_rack_raw,
-            strlen(local_rack_raw),
+            local_dc,
+            local_dc_length,
+            local_rack,
+            local_rack_length,
         )
     }
 }
@@ -1137,10 +1147,10 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    local_dc_raw: *const c_char,
-    local_dc_length: size_t,
-    local_rack_raw: *const c_char,
-    local_rack_length: size_t,
+    local_dc_raw: CassStrLenDelimited<'_>,
+    local_dc_length: CassStrLen,
+    local_rack_raw: CassStrLenDelimited<'_>,
+    local_rack_length: CassStrLen,
 ) -> CassError {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
         tracing::error!(
@@ -1162,16 +1172,17 @@ pub unsafe extern "C" fn cass_cluster_set_load_balance_rack_aware_n(
 
 pub(crate) unsafe fn set_load_balance_rack_aware_n(
     load_balancing_config: &mut LoadBalancingConfig,
-    local_dc_raw: *const c_char,
-    local_dc_length: size_t,
-    local_rack_raw: *const c_char,
-    local_rack_length: size_t,
+    local_dc_raw: CassStrLenDelimited<'_>,
+    local_dc_length: CassStrLen,
+    local_rack_raw: CassStrLenDelimited<'_>,
+    local_rack_length: CassStrLen,
 ) -> CassError {
-    let (local_dc, local_rack) = match (
-        unsafe { ptr_to_cstr_n(local_dc_raw, local_dc_length) },
-        unsafe { ptr_to_cstr_n(local_rack_raw, local_rack_length) },
-    ) {
-        (Ok(local_dc_str), Ok(local_rack_str)) if local_dc_length > 0 && local_rack_length > 0 => {
+    let (local_dc, local_rack) = match (unsafe { local_dc_raw.to_str(local_dc_length) }, unsafe {
+        local_rack_raw.to_str(local_rack_length)
+    }) {
+        (Ok(local_dc_str), Ok(local_rack_str))
+            if !local_dc_length.is_empty() && !local_rack_length.is_empty() =>
+        {
             (local_dc_str.to_owned(), local_rack_str.to_owned())
         }
         // One of them either is a null pointer, is an empty string or is not a proper UTF-8.
@@ -1413,16 +1424,17 @@ pub unsafe extern "C" fn cass_cluster_set_latency_aware_routing_settings(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_whitelist_filtering(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    hosts: *const c_char,
+    hosts: CassStrNulTerminated<'_>,
 ) {
-    unsafe { cass_cluster_set_whitelist_filtering_n(cluster_raw, hosts, strlen(hosts)) }
+    let (hosts, hosts_size) = unsafe { hosts.as_len_delimited() };
+    unsafe { cass_cluster_set_whitelist_filtering_n(cluster_raw, hosts, hosts_size) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_whitelist_filtering_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    hosts: *const c_char,
-    hosts_size: size_t,
+    hosts: CassStrLenDelimited<'_>,
+    hosts_size: CassStrLen,
 ) {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
         tracing::error!("Provided null cluster pointer to cass_cluster_set_whitelist_filtering_n!");
@@ -1450,16 +1462,17 @@ pub unsafe extern "C" fn cass_cluster_set_whitelist_filtering_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_blacklist_filtering(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    hosts: *const c_char,
+    hosts: CassStrNulTerminated<'_>,
 ) {
-    unsafe { cass_cluster_set_blacklist_filtering_n(cluster_raw, hosts, strlen(hosts)) }
+    let (hosts, hosts_size) = unsafe { hosts.as_len_delimited() };
+    unsafe { cass_cluster_set_blacklist_filtering_n(cluster_raw, hosts, hosts_size) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_blacklist_filtering_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    hosts: *const c_char,
-    hosts_size: size_t,
+    hosts: CassStrLenDelimited<'_>,
+    hosts_size: CassStrLen,
 ) {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
         tracing::error!("Provided null cluster pointer to cass_cluster_set_blacklist_filtering_n!");
@@ -1485,16 +1498,17 @@ pub unsafe extern "C" fn cass_cluster_set_blacklist_filtering_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_whitelist_dc_filtering(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    dcs: *const c_char,
+    dcs: CassStrNulTerminated<'_>,
 ) {
-    unsafe { cass_cluster_set_whitelist_dc_filtering_n(cluster_raw, dcs, strlen(dcs)) }
+    let (dcs, dcs_size) = unsafe { dcs.as_len_delimited() };
+    unsafe { cass_cluster_set_whitelist_dc_filtering_n(cluster_raw, dcs, dcs_size) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_whitelist_dc_filtering_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    dcs: *const c_char,
-    dcs_size: size_t,
+    dcs: CassStrLenDelimited<'_>,
+    dcs_size: CassStrLen,
 ) {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
         tracing::error!(
@@ -1517,16 +1531,17 @@ pub unsafe extern "C" fn cass_cluster_set_whitelist_dc_filtering_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_blacklist_dc_filtering(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    dcs: *const c_char,
+    dcs: CassStrNulTerminated<'_>,
 ) {
-    unsafe { cass_cluster_set_blacklist_dc_filtering_n(cluster_raw, dcs, strlen(dcs)) }
+    let (dcs, dcs_size) = unsafe { dcs.as_len_delimited() };
+    unsafe { cass_cluster_set_blacklist_dc_filtering_n(cluster_raw, dcs, dcs_size) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_blacklist_dc_filtering_n(
     cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    dcs: *const c_char,
-    dcs_size: size_t,
+    dcs: CassStrLenDelimited<'_>,
+    dcs_size: CassStrLen,
 ) {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster_raw) else {
         tracing::error!(
@@ -1624,17 +1639,18 @@ pub unsafe extern "C" fn cass_cluster_set_serial_consistency(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_execution_profile(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    name: *const c_char,
+    name: CassStrNulTerminated<'_>,
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
 ) -> CassError {
-    unsafe { cass_cluster_set_execution_profile_n(cluster, name, strlen(name), profile) }
+    let (name, name_length) = unsafe { name.as_len_delimited() };
+    unsafe { cass_cluster_set_execution_profile_n(cluster, name, name_length, profile) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
     cluster: CassBorrowedExclusivePtr<CassCluster, CMut>,
-    name: *const c_char,
-    name_length: size_t,
+    name: CassStrLenDelimited<'_>,
+    name_length: CassStrLen,
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
 ) -> CassError {
     let Some(cluster) = BoxFFI::as_mut_ref(cluster) else {
@@ -1647,7 +1663,7 @@ pub unsafe extern "C" fn cass_cluster_set_execution_profile_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let name = match unsafe { ptr_to_cstr_n(name, name_length) } {
+    let name = match unsafe { name.to_str(name_length) } {
         Ok(name) => match name.to_owned().try_into() {
             Ok(name) => name,
             Err(EmptyProfileName) => {
@@ -1821,7 +1837,10 @@ mod tests {
             // null ip pointer
             {
                 assert_cass_error_eq!(
-                    cass_cluster_set_local_address(cluster_raw.borrow_mut(), std::ptr::null()),
+                    cass_cluster_set_local_address(
+                        cluster_raw.borrow_mut(),
+                        CassStrNulTerminated::from_raw(std::ptr::null())
+                    ),
                     CassError::CASS_OK
                 );
 
@@ -1832,7 +1851,10 @@ mod tests {
             // empty string
             {
                 assert_cass_error_eq!(
-                    cass_cluster_set_local_address(cluster_raw.borrow_mut(), c"".as_ptr()),
+                    cass_cluster_set_local_address(
+                        cluster_raw.borrow_mut(),
+                        CassStrNulTerminated::from_cstr(c"")
+                    ),
                     CassError::CASS_OK
                 );
 
@@ -1843,7 +1865,10 @@ mod tests {
             // valid ipv4 address
             {
                 assert_cass_error_eq!(
-                    cass_cluster_set_local_address(cluster_raw.borrow_mut(), c"1.2.3.4".as_ptr()),
+                    cass_cluster_set_local_address(
+                        cluster_raw.borrow_mut(),
+                        CassStrNulTerminated::from_cstr(c"1.2.3.4")
+                    ),
                     CassError::CASS_OK
                 );
 
@@ -1859,7 +1884,7 @@ mod tests {
                 assert_cass_error_eq!(
                     cass_cluster_set_local_address(
                         cluster_raw.borrow_mut(),
-                        c"2001:db8::8a2e:370:7334".as_ptr()
+                        CassStrNulTerminated::from_cstr(c"2001:db8::8a2e:370:7334")
                     ),
                     CassError::CASS_OK
                 );
@@ -1874,7 +1899,10 @@ mod tests {
             // non-numeric address
             {
                 assert_cass_error_eq!(
-                    cass_cluster_set_local_address(cluster_raw.borrow_mut(), c"foo".as_ptr()),
+                    cass_cluster_set_local_address(
+                        cluster_raw.borrow_mut(),
+                        CassStrNulTerminated::from_cstr(c"foo")
+                    ),
                     CassError::CASS_ERROR_LIB_BAD_PARAMS
                 );
             }
@@ -1885,7 +1913,7 @@ mod tests {
                 assert_cass_error_eq!(
                     cass_cluster_set_local_address(
                         cluster_raw.borrow_mut(),
-                        non_utf8_slice.as_ptr() as *const c_char
+                        CassStrNulTerminated::from_raw(non_utf8_slice.as_ptr() as *const c_char)
                     ),
                     CassError::CASS_ERROR_LIB_BAD_PARAMS
                 );
@@ -2087,7 +2115,7 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_dc_aware(
                             cluster_raw.borrow_mut(),
-                            c"eu".as_ptr(),
+                            CassStrNulTerminated::from_cstr(c"eu"),
                             0, // forbid DC failover
                             0
                         ),
@@ -2126,8 +2154,8 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_rack_aware(
                             cluster_raw.borrow_mut(),
-                            c"eu-east".as_ptr(),
-                            c"rack1".as_ptr(),
+                            CassStrNulTerminated::from_cstr(c"eu-east"),
+                            CassStrNulTerminated::from_cstr(c"rack1"),
                         ),
                         CassError::CASS_OK
                     );
@@ -2150,7 +2178,7 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_dc_aware(
                             cluster_raw.borrow_mut(),
-                            c"eu".as_ptr(),
+                            CassStrNulTerminated::from_cstr(c"eu"),
                             42,        // allow DC failover
                             cass_true  // allow remote DCs for local CL
                         ),
@@ -2179,7 +2207,7 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_dc_aware(
                             cluster_raw.borrow_mut(),
-                            std::ptr::null(),
+                            CassStrNulTerminated::from_raw(std::ptr::null()),
                             0,
                             0
                         ),
@@ -2188,16 +2216,16 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_rack_aware(
                             cluster_raw.borrow_mut(),
-                            c"eu".as_ptr(),
-                            std::ptr::null(),
+                            CassStrNulTerminated::from_cstr(c"eu"),
+                            CassStrNulTerminated::from_raw(std::ptr::null()),
                         ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_rack_aware(
                             cluster_raw.borrow_mut(),
-                            std::ptr::null(),
-                            c"rack".as_ptr(),
+                            CassStrNulTerminated::from_raw(std::ptr::null()),
+                            CassStrNulTerminated::from_cstr(c"rack"),
                         ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
@@ -2209,7 +2237,7 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_dc_aware(
                             cluster_raw.borrow_mut(),
-                            std::ptr::null(),
+                            CassStrNulTerminated::from_raw(std::ptr::null()),
                             0,
                             0
                         ),
@@ -2218,16 +2246,16 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_rack_aware(
                             cluster_raw.borrow_mut(),
-                            c"eu".as_ptr(),
-                            empty_str,
+                            CassStrNulTerminated::from_cstr(c"eu"),
+                            CassStrNulTerminated::from_raw(empty_str),
                         ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
                     assert_cass_error_eq!(
                         cass_cluster_set_load_balance_rack_aware(
                             cluster_raw.borrow_mut(),
-                            empty_str,
-                            c"rack".as_ptr(),
+                            CassStrNulTerminated::from_raw(empty_str),
+                            CassStrNulTerminated::from_cstr(c"rack"),
                         ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
                     );
@@ -2282,7 +2310,7 @@ mod tests {
             {
                 cass_cluster_set_whitelist_filtering(
                     cluster_raw.borrow_mut(),
-                    c" 127.0.0.1 ,  127.0.0.2 ".as_ptr(),
+                    CassStrNulTerminated::from_cstr(c" 127.0.0.1 ,  127.0.0.2 "),
                 );
 
                 let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
@@ -2300,7 +2328,7 @@ mod tests {
             {
                 cass_cluster_set_whitelist_filtering(
                     cluster_raw.borrow_mut(),
-                    c"foo, 127.0.0.3, bar,,baz".as_ptr(),
+                    CassStrNulTerminated::from_cstr(c"foo, 127.0.0.3, bar,,baz"),
                 );
 
                 let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
@@ -2316,7 +2344,10 @@ mod tests {
 
             // Provide empty string - this should clear the list.
             {
-                cass_cluster_set_whitelist_filtering(cluster_raw.borrow_mut(), c"".as_ptr());
+                cass_cluster_set_whitelist_filtering(
+                    cluster_raw.borrow_mut(),
+                    CassStrNulTerminated::from_cstr(c""),
+                );
 
                 let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                 assert!(
@@ -2332,7 +2363,7 @@ mod tests {
             {
                 cass_cluster_set_blacklist_filtering(
                     cluster_raw.borrow_mut(),
-                    c"1.1.1.1,2.2.2.2,foo,,,,  ,3.3.3.3,".as_ptr(),
+                    CassStrNulTerminated::from_cstr(c"1.1.1.1,2.2.2.2,foo,,,,  ,3.3.3.3,"),
                 );
 
                 let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
@@ -2348,7 +2379,10 @@ mod tests {
 
             // ..and clear it with the null pointer
             {
-                cass_cluster_set_blacklist_filtering(cluster_raw.borrow_mut(), std::ptr::null());
+                cass_cluster_set_blacklist_filtering(
+                    cluster_raw.borrow_mut(),
+                    CassStrNulTerminated::from_raw(std::ptr::null()),
+                );
 
                 let cluster = BoxFFI::as_ref(cluster_raw.borrow()).unwrap();
                 assert!(
@@ -2380,7 +2414,7 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile(
                             cluster_raw.borrow_mut(),
-                            make_c_str!("profile1"),
+                            CassStrNulTerminated::from_raw(make_c_str!("profile1")),
                             exec_profile_raw.borrow_mut()
                         ),
                         CassError::CASS_OK
@@ -2397,8 +2431,8 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile_n(
                             cluster_raw.borrow_mut(),
-                            c_str,
-                            c_strlen,
+                            CassStrLenDelimited::from_raw(c_str),
+                            CassStrLen::from_raw(c_strlen),
                             exec_profile_raw.borrow_mut()
                         ),
                         CassError::CASS_OK
@@ -2414,7 +2448,7 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile(
                             cluster_raw.borrow_mut(),
-                            make_c_str!("profile2"),
+                            CassStrNulTerminated::from_raw(make_c_str!("profile2")),
                             exec_profile_raw.borrow_mut()
                         ),
                         CassError::CASS_OK
@@ -2434,7 +2468,7 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile(
                             cluster_raw.borrow_mut(),
-                            std::ptr::null(),
+                            CassStrNulTerminated::from_raw(std::ptr::null()),
                             exec_profile_raw.borrow_mut()
                         ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
@@ -2445,7 +2479,7 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile(
                             cluster_raw.borrow_mut(),
-                            make_c_str!(""),
+                            CassStrNulTerminated::from_raw(make_c_str!("")),
                             exec_profile_raw.borrow_mut()
                         ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS
@@ -2456,7 +2490,7 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_cluster_set_execution_profile(
                             cluster_raw.borrow_mut(),
-                            make_c_str!("profile1"),
+                            CassStrNulTerminated::from_raw(make_c_str!("profile1")),
                             BoxFFI::null_mut(),
                         ),
                         CassError::CASS_ERROR_LIB_BAD_PARAMS

--- a/scylla-rust-wrapper/src/cql_types/data_type.rs
+++ b/scylla-rust-wrapper/src/cql_types/data_type.rs
@@ -556,23 +556,24 @@ pub unsafe extern "C" fn cass_data_type_type_name(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_type_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
-    type_name: *const c_char,
+    type_name: CassStrNulTerminated<'_>,
 ) -> CassError {
-    unsafe { cass_data_type_set_type_name_n(data_type, type_name, strlen(type_name)) }
+    let (type_name, type_name_length) = unsafe { type_name.as_len_delimited() };
+    unsafe { cass_data_type_set_type_name_n(data_type, type_name, type_name_length) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_type_name_n(
     data_type_raw: CassBorrowedSharedPtr<CassDataType, CMut>,
-    type_name: *const c_char,
-    type_name_length: size_t,
+    type_name: CassStrLenDelimited<'_>,
+    type_name_length: CassStrLen,
 ) -> CassError {
     let Some(data_type) = ArcFFI::as_ref(data_type_raw) else {
         tracing::error!("Provided null data type pointer to cass_data_type_set_type_name_n!");
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let type_name_string = match unsafe { ptr_to_cstr_n(type_name, type_name_length) } {
+    let type_name_string = match unsafe { type_name.to_str(type_name_length) } {
         Ok(s) => s.to_string(),
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Provided null type name pointer to cass_data_type_set_type_name(_n)!");
@@ -616,23 +617,24 @@ pub unsafe extern "C" fn cass_data_type_keyspace(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_keyspace(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
-    keyspace: *const c_char,
+    keyspace: CassStrNulTerminated<'_>,
 ) -> CassError {
-    unsafe { cass_data_type_set_keyspace_n(data_type, keyspace, strlen(keyspace)) }
+    let (keyspace, keyspace_length) = unsafe { keyspace.as_len_delimited() };
+    unsafe { cass_data_type_set_keyspace_n(data_type, keyspace, keyspace_length) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_keyspace_n(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
-    keyspace: *const c_char,
-    keyspace_length: size_t,
+    keyspace: CassStrLenDelimited<'_>,
+    keyspace_length: CassStrLen,
 ) -> CassError {
     let Some(data_type) = ArcFFI::as_ref(data_type) else {
         tracing::error!("Provided null data type pointer to cass_data_type_set_keyspace_n!");
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let keyspace_string = match unsafe { ptr_to_cstr_n(keyspace, keyspace_length) } {
+    let keyspace_string = match unsafe { keyspace.to_str(keyspace_length) } {
         Ok(s) => s.to_string(),
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Provided null keyspace pointer to cass_data_type_set_keyspace(_n)!");
@@ -676,23 +678,24 @@ pub unsafe extern "C" fn cass_data_type_class_name(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_class_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
-    class_name: *const ::std::os::raw::c_char,
+    class_name: CassStrNulTerminated<'_>,
 ) -> CassError {
-    unsafe { cass_data_type_set_class_name_n(data_type, class_name, strlen(class_name)) }
+    let (class_name, class_name_length) = unsafe { class_name.as_len_delimited() };
+    unsafe { cass_data_type_set_class_name_n(data_type, class_name, class_name_length) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_set_class_name_n(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
-    class_name: *const ::std::os::raw::c_char,
-    class_name_length: size_t,
+    class_name: CassStrLenDelimited<'_>,
+    class_name_length: CassStrLen,
 ) -> CassError {
     let Some(data_type) = ArcFFI::as_ref(data_type) else {
         tracing::error!("Provided null data type pointer to cass_data_type_set_class_name_n!");
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let class_string = match unsafe { ptr_to_cstr_n(class_name, class_name_length) } {
+    let class_string = match unsafe { class_name.to_str(class_name_length) } {
         Ok(s) => s.to_string(),
         Err(PtrToStrError::NullPointer) => {
             tracing::error!(
@@ -767,19 +770,20 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name(
-    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
-    name: *const ::std::os::raw::c_char,
-) -> CassBorrowedSharedPtr<CassDataType, CConst> {
-    unsafe { cass_data_type_sub_data_type_by_name_n(data_type, name, strlen(name)) }
+pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name<'a>(
+    data_type: CassBorrowedSharedPtr<'a, CassDataType, CConst>,
+    name: CassStrNulTerminated<'_>,
+) -> CassBorrowedSharedPtr<'a, CassDataType, CConst> {
+    let (name, name_length) = unsafe { name.as_len_delimited() };
+    unsafe { cass_data_type_sub_data_type_by_name_n(data_type, name, name_length) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n(
-    data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
-    name: *const ::std::os::raw::c_char,
-    name_length: size_t,
-) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n<'a>(
+    data_type: CassBorrowedSharedPtr<'a, CassDataType, CConst>,
+    name: CassStrLenDelimited<'_>,
+    name_length: CassStrLen,
+) -> CassBorrowedSharedPtr<'a, CassDataType, CConst> {
     let Some(data_type) = ArcFFI::as_ref(data_type) else {
         tracing::error!(
             "Provided null data type pointer to cass_data_type_sub_data_type_by_name_n!"
@@ -787,7 +791,7 @@ pub unsafe extern "C" fn cass_data_type_sub_data_type_by_name_n(
         return ArcFFI::null();
     };
 
-    let name_str = match unsafe { ptr_to_cstr_n(name, name_length) } {
+    let name_str = match unsafe { name.to_str(name_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => {
             tracing::error!(
@@ -856,17 +860,18 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
-    name: *const c_char,
+    name: CassStrNulTerminated<'_>,
     sub_data_type: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassError {
-    unsafe { cass_data_type_add_sub_type_by_name_n(data_type, name, strlen(name), sub_data_type) }
+    let (name, name_length) = unsafe { name.as_len_delimited() };
+    unsafe { cass_data_type_add_sub_type_by_name_n(data_type, name, name_length, sub_data_type) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
     data_type_raw: CassBorrowedSharedPtr<CassDataType, CMut>,
-    name: *const c_char,
-    name_length: size_t,
+    name: CassStrLenDelimited<'_>,
+    name_length: CassStrLen,
     sub_data_type_raw: CassBorrowedSharedPtr<CassDataType, CConst>,
 ) -> CassError {
     let Some(data_type) = ArcFFI::as_ref(data_type_raw) else {
@@ -882,7 +887,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_type_by_name_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let name_string = match unsafe { ptr_to_cstr_n(name, name_length) } {
+    let name_string = match unsafe { name.to_str(name_length) } {
         Ok(s) => s.to_string(),
         Err(PtrToStrError::NullPointer) => {
             tracing::error!(
@@ -919,7 +924,7 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name(
     data_type: CassBorrowedSharedPtr<CassDataType, CMut>,
-    name: *const c_char,
+    name: CassStrNulTerminated<'_>,
     sub_value_type: CassValueType,
 ) -> CassError {
     let sub_data_type = CassDataType::new_arced(CassDataTypeInner::Value(sub_value_type));
@@ -937,8 +942,8 @@ pub unsafe extern "C" fn cass_data_type_add_sub_value_type_by_name_n(
     unsafe {
         cass_data_type_add_sub_type_by_name_n(
             data_type,
-            name,
-            name_length,
+            CassStrLenDelimited::from_raw(name),
+            CassStrLen::from_raw(name_length),
             ArcFFI::as_ptr(&sub_data_type),
         )
     }

--- a/scylla-rust-wrapper/src/cql_types/inet.rs
+++ b/scylla-rust-wrapper/src/cql_types/inet.rs
@@ -84,19 +84,20 @@ pub unsafe extern "C" fn cass_inet_string(inet: CassInet, output: *mut c_char) {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_inet_from_string(
-    input: *const c_char,
+    input: CassStrNulTerminated<'_>,
     inet: *mut CassInet,
 ) -> CassError {
-    unsafe { cass_inet_from_string_n(input, strlen(input), inet) }
+    let (input, input_length) = unsafe { input.as_len_delimited() };
+    unsafe { cass_inet_from_string_n(input, input_length, inet) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_inet_from_string_n(
-    input_raw: *const c_char,
-    input_length: size_t,
+    input_raw: CassStrLenDelimited<'_>,
+    input_length: CassStrLen,
     inet_raw: *mut CassInet,
 ) -> CassError {
-    let input_str = match unsafe { ptr_to_cstr_n(input_raw, input_length) } {
+    let input_str = match unsafe { input_raw.to_str(input_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Provided null input string to cass_inet_from_string(_n)!");

--- a/scylla-rust-wrapper/src/cql_types/mod.rs
+++ b/scylla-rust-wrapper/src/cql_types/mod.rs
@@ -11,7 +11,9 @@ pub use crate::cass_consistency_types::CassConsistency;
 pub use crate::cass_data_types::CassValueType;
 pub use crate::cass_error_types::CassWriteType;
 
-use std::ffi::{CStr, c_char};
+use std::ffi::CStr;
+
+use crate::argconv::CassStrNulTerminated;
 
 impl CassConsistency {
     pub(crate) fn as_cstr(&self) -> &'static CStr {
@@ -34,8 +36,10 @@ impl CassConsistency {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_consistency_string(consistency: CassConsistency) -> *const c_char {
-    consistency.as_cstr().as_ptr() as *const c_char
+pub unsafe extern "C" fn cass_consistency_string(
+    consistency: CassConsistency,
+) -> CassStrNulTerminated<'static> {
+    CassStrNulTerminated::from_cstr(consistency.as_cstr())
 }
 
 impl CassWriteType {
@@ -55,6 +59,8 @@ impl CassWriteType {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_write_type_string(write_type: CassWriteType) -> *const c_char {
-    write_type.as_cstr().as_ptr() as *const c_char
+pub unsafe extern "C" fn cass_write_type_string(
+    write_type: CassWriteType,
+) -> CassStrNulTerminated<'static> {
+    CassStrNulTerminated::from_cstr(write_type.as_cstr())
 }

--- a/scylla-rust-wrapper/src/cql_types/user_type.rs
+++ b/scylla-rust-wrapper/src/cql_types/user_type.rs
@@ -3,7 +3,6 @@ use crate::cass_error::CassError;
 use crate::cql_types::data_type::{CassDataType, CassDataTypeInner};
 use crate::cql_types::value::{self, CassCqlValue};
 use crate::types::*;
-use std::os::raw::c_char;
 use std::sync::Arc;
 
 #[derive(Clone)]

--- a/scylla-rust-wrapper/src/cql_types/uuid.rs
+++ b/scylla-rust-wrapper/src/cql_types/uuid.rs
@@ -239,19 +239,20 @@ pub unsafe extern "C" fn cass_uuid_string(uuid_raw: CassUuid, output: *mut c_cha
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_from_string(
-    value: *const c_char,
+    value: CassStrNulTerminated<'_>,
     output: *mut CassUuid,
 ) -> CassError {
-    unsafe { cass_uuid_from_string_n(value, strlen(value), output) }
+    let (value, value_length) = unsafe { value.as_len_delimited() };
+    unsafe { cass_uuid_from_string_n(value, value_length, output) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_uuid_from_string_n(
-    value: *const c_char,
-    value_length: size_t,
+    value: CassStrLenDelimited<'_>,
+    value_length: CassStrLen,
     output: *mut CassUuid,
 ) -> CassError {
-    let value_str = match unsafe { ptr_to_cstr_n(value, value_length) } {
+    let value_str = match unsafe { value.to_str(value_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Provided null string pointer to cass_uuid_from_string(_n)!");

--- a/scylla-rust-wrapper/src/exec_profile.rs
+++ b/scylla-rust-wrapper/src/exec_profile.rs
@@ -1,5 +1,5 @@
 use std::convert::{TryFrom, TryInto};
-use std::ffi::c_char;
+
 use std::future::Future;
 use std::net::IpAddr;
 use std::ops::Deref;
@@ -16,7 +16,7 @@ use scylla::statement::{Consistency, SerialConsistency};
 
 use crate::argconv::{
     ArcFFI, BoxFFI, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr, CassOwnedExclusivePtr,
-    FFI, FromBox, PtrToStrError, ptr_to_cstr_n, strlen,
+    CassStrLen, CassStrLenDelimited, CassStrNulTerminated, FFI, FromBox, PtrToStrError,
 };
 use crate::cass_error::CassError;
 use crate::cluster::{
@@ -30,7 +30,7 @@ use crate::session::CassConnectedSession;
 use crate::statements::batch::CassBatch;
 use crate::statements::statement::CassStatement;
 use crate::types::{
-    cass_bool_t, cass_double_t, cass_int32_t, cass_int64_t, cass_uint32_t, cass_uint64_t, size_t,
+    cass_bool_t, cass_double_t, cass_int32_t, cass_int64_t, cass_uint32_t, cass_uint64_t,
 };
 
 /// Holds information about which execution profile settings were overridden.
@@ -261,23 +261,24 @@ pub unsafe extern "C" fn cass_execution_profile_free(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_execution_profile(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
-    name: *const c_char,
+    name: CassStrNulTerminated<'_>,
 ) -> CassError {
-    unsafe { cass_statement_set_execution_profile_n(statement, name, strlen(name)) }
+    let (name, name_length) = unsafe { name.as_len_delimited() };
+    unsafe { cass_statement_set_execution_profile_n(statement, name, name_length) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_execution_profile_n(
     statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
-    name: *const c_char,
-    name_length: size_t,
+    name: CassStrLenDelimited<'_>,
+    name_length: CassStrLen,
 ) -> CassError {
     let Some(statement) = BoxFFI::as_mut_ref(statement) else {
         tracing::error!("Provided null statement pointer to cass_statement_set_execution_profile!");
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let name: Option<ExecProfileName> = match unsafe { ptr_to_cstr_n(name, name_length) } {
+    let name: Option<ExecProfileName> = match unsafe { name.to_str(name_length) } {
         Ok(name) => name.to_owned().try_into().ok(),
         // NULL or empty name clears the profile — intentional.
         Err(PtrToStrError::NullPointer) => None,
@@ -296,23 +297,24 @@ pub unsafe extern "C" fn cass_statement_set_execution_profile_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_execution_profile(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
-    name: *const c_char,
+    name: CassStrNulTerminated<'_>,
 ) -> CassError {
-    unsafe { cass_batch_set_execution_profile_n(batch, name, strlen(name)) }
+    let (name, name_length) = unsafe { name.as_len_delimited() };
+    unsafe { cass_batch_set_execution_profile_n(batch, name, name_length) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_batch_set_execution_profile_n(
     batch: CassBorrowedExclusivePtr<CassBatch, CMut>,
-    name: *const c_char,
-    name_length: size_t,
+    name: CassStrLenDelimited<'_>,
+    name_length: CassStrLen,
 ) -> CassError {
     let Some(batch) = BoxFFI::as_mut_ref(batch) else {
         tracing::error!("Provided null batch pointer to cass_batch_set_execution_profile!");
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let name: Option<ExecProfileName> = match unsafe { ptr_to_cstr_n(name, name_length) } {
+    let name: Option<ExecProfileName> = match unsafe { name.to_str(name_length) } {
         Ok(name) => name.to_owned().try_into().ok(),
         // NULL or empty name clears the profile — intentional.
         Err(PtrToStrError::NullPointer) => None,
@@ -479,15 +481,16 @@ pub unsafe extern "C" fn cass_execution_profile_set_latency_aware_routing_settin
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    local_dc: *const c_char,
+    local_dc: CassStrNulTerminated<'_>,
     used_hosts_per_remote_dc: cass_uint32_t,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
+    let (local_dc, local_dc_length) = unsafe { local_dc.as_len_delimited() };
     unsafe {
         cass_execution_profile_set_load_balance_dc_aware_n(
             profile,
             local_dc,
-            strlen(local_dc),
+            local_dc_length,
             used_hosts_per_remote_dc,
             allow_remote_dcs_for_local_cl,
         )
@@ -497,8 +500,8 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware_n(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    local_dc: *const c_char,
-    local_dc_length: size_t,
+    local_dc: CassStrLenDelimited<'_>,
+    local_dc_length: CassStrLen,
     used_hosts_per_remote_dc: cass_uint32_t,
     allow_remote_dcs_for_local_cl: cass_bool_t,
 ) -> CassError {
@@ -523,16 +526,18 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_dc_aware_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    local_dc_raw: *const c_char,
-    local_rack_raw: *const c_char,
+    local_dc_raw: CassStrNulTerminated<'_>,
+    local_rack_raw: CassStrNulTerminated<'_>,
 ) -> CassError {
+    let (local_dc, local_dc_length) = unsafe { local_dc_raw.as_len_delimited() };
+    let (local_rack, local_rack_length) = unsafe { local_rack_raw.as_len_delimited() };
     unsafe {
         cass_execution_profile_set_load_balance_rack_aware_n(
             profile,
-            local_dc_raw,
-            strlen(local_dc_raw),
-            local_rack_raw,
-            strlen(local_rack_raw),
+            local_dc,
+            local_dc_length,
+            local_rack,
+            local_rack_length,
         )
     }
 }
@@ -540,10 +545,10 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_load_balance_rack_aware_n(
     profile: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    local_dc_raw: *const c_char,
-    local_dc_length: size_t,
-    local_rack_raw: *const c_char,
-    local_rack_length: size_t,
+    local_dc_raw: CassStrLenDelimited<'_>,
+    local_dc_length: CassStrLen,
+    local_rack_raw: CassStrLenDelimited<'_>,
+    local_rack_length: CassStrLen,
 ) -> CassError {
     let Some(profile_builder) = BoxFFI::as_mut_ref(profile) else {
         tracing::error!(
@@ -582,16 +587,17 @@ pub unsafe extern "C" fn cass_execution_profile_set_load_balance_round_robin(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_whitelist_filtering(
     profile_raw: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    hosts: *const c_char,
+    hosts: CassStrNulTerminated<'_>,
 ) -> CassError {
-    unsafe { cass_execution_profile_set_whitelist_filtering_n(profile_raw, hosts, strlen(hosts)) }
+    let (hosts, hosts_size) = unsafe { hosts.as_len_delimited() };
+    unsafe { cass_execution_profile_set_whitelist_filtering_n(profile_raw, hosts, hosts_size) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_whitelist_filtering_n(
     profile_raw: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    hosts: *const c_char,
-    hosts_size: size_t,
+    hosts: CassStrLenDelimited<'_>,
+    hosts_size: CassStrLen,
 ) -> CassError {
     let Some(profile_builder) = BoxFFI::as_mut_ref(profile_raw) else {
         tracing::error!(
@@ -627,16 +633,17 @@ pub unsafe extern "C" fn cass_execution_profile_set_whitelist_filtering_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_blacklist_filtering(
     profile_raw: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    hosts: *const c_char,
+    hosts: CassStrNulTerminated<'_>,
 ) -> CassError {
-    unsafe { cass_execution_profile_set_blacklist_filtering_n(profile_raw, hosts, strlen(hosts)) }
+    let (hosts, hosts_size) = unsafe { hosts.as_len_delimited() };
+    unsafe { cass_execution_profile_set_blacklist_filtering_n(profile_raw, hosts, hosts_size) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_blacklist_filtering_n(
     profile_raw: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    hosts: *const c_char,
-    hosts_size: size_t,
+    hosts: CassStrLenDelimited<'_>,
+    hosts_size: CassStrLen,
 ) -> CassError {
     let Some(profile_builder) = BoxFFI::as_mut_ref(profile_raw) else {
         tracing::error!(
@@ -672,16 +679,17 @@ pub unsafe extern "C" fn cass_execution_profile_set_blacklist_filtering_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_whitelist_dc_filtering(
     profile_raw: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    dcs: *const c_char,
+    dcs: CassStrNulTerminated<'_>,
 ) -> CassError {
-    unsafe { cass_execution_profile_set_whitelist_dc_filtering_n(profile_raw, dcs, strlen(dcs)) }
+    let (dcs, dcs_size) = unsafe { dcs.as_len_delimited() };
+    unsafe { cass_execution_profile_set_whitelist_dc_filtering_n(profile_raw, dcs, dcs_size) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_whitelist_dc_filtering_n(
     profile_raw: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    dcs: *const c_char,
-    dcs_size: size_t,
+    dcs: CassStrLenDelimited<'_>,
+    dcs_size: CassStrLen,
 ) -> CassError {
     let Some(profile_builder) = BoxFFI::as_mut_ref(profile_raw) else {
         tracing::error!(
@@ -709,16 +717,17 @@ pub unsafe extern "C" fn cass_execution_profile_set_whitelist_dc_filtering_n(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_blacklist_dc_filtering(
     profile_raw: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    dcs: *const c_char,
+    dcs: CassStrNulTerminated<'_>,
 ) -> CassError {
-    unsafe { cass_execution_profile_set_blacklist_dc_filtering_n(profile_raw, dcs, strlen(dcs)) }
+    let (dcs, dcs_size) = unsafe { dcs.as_len_delimited() };
+    unsafe { cass_execution_profile_set_blacklist_dc_filtering_n(profile_raw, dcs, dcs_size) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_execution_profile_set_blacklist_dc_filtering_n(
     profile_raw: CassBorrowedExclusivePtr<CassExecProfile, CMut>,
-    dcs: *const c_char,
-    dcs_size: size_t,
+    dcs: CassStrLenDelimited<'_>,
+    dcs_size: CassStrLen,
 ) -> CassError {
     let Some(profile_builder) = BoxFFI::as_mut_ref(profile_raw) else {
         tracing::error!(
@@ -886,7 +895,7 @@ mod tests {
 
     use super::*;
 
-    use crate::argconv::CassPtr;
+    use crate::argconv::{CassPtr, CassStrLen, CassStrLenDelimited, CassStrNulTerminated};
     use crate::cql_types::CassConsistency;
     use crate::retry_policy::{
         cass_retry_policy_downgrading_consistency_new, cass_retry_policy_free,
@@ -948,7 +957,7 @@ mod tests {
             {
                 cass_execution_profile_set_blacklist_filtering(
                     profile_raw.borrow_mut(),
-                    c" 127.0.0.1 ,  127.0.0.2 ".as_ptr(),
+                    CassStrNulTerminated::from_cstr(c" 127.0.0.1 ,  127.0.0.2 "),
                 );
 
                 let profile = BoxFFI::as_ref(profile_raw.borrow()).unwrap();
@@ -966,7 +975,7 @@ mod tests {
             {
                 cass_execution_profile_set_blacklist_filtering(
                     profile_raw.borrow_mut(),
-                    c"foo, 127.0.0.3, bar,,baz".as_ptr(),
+                    CassStrNulTerminated::from_cstr(c"foo, 127.0.0.3, bar,,baz"),
                 );
 
                 let profile = BoxFFI::as_ref(profile_raw.borrow()).unwrap();
@@ -984,7 +993,7 @@ mod tests {
             {
                 cass_execution_profile_set_blacklist_filtering(
                     profile_raw.borrow_mut(),
-                    c"".as_ptr(),
+                    CassStrNulTerminated::from_cstr(c""),
                 );
 
                 let profile = BoxFFI::as_ref(profile_raw.borrow()).unwrap();
@@ -1001,7 +1010,7 @@ mod tests {
             {
                 cass_execution_profile_set_blacklist_filtering(
                     profile_raw.borrow_mut(),
-                    c"1.1.1.1,2.2.2.2,foo,,,,  ,3.3.3.3,".as_ptr(),
+                    CassStrNulTerminated::from_cstr(c"1.1.1.1,2.2.2.2,foo,,,,  ,3.3.3.3,"),
                 );
 
                 let cluster = BoxFFI::as_ref(profile_raw.borrow()).unwrap();
@@ -1019,7 +1028,7 @@ mod tests {
             {
                 cass_execution_profile_set_blacklist_filtering(
                     profile_raw.borrow_mut(),
-                    std::ptr::null(),
+                    CassStrNulTerminated::from_raw(std::ptr::null()),
                 );
 
                 let profile = BoxFFI::as_ref(profile_raw.borrow()).unwrap();
@@ -1070,7 +1079,7 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_execution_profile_set_load_balance_dc_aware(
                             profile_raw.borrow_mut(),
-                            c"eu".as_ptr(),
+                            CassStrNulTerminated::from_cstr(c"eu"),
                             0, // forbid DC failover
                             0
                         ),
@@ -1140,7 +1149,8 @@ mod tests {
     fn test_statement_and_batch_set_exec_profile() {
         unsafe {
             let empty_query = make_c_str!("");
-            let mut statement_raw = cass_statement_new(empty_query, 0);
+            let mut statement_raw =
+                cass_statement_new(CassStrNulTerminated::from_raw(empty_query), 0);
             let mut batch_raw = cass_batch_new(CassBatchType::CASS_BATCH_TYPE_LOGGED);
             assert_cass_error_eq!(
                 cass_batch_add_statement(batch_raw.borrow_mut(), statement_raw.borrow()),
@@ -1157,11 +1167,11 @@ mod tests {
                 }
                 {
                     let valid_name = "profile";
-                    let valid_name_c_str = make_c_str!("profile");
+                    let valid_name_c_str = CassStrNulTerminated::from_raw(make_c_str!("profile"));
                     assert_cass_error_eq!(
                         cass_statement_set_execution_profile(
                             statement_raw.borrow_mut(),
-                            valid_name_c_str,
+                            valid_name_c_str.clone(),
                         ),
                         CassError::CASS_OK
                     );
@@ -1202,14 +1212,14 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_statement_set_execution_profile(
                             statement_raw.borrow_mut(),
-                            std::ptr::null::<i8>()
+                            CassStrNulTerminated::from_raw(std::ptr::null())
                         ),
                         CassError::CASS_OK
                     );
                     assert_cass_error_eq!(
                         cass_batch_set_execution_profile(
                             batch_raw.borrow_mut(),
-                            std::ptr::null::<i8>()
+                            CassStrNulTerminated::from_raw(std::ptr::null())
                         ),
                         CassError::CASS_OK
                     );
@@ -1226,16 +1236,16 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_statement_set_execution_profile_n(
                             statement_raw.borrow_mut(),
-                            valid_name_c_str,
-                            valid_name_len,
+                            CassStrLenDelimited::from_raw(valid_name_c_str),
+                            CassStrLen::from_raw(valid_name_len),
                         ),
                         CassError::CASS_OK
                     );
                     assert_cass_error_eq!(
                         cass_batch_set_execution_profile_n(
                             batch_raw.borrow_mut(),
-                            valid_name_c_str,
-                            valid_name_len,
+                            CassStrLenDelimited::from_raw(valid_name_c_str),
+                            CassStrLen::from_raw(valid_name_len),
                         ),
                         CassError::CASS_OK
                     );
@@ -1272,12 +1282,15 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_statement_set_execution_profile(
                             statement_raw.borrow_mut(),
-                            make_c_str!("")
+                            CassStrNulTerminated::from_raw(make_c_str!(""))
                         ),
                         CassError::CASS_OK
                     );
                     assert_cass_error_eq!(
-                        cass_batch_set_execution_profile(batch_raw.borrow_mut(), make_c_str!("")),
+                        cass_batch_set_execution_profile(
+                            batch_raw.borrow_mut(),
+                            CassStrNulTerminated::from_raw(make_c_str!(""))
+                        ),
                         CassError::CASS_OK
                     );
 

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -1,6 +1,7 @@
 use crate::LOGGER;
 use crate::argconv::{
-    CConst, CassBorrowedSharedPtr, FFI, FromRef, RefFFI, arr_to_cstr, ptr_to_cstr, str_to_arr,
+    CConst, CassBorrowedSharedPtr, CassStrNulTerminated, FFI, FromRef, RefFFI, arr_to_cstr,
+    str_to_arr,
 };
 use crate::cass_log_types::{CassLogLevel, CassLogMessage};
 use std::convert::TryFrom;
@@ -82,9 +83,9 @@ pub(crate) unsafe extern "C" fn stderr_log_callback(
     eprintln!(
         "{} [{}] ({}:{}) {}",
         message.time_ms,
-        unsafe { ptr_to_cstr(cass_log_level_string(message.severity)) }
+        unsafe { cass_log_level_string(message.severity).to_str() }
             .expect("cass_log_level_string always returns a valid UTF-8 c-string literal"),
-        unsafe { ptr_to_cstr(message.file) }
+        unsafe { CassStrNulTerminated::from_raw(message.file).to_str() }
             .expect("file is set to a null-terminated Rust string by on_event"),
         message.line,
         unsafe { arr_to_cstr::<{ CASS_LOG_MAX_MESSAGE_SIZE }>(&message.message) }
@@ -182,7 +183,9 @@ pub unsafe extern "C" fn cass_log_set_level(log_level: CassLogLevel) {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_log_level_string(log_level: CassLogLevel) -> *const c_char {
+pub unsafe extern "C" fn cass_log_level_string(
+    log_level: CassLogLevel,
+) -> CassStrNulTerminated<'static> {
     let log_level_str = match log_level {
         CassLogLevel::CASS_LOG_TRACE => c"TRACE",
         CassLogLevel::CASS_LOG_DEBUG => c"DEBUG",
@@ -194,7 +197,7 @@ pub unsafe extern "C" fn cass_log_level_string(log_level: CassLogLevel) -> *cons
         _ => c"",
     };
 
-    log_level_str.as_ptr()
+    CassStrNulTerminated::from_cstr(log_level_str)
 }
 
 #[unsafe(no_mangle)]

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -1,7 +1,6 @@
 use crate::LOGGER;
 use crate::argconv::{
-    CConst, CassBorrowedSharedPtr, CassStrNulTerminated, FFI, FromRef, RefFFI, arr_to_cstr,
-    str_to_arr,
+    CConst, CassBorrowedSharedPtr, CassStrNulTerminated, FFI, FromRef, RefFFI, str_to_arr,
 };
 use crate::cass_log_types::{CassLogLevel, CassLogMessage};
 use std::convert::TryFrom;
@@ -88,7 +87,7 @@ pub(crate) unsafe extern "C" fn stderr_log_callback(
         unsafe { CassStrNulTerminated::from_raw(message.file).to_str() }
             .expect("file is set to a null-terminated Rust string by on_event"),
         message.line,
-        unsafe { arr_to_cstr::<{ CASS_LOG_MAX_MESSAGE_SIZE }>(&message.message) }
+        unsafe { CassStrNulTerminated::from_raw(message.message.as_ptr()).to_str() }
             .expect("message is populated from a Rust String via str_to_arr"),
     )
 }

--- a/scylla-rust-wrapper/src/metadata.rs
+++ b/scylla-rust-wrapper/src/metadata.rs
@@ -123,28 +123,27 @@ pub unsafe extern "C" fn cass_schema_meta_free(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name(
-    schema_meta: CassBorrowedSharedPtr<CassSchemaMeta, CConst>,
-    keyspace_name: *const c_char,
-) -> CassBorrowedSharedPtr<CassKeyspaceMeta, CConst> {
-    unsafe {
-        cass_schema_meta_keyspace_by_name_n(schema_meta, keyspace_name, strlen(keyspace_name))
-    }
+pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name<'a>(
+    schema_meta: CassBorrowedSharedPtr<'a, CassSchemaMeta, CConst>,
+    keyspace_name: CassStrNulTerminated<'_>,
+) -> CassBorrowedSharedPtr<'a, CassKeyspaceMeta, CConst> {
+    let (keyspace_name, keyspace_name_length) = unsafe { keyspace_name.as_len_delimited() };
+    unsafe { cass_schema_meta_keyspace_by_name_n(schema_meta, keyspace_name, keyspace_name_length) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name_n(
-    schema_meta: CassBorrowedSharedPtr<CassSchemaMeta, CConst>,
-    keyspace_name: *const c_char,
-    keyspace_name_length: size_t,
-) -> CassBorrowedSharedPtr<CassKeyspaceMeta, CConst> {
+pub unsafe extern "C" fn cass_schema_meta_keyspace_by_name_n<'a>(
+    schema_meta: CassBorrowedSharedPtr<'a, CassSchemaMeta, CConst>,
+    keyspace_name: CassStrLenDelimited<'_>,
+    keyspace_name_length: CassStrLen,
+) -> CassBorrowedSharedPtr<'a, CassKeyspaceMeta, CConst> {
     let Some(metadata) = BoxFFI::as_ref(schema_meta) else {
         tracing::error!(
             "Provided null schema metadata pointer to cass_schema_meta_keyspace_by_name_n!"
         );
         return RefFFI::null();
     };
-    let keyspace = match unsafe { ptr_to_cstr_n(keyspace_name, keyspace_name_length) } {
+    let keyspace = match unsafe { keyspace_name.to_str(keyspace_name_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => return RefFFI::null(),
         Err(PtrToStrError::InvalidUtf8(_)) => {
@@ -178,26 +177,27 @@ pub unsafe extern "C" fn cass_keyspace_meta_name(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name(
-    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
-    type_: *const c_char,
-) -> CassBorrowedSharedPtr<CassDataType, CConst> {
-    unsafe { cass_keyspace_meta_user_type_by_name_n(keyspace_meta, type_, strlen(type_)) }
+pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name<'a>(
+    keyspace_meta: CassBorrowedSharedPtr<'a, CassKeyspaceMeta, CConst>,
+    type_: CassStrNulTerminated<'_>,
+) -> CassBorrowedSharedPtr<'a, CassDataType, CConst> {
+    let (type_, type_length) = unsafe { type_.as_len_delimited() };
+    unsafe { cass_keyspace_meta_user_type_by_name_n(keyspace_meta, type_, type_length) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
-    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
-    type_: *const c_char,
-    type_length: size_t,
-) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n<'a>(
+    keyspace_meta: CassBorrowedSharedPtr<'a, CassKeyspaceMeta, CConst>,
+    type_: CassStrLenDelimited<'_>,
+    type_length: CassStrLen,
+) -> CassBorrowedSharedPtr<'a, CassDataType, CConst> {
     let Some(keyspace_meta) = RefFFI::as_ref(keyspace_meta) else {
         tracing::error!(
             "Provided null keyspace metadata pointer to cass_keyspace_meta_user_type_by_name_n!"
         );
         return ArcFFI::null();
     };
-    let user_type_name = match unsafe { ptr_to_cstr_n(type_, type_length) } {
+    let user_type_name = match unsafe { type_.to_str(type_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => return ArcFFI::null(),
         Err(PtrToStrError::InvalidUtf8(_)) => {
@@ -218,26 +218,27 @@ pub unsafe extern "C" fn cass_keyspace_meta_user_type_by_name_n(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_keyspace_meta_table_by_name(
-    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
-    table: *const c_char,
-) -> CassBorrowedSharedPtr<CassTableMeta, CConst> {
-    unsafe { cass_keyspace_meta_table_by_name_n(keyspace_meta, table, strlen(table)) }
+pub unsafe extern "C" fn cass_keyspace_meta_table_by_name<'a>(
+    keyspace_meta: CassBorrowedSharedPtr<'a, CassKeyspaceMeta, CConst>,
+    table: CassStrNulTerminated<'_>,
+) -> CassBorrowedSharedPtr<'a, CassTableMeta, CConst> {
+    let (table, table_length) = unsafe { table.as_len_delimited() };
+    unsafe { cass_keyspace_meta_table_by_name_n(keyspace_meta, table, table_length) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_keyspace_meta_table_by_name_n(
-    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
-    table: *const c_char,
-    table_length: size_t,
-) -> CassBorrowedSharedPtr<CassTableMeta, CConst> {
+pub unsafe extern "C" fn cass_keyspace_meta_table_by_name_n<'a>(
+    keyspace_meta: CassBorrowedSharedPtr<'a, CassKeyspaceMeta, CConst>,
+    table: CassStrLenDelimited<'_>,
+    table_length: CassStrLen,
+) -> CassBorrowedSharedPtr<'a, CassTableMeta, CConst> {
     let Some(keyspace_meta) = RefFFI::as_ref(keyspace_meta) else {
         tracing::error!(
             "Provided null keyspace metadata pointer to cass_keyspace_meta_table_by_name_n!"
         );
         return RefFFI::null();
     };
-    let table_name = match unsafe { ptr_to_cstr_n(table, table_length) } {
+    let table_name = match unsafe { table.to_str(table_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => return RefFFI::null(),
         Err(PtrToStrError::InvalidUtf8(_)) => {
@@ -405,26 +406,27 @@ pub unsafe extern "C" fn cass_table_meta_clustering_key_count(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_table_meta_column_by_name(
-    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
-    column: *const c_char,
-) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
-    unsafe { cass_table_meta_column_by_name_n(table_meta, column, strlen(column)) }
+pub unsafe extern "C" fn cass_table_meta_column_by_name<'a>(
+    table_meta: CassBorrowedSharedPtr<'a, CassTableMeta, CConst>,
+    column: CassStrNulTerminated<'_>,
+) -> CassBorrowedSharedPtr<'a, CassColumnMeta, CConst> {
+    let (column, column_length) = unsafe { column.as_len_delimited() };
+    unsafe { cass_table_meta_column_by_name_n(table_meta, column, column_length) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_table_meta_column_by_name_n(
-    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
-    column: *const c_char,
-    column_length: size_t,
-) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
+pub unsafe extern "C" fn cass_table_meta_column_by_name_n<'a>(
+    table_meta: CassBorrowedSharedPtr<'a, CassTableMeta, CConst>,
+    column: CassStrLenDelimited<'_>,
+    column_length: CassStrLen,
+) -> CassBorrowedSharedPtr<'a, CassColumnMeta, CConst> {
     let Some(table_meta) = RefFFI::as_ref(table_meta) else {
         tracing::error!(
             "Provided null table metadata pointer to cass_table_meta_column_by_name_n!"
         );
         return RefFFI::null();
     };
-    let column_name = match unsafe { ptr_to_cstr_n(column, column_length) } {
+    let column_name = match unsafe { column.to_str(column_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => return RefFFI::null(),
         Err(PtrToStrError::InvalidUtf8(_)) => {
@@ -478,26 +480,27 @@ pub unsafe extern "C" fn cass_column_meta_type(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name(
-    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
-    view: *const c_char,
-) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
-    unsafe { cass_keyspace_meta_materialized_view_by_name_n(keyspace_meta, view, strlen(view)) }
+pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name<'a>(
+    keyspace_meta: CassBorrowedSharedPtr<'a, CassKeyspaceMeta, CConst>,
+    view: CassStrNulTerminated<'_>,
+) -> CassBorrowedSharedPtr<'a, CassMaterializedViewMeta, CConst> {
+    let (view, view_length) = unsafe { view.as_len_delimited() };
+    unsafe { cass_keyspace_meta_materialized_view_by_name_n(keyspace_meta, view, view_length) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name_n(
-    keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
-    view: *const c_char,
-    view_length: size_t,
-) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
+pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name_n<'a>(
+    keyspace_meta: CassBorrowedSharedPtr<'a, CassKeyspaceMeta, CConst>,
+    view: CassStrLenDelimited<'_>,
+    view_length: CassStrLen,
+) -> CassBorrowedSharedPtr<'a, CassMaterializedViewMeta, CConst> {
     let Some(keyspace_meta) = RefFFI::as_ref(keyspace_meta) else {
         tracing::error!(
             "Provided null keyspace metadata pointer to cass_keyspace_meta_materialized_view_by_name_n!"
         );
         return RefFFI::null();
     };
-    let view_name = match unsafe { ptr_to_cstr_n(view, view_length) } {
+    let view_name = match unsafe { view.to_str(view_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => return RefFFI::null(),
         Err(PtrToStrError::InvalidUtf8(_)) => {
@@ -515,26 +518,27 @@ pub unsafe extern "C" fn cass_keyspace_meta_materialized_view_by_name_n(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name(
-    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
-    view: *const c_char,
-) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
-    unsafe { cass_table_meta_materialized_view_by_name_n(table_meta, view, strlen(view)) }
+pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name<'a>(
+    table_meta: CassBorrowedSharedPtr<'a, CassTableMeta, CConst>,
+    view: CassStrNulTerminated<'_>,
+) -> CassBorrowedSharedPtr<'a, CassMaterializedViewMeta, CConst> {
+    let (view, view_length) = unsafe { view.as_len_delimited() };
+    unsafe { cass_table_meta_materialized_view_by_name_n(table_meta, view, view_length) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name_n(
-    table_meta: CassBorrowedSharedPtr<CassTableMeta, CConst>,
-    view: *const c_char,
-    view_length: size_t,
-) -> CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst> {
+pub unsafe extern "C" fn cass_table_meta_materialized_view_by_name_n<'a>(
+    table_meta: CassBorrowedSharedPtr<'a, CassTableMeta, CConst>,
+    view: CassStrLenDelimited<'_>,
+    view_length: CassStrLen,
+) -> CassBorrowedSharedPtr<'a, CassMaterializedViewMeta, CConst> {
     let Some(table_meta) = RefFFI::as_ref(table_meta) else {
         tracing::error!(
             "Provided null table metadata pointer to cass_table_meta_materialized_view_by_name_n!"
         );
         return RefFFI::null();
     };
-    let view_name = match unsafe { ptr_to_cstr_n(view, view_length) } {
+    let view_name = match unsafe { view.to_str(view_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => return RefFFI::null(),
         Err(PtrToStrError::InvalidUtf8(_)) => {
@@ -584,19 +588,20 @@ pub unsafe extern "C" fn cass_table_meta_materialized_view(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name(
-    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
-    column: *const c_char,
-) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
-    unsafe { cass_materialized_view_meta_column_by_name_n(view_meta, column, strlen(column)) }
+pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name<'a>(
+    view_meta: CassBorrowedSharedPtr<'a, CassMaterializedViewMeta, CConst>,
+    column: CassStrNulTerminated<'_>,
+) -> CassBorrowedSharedPtr<'a, CassColumnMeta, CConst> {
+    let (column, column_length) = unsafe { column.as_len_delimited() };
+    unsafe { cass_materialized_view_meta_column_by_name_n(view_meta, column, column_length) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name_n(
-    view_meta: CassBorrowedSharedPtr<CassMaterializedViewMeta, CConst>,
-    column: *const c_char,
-    column_length: size_t,
-) -> CassBorrowedSharedPtr<CassColumnMeta, CConst> {
+pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name_n<'a>(
+    view_meta: CassBorrowedSharedPtr<'a, CassMaterializedViewMeta, CConst>,
+    column: CassStrLenDelimited<'_>,
+    column_length: CassStrLen,
+) -> CassBorrowedSharedPtr<'a, CassColumnMeta, CConst> {
     let Some(view_meta) = RefFFI::as_ref(view_meta) else {
         tracing::error!(
             "Provided null materialized view metadata pointer to cass_materialized_view_meta_column_by_name_n!"
@@ -604,7 +609,7 @@ pub unsafe extern "C" fn cass_materialized_view_meta_column_by_name_n(
         return RefFFI::null();
     };
 
-    let column_name = match unsafe { ptr_to_cstr_n(column, column_length) } {
+    let column_name = match unsafe { column.to_str(column_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => return RefFFI::null(),
         Err(PtrToStrError::InvalidUtf8(_)) => {

--- a/scylla-rust-wrapper/src/query_result.rs
+++ b/scylla-rust-wrapper/src/query_result.rs
@@ -563,23 +563,24 @@ pub unsafe extern "C" fn cass_row_get_column<'result>(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_row_get_column_by_name<'result>(
     row: CassBorrowedSharedPtr<'result, CassRow<'result>, CConst>,
-    name: *const c_char,
+    name: CassStrNulTerminated<'_>,
 ) -> CassBorrowedSharedPtr<'result, CassValue<'result>, CConst> {
-    unsafe { cass_row_get_column_by_name_n(row, name, strlen(name)) }
+    let (name, name_len) = unsafe { name.as_len_delimited() };
+    unsafe { cass_row_get_column_by_name_n(row, name, name_len) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_row_get_column_by_name_n<'result>(
     row: CassBorrowedSharedPtr<'result, CassRow<'result>, CConst>,
-    name: *const c_char,
-    name_length: size_t,
+    name: CassStrLenDelimited<'_>,
+    name_length: CassStrLen,
 ) -> CassBorrowedSharedPtr<'result, CassValue<'result>, CConst> {
     let Some(row_from_raw) = RefFFI::as_ref(row) else {
         tracing::error!("Provided null row pointer to cass_row_get_column_by_name_n!");
         return RefFFI::null();
     };
 
-    let name_str = match unsafe { ptr_to_cstr_n(name, name_length) } {
+    let name_str = match unsafe { name.to_str(name_length) } {
         Ok(s) => s,
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Provided null name pointer to cass_row_get_column_by_name_n!");
@@ -1214,7 +1215,9 @@ mod tests {
     use scylla::response::PagingStateResponse;
     use scylla::response::query_result::ColumnSpecs;
 
-    use crate::argconv::{CConst, CassBorrowedSharedPtr, ptr_to_cstr_n};
+    use crate::argconv::{
+        CConst, CassBorrowedSharedPtr, CassStrLen, CassStrLenDelimited, CassStrNulTerminated,
+    };
     use crate::cql_types::data_type::{CassColumnSpec, CassDataType, CassDataTypeInner};
     use crate::{
         argconv::{ArcFFI, RefFFI},
@@ -1295,7 +1298,11 @@ mod tests {
             )
         };
         assert_eq!(CassError::CASS_OK, cass_err);
-        unsafe { ptr_to_cstr_n(name_ptr, name_length).ok() }
+        unsafe {
+            CassStrLenDelimited::from_raw(name_ptr)
+                .to_str(CassStrLen::from_raw(name_length))
+                .ok()
+        }
     }
 
     #[test]
@@ -1436,30 +1443,49 @@ mod tests {
         unsafe {
             // -- non-_n variant --
             // NULL name: caught by ptr_to_cstr before touching the row.
-            let value = super::cass_row_get_column_by_name(row_ptr.borrow(), std::ptr::null());
+            let value = super::cass_row_get_column_by_name(
+                row_ptr.borrow(),
+                CassStrNulTerminated::from_raw(std::ptr::null()),
+            );
             assert!(RefFFI::is_null(&value));
 
             // Empty name: no column has an empty name, so returns null.
-            let value = super::cass_row_get_column_by_name(row_ptr.borrow(), c"".as_ptr());
+            let value = super::cass_row_get_column_by_name(
+                row_ptr.borrow(),
+                CassStrNulTerminated::from_cstr(c""),
+            );
             assert!(RefFFI::is_null(&value));
 
             // Nonexistent name: returns null.
-            let value =
-                super::cass_row_get_column_by_name(row_ptr.borrow(), c"no_such_col".as_ptr());
+            let value = super::cass_row_get_column_by_name(
+                row_ptr.borrow(),
+                CassStrNulTerminated::from_cstr(c"no_such_col"),
+            );
             assert!(RefFFI::is_null(&value));
 
             // -- _n variant (needs a real row to reach name checking) --
-            // NULL name: caught by ptr_to_cstr_n.
-            let value = super::cass_row_get_column_by_name_n(row_ptr.borrow(), std::ptr::null(), 0);
+            // NULL name: caught by `CassStrLenDelimited::to_str`.
+            let value = super::cass_row_get_column_by_name_n(
+                row_ptr.borrow(),
+                CassStrLenDelimited::null(),
+                CassStrLen::from_raw(0),
+            );
             assert!(RefFFI::is_null(&value));
 
             // Empty name (zero length): no match, returns null.
-            let value = super::cass_row_get_column_by_name_n(row_ptr.borrow(), c"x".as_ptr(), 0);
+            let value = super::cass_row_get_column_by_name_n(
+                row_ptr.borrow(),
+                CassStrLenDelimited::from_raw(b"x".as_ptr().cast()),
+                CassStrLen::from_raw(0),
+            );
             assert!(RefFFI::is_null(&value));
 
             // Nonexistent name: returns null.
-            let value =
-                super::cass_row_get_column_by_name_n(row_ptr.borrow(), c"no_such_col".as_ptr(), 11);
+            let value = super::cass_row_get_column_by_name_n(
+                row_ptr.borrow(),
+                CassStrLenDelimited::from_raw(b"no_such_col".as_ptr().cast()),
+                CassStrLen::from_raw(11),
+            );
             assert!(RefFFI::is_null(&value));
         }
     }

--- a/scylla-rust-wrapper/src/runtime.rs
+++ b/scylla-rust-wrapper/src/runtime.rs
@@ -131,7 +131,7 @@ mod tests {
     use scylla_proxy::RunningProxy;
 
     use crate::{
-        argconv::str_to_c_str_n,
+        argconv::{CassStrLen, CassStrLenDelimited, str_to_c_str_n},
         cass_error::CassError,
         cluster::{cass_cluster_free, cass_cluster_new, cass_cluster_set_contact_points_n},
         future::cass_future_free,
@@ -203,7 +203,11 @@ mod tests {
                 let (c_ip, c_ip_len) = str_to_c_str_n(ip.as_str());
 
                 assert_cass_error_eq!(
-                    cass_cluster_set_contact_points_n(cluster_raw.borrow_mut(), c_ip, c_ip_len),
+                    cass_cluster_set_contact_points_n(
+                        cluster_raw.borrow_mut(),
+                        CassStrLenDelimited::from_raw(c_ip),
+                        CassStrLen::from_raw(c_ip_len)
+                    ),
                     CassError::CASS_OK
                 );
                 let session_raw = cass_session_new();

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -13,7 +13,6 @@ use crate::runtime::Runtime;
 use crate::statements::batch::CassBatch;
 use crate::statements::prepared::CassPrepared;
 use crate::statements::statement::{BoundStatement, CassStatement, SimpleQueryRowSerializer};
-use crate::types::size_t;
 use scylla::client::execution_profile::ExecutionProfileHandle;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
@@ -27,7 +26,6 @@ use scylla::statement::unprepared::Statement;
 use std::collections::HashMap;
 use std::future::Future;
 use std::ops::Deref;
-use std::os::raw::c_char;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -257,17 +255,18 @@ pub unsafe extern "C" fn cass_session_connect(
 pub unsafe extern "C" fn cass_session_connect_keyspace(
     session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
     cluster_raw: CassBorrowedSharedPtr<CassCluster, CConst>,
-    keyspace: *const c_char,
+    keyspace: CassStrNulTerminated<'_>,
 ) -> CassOwnedSharedPtr<CassFuture, CMut> {
-    unsafe { cass_session_connect_keyspace_n(session_raw, cluster_raw, keyspace, strlen(keyspace)) }
+    let (keyspace, keyspace_length) = unsafe { keyspace.as_len_delimited() };
+    unsafe { cass_session_connect_keyspace_n(session_raw, cluster_raw, keyspace, keyspace_length) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_connect_keyspace_n(
     session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
     cluster_raw: CassBorrowedSharedPtr<CassCluster, CConst>,
-    keyspace: *const c_char,
-    keyspace_length: size_t,
+    keyspace: CassStrLenDelimited<'_>,
+    keyspace_length: CassStrLen,
 ) -> CassOwnedSharedPtr<CassFuture, CMut> {
     let Some(session) = ArcFFI::cloned_from_ptr(session_raw) else {
         tracing::error!("Provided null session pointer to cass_session_connect_keyspace_n!");
@@ -277,7 +276,7 @@ pub unsafe extern "C" fn cass_session_connect_keyspace_n(
         tracing::error!("Provided null cluster pointer to cass_session_connect_keyspace_n!");
         return ArcFFI::null();
     };
-    let keyspace = match unsafe { ptr_to_cstr_n(keyspace, keyspace_length) } {
+    let keyspace = match unsafe { keyspace.to_str(keyspace_length) } {
         Ok(ks) => Some(ks.to_owned()),
         Err(PtrToStrError::NullPointer) => None,
         Err(PtrToStrError::InvalidUtf8(_)) => {
@@ -572,23 +571,24 @@ pub unsafe extern "C" fn cass_session_prepare_from_existing(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_prepare(
     session: CassBorrowedSharedPtr<CassSession, CMut>,
-    query: *const c_char,
+    query: CassStrNulTerminated<'_>,
 ) -> CassOwnedSharedPtr<CassFuture, CMut> {
-    unsafe { cass_session_prepare_n(session, query, strlen(query)) }
+    let (query, query_length) = unsafe { query.as_len_delimited() };
+    unsafe { cass_session_prepare_n(session, query, query_length) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_prepare_n(
     cass_session_raw: CassBorrowedSharedPtr<CassSession, CMut>,
-    query: *const c_char,
-    query_length: size_t,
+    query: CassStrLenDelimited<'_>,
+    query_length: CassStrLen,
 ) -> CassOwnedSharedPtr<CassFuture, CMut> {
     let Some(cass_session) = ArcFFI::cloned_from_ptr(cass_session_raw) else {
         tracing::error!("Provided null session pointer to cass_session_prepare_n!");
         return ArcFFI::null();
     };
 
-    let query_str = match unsafe { ptr_to_cstr_n(query, query_length) } {
+    let query_str = match unsafe { query.to_str(query_length) } {
         Ok(s) => s,
         // Apparently nullptr denotes an empty statement string.
         // It seems to be intended (for some weird reason, why not save a round-trip???)
@@ -872,7 +872,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        argconv::make_c_str,
+        argconv::{CassStrLen, CassStrLenDelimited, CassStrNulTerminated, make_c_str},
         cluster::{
             cass_cluster_free, cass_cluster_new, cass_cluster_set_contact_points_n,
             cass_cluster_set_execution_profile,
@@ -918,7 +918,11 @@ mod tests {
             let (c_ip, c_ip_len) = str_to_c_str_n(ip.as_str());
 
             assert_cass_error_eq!(
-                cass_cluster_set_contact_points_n(cluster_raw.borrow_mut(), c_ip, c_ip_len),
+                cass_cluster_set_contact_points_n(
+                    cluster_raw.borrow_mut(),
+                    CassStrLenDelimited::from_raw(c_ip),
+                    CassStrLen::from_raw(c_ip_len)
+                ),
                 CassError::CASS_OK
             );
             let session_raw = cass_session_new();
@@ -943,7 +947,7 @@ mod tests {
 
                 cass_cluster_set_execution_profile(
                     cluster_raw.borrow_mut(),
-                    make_c_str!("prof"),
+                    CassStrNulTerminated::from_raw(make_c_str!("prof")),
                     profile_raw.borrow_mut(),
                 );
                 // Mutations in cluster do not affect the session that was connected before.
@@ -1022,7 +1026,11 @@ mod tests {
             let (c_ip, c_ip_len) = str_to_c_str_n(ip.as_str());
 
             assert_cass_error_eq!(
-                cass_cluster_set_contact_points_n(cluster_raw.borrow_mut(), c_ip, c_ip_len),
+                cass_cluster_set_contact_points_n(
+                    cluster_raw.borrow_mut(),
+                    CassStrLenDelimited::from_raw(c_ip),
+                    CassStrLen::from_raw(c_ip_len)
+                ),
                 CassError::CASS_OK
             );
 
@@ -1040,7 +1048,8 @@ mod tests {
             let invalid_query = make_c_str!(
                 "INSERT INTO system.runtime_info (group, item, value) VALUES ('bindings_test', 'bindings_test', 'bindings_test')"
             );
-            let mut statement_raw = cass_statement_new(invalid_query, 0);
+            let mut statement_raw =
+                cass_statement_new(CassStrNulTerminated::from_raw(invalid_query), 0);
             let mut batch_raw = cass_batch_new(CassBatchType::CASS_BATCH_TYPE_LOGGED);
             assert_cass_error_eq!(
                 cass_batch_add_statement(batch_raw.borrow_mut(), statement_raw.borrow()),
@@ -1050,7 +1059,7 @@ mod tests {
             assert_cass_error_eq!(
                 cass_cluster_set_execution_profile(
                     cluster_raw.borrow_mut(),
-                    valid_name_c_str,
+                    CassStrNulTerminated::from_raw(valid_name_c_str),
                     profile_raw.borrow_mut(),
                 ),
                 CassError::CASS_OK
@@ -1072,12 +1081,15 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_statement_set_execution_profile(
                             statement_raw.borrow_mut(),
-                            valid_name_c_str,
+                            CassStrNulTerminated::from_raw(valid_name_c_str),
                         ),
                         CassError::CASS_OK
                     );
                     assert_cass_error_eq!(
-                        cass_batch_set_execution_profile(batch_raw.borrow_mut(), valid_name_c_str,),
+                        cass_batch_set_execution_profile(
+                            batch_raw.borrow_mut(),
+                            CassStrNulTerminated::from_raw(valid_name_c_str),
+                        ),
                         CassError::CASS_OK
                     );
 
@@ -1156,14 +1168,14 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_statement_set_execution_profile(
                             statement_raw.borrow_mut(),
-                            std::ptr::null::<i8>()
+                            CassStrNulTerminated::from_raw(std::ptr::null())
                         ),
                         CassError::CASS_OK
                     );
                     assert_cass_error_eq!(
                         cass_batch_set_execution_profile(
                             batch_raw.borrow_mut(),
-                            std::ptr::null::<i8>()
+                            CassStrNulTerminated::from_raw(std::ptr::null())
                         ),
                         CassError::CASS_OK
                     );
@@ -1177,16 +1189,16 @@ mod tests {
                     assert_cass_error_eq!(
                         cass_statement_set_execution_profile_n(
                             statement_raw.borrow_mut(),
-                            nonexisting_name_c_str,
-                            nonexisting_name_len,
+                            CassStrLenDelimited::from_raw(nonexisting_name_c_str),
+                            CassStrLen::from_raw(nonexisting_name_len),
                         ),
                         CassError::CASS_OK
                     );
                     assert_cass_error_eq!(
                         cass_batch_set_execution_profile_n(
                             batch_raw.borrow_mut(),
-                            nonexisting_name_c_str,
-                            nonexisting_name_len,
+                            CassStrLenDelimited::from_raw(nonexisting_name_c_str),
+                            CassStrLen::from_raw(nonexisting_name_len),
                         ),
                         CassError::CASS_OK
                     );

--- a/scylla-rust-wrapper/src/ssl.rs
+++ b/scylla-rust-wrapper/src/ssl.rs
@@ -1,4 +1,7 @@
-use crate::argconv::{ArcFFI, CMut, CassBorrowedSharedPtr, CassOwnedSharedPtr, FFI, FromArc};
+use crate::argconv::{
+    ArcFFI, CMut, CassBorrowedSharedPtr, CassOwnedSharedPtr, CassStrLen, CassStrLenDelimited,
+    CassStrNulTerminated, FFI, FromArc,
+};
 use crate::cass_error::CassError;
 use crate::types::size_t;
 use libc::{c_int, strlen};
@@ -101,27 +104,42 @@ unsafe extern "C" fn pem_password_callback(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_ssl_add_trusted_cert(
     ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
-    cert: *const c_char,
+    cert: CassStrNulTerminated<'_>,
 ) -> CassError {
-    if cert.is_null() {
-        return CassError::CASS_ERROR_SSL_INVALID_CERT;
-    }
-
-    unsafe { cass_ssl_add_trusted_cert_n(ssl, cert, strlen(cert).try_into().unwrap()) }
+    let (cert, cert_length) = unsafe { cert.as_len_delimited() };
+    unsafe { cass_ssl_add_trusted_cert_n(ssl, cert, cert_length) }
 }
+
+// These functions accept PEM-encoded data (ASCII text format), not binary DER.
+// Both the cpp-driver API documentation and the implementation (PEM_read_bio_X509,
+// PEM_read_bio_PrivateKey) enforce PEM-only input. Since ASCII is a subset of
+// UTF-8, using CassStrLenDelimited (which validates UTF-8) is safe and appropriate.
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_ssl_add_trusted_cert_n(
     ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
-    cert: *const c_char,
-    cert_length: size_t,
+    cert: CassStrLenDelimited<'_>,
+    cert_length: CassStrLen,
 ) -> CassError {
     let Some(ssl) = ArcFFI::cloned_from_ptr(ssl) else {
         tracing::error!("Provided null ssl pointer to cass_ssl_add_trusted_cert_n!");
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let bio = unsafe { BIO_new_mem_buf(cert as *const c_void, cert_length.try_into().unwrap()) };
+    let cert_str = match unsafe { cert.to_str(cert_length) } {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("Invalid PEM certificate data: {e}");
+            return CassError::CASS_ERROR_SSL_INVALID_CERT;
+        }
+    };
+
+    let bio = unsafe {
+        BIO_new_mem_buf(
+            cert_str.as_ptr() as *const c_void,
+            cert_str.len().try_into().unwrap(),
+        )
+    };
 
     if bio.is_null() {
         return CassError::CASS_ERROR_SSL_INVALID_CERT;
@@ -188,27 +206,37 @@ pub unsafe extern "C" fn cass_ssl_set_verify_flags(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_ssl_set_cert(
     ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
-    cert: *const c_char,
+    cert: CassStrNulTerminated<'_>,
 ) -> CassError {
-    if cert.is_null() {
-        return CassError::CASS_ERROR_SSL_INVALID_CERT;
-    }
-
-    unsafe { cass_ssl_set_cert_n(ssl, cert, strlen(cert).try_into().unwrap()) }
+    let (cert, cert_length) = unsafe { cert.as_len_delimited() };
+    unsafe { cass_ssl_set_cert_n(ssl, cert, cert_length) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_ssl_set_cert_n(
     ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
-    cert: *const c_char,
-    cert_length: size_t,
+    cert: CassStrLenDelimited<'_>,
+    cert_length: CassStrLen,
 ) -> CassError {
     let Some(ssl) = ArcFFI::cloned_from_ptr(ssl) else {
         tracing::error!("Provided null ssl pointer to cass_ssl_set_cert_n!");
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let bio = unsafe { BIO_new_mem_buf(cert as *const c_void, cert_length.try_into().unwrap()) };
+    let cert_str = match unsafe { cert.to_str(cert_length) } {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("Invalid PEM certificate data: {e}");
+            return CassError::CASS_ERROR_SSL_INVALID_CERT;
+        }
+    };
+
+    let bio = unsafe {
+        BIO_new_mem_buf(
+            cert_str.as_ptr() as *const c_void,
+            cert_str.len().try_into().unwrap(),
+        )
+    };
 
     if bio.is_null() {
         return CassError::CASS_ERROR_SSL_INVALID_CERT;
@@ -280,29 +308,24 @@ unsafe extern "C" fn SSL_CTX_use_certificate_chain_bio(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_ssl_set_private_key(
     ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
-    key: *const c_char,
+    key: CassStrNulTerminated<'_>,
     password: *mut c_char,
 ) -> CassError {
-    if key.is_null() || password.is_null() {
+    if password.is_null() {
         return CassError::CASS_ERROR_SSL_INVALID_PRIVATE_KEY;
     }
 
-    unsafe {
-        cass_ssl_set_private_key_n(
-            ssl,
-            key,
-            strlen(key).try_into().unwrap(),
-            password,
-            strlen(password).try_into().unwrap(),
-        )
-    }
+    let (key, key_length) = unsafe { key.as_len_delimited() };
+    unsafe { cass_ssl_set_private_key_n(ssl, key, key_length, password, 0) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_ssl_set_private_key_n(
     ssl: CassBorrowedSharedPtr<CassSsl, CMut>,
-    key: *const c_char,
-    key_length: size_t,
+    key: CassStrLenDelimited<'_>,
+    key_length: CassStrLen,
+    // Password is passed as opaque userdata to OpenSSL's PEM password callback,
+    // not used as a string by this function directly. Left as raw pointer.
     password: *mut c_char,
     _password_length: size_t,
 ) -> CassError {
@@ -311,7 +334,20 @@ pub unsafe extern "C" fn cass_ssl_set_private_key_n(
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
 
-    let bio = unsafe { BIO_new_mem_buf(key as *const c_void, key_length.try_into().unwrap()) };
+    let key_str = match unsafe { key.to_str(key_length) } {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("Invalid PEM private key data: {e}");
+            return CassError::CASS_ERROR_SSL_INVALID_PRIVATE_KEY;
+        }
+    };
+
+    let bio = unsafe {
+        BIO_new_mem_buf(
+            key_str.as_ptr() as *const c_void,
+            key_str.len().try_into().unwrap(),
+        )
+    };
 
     if bio.is_null() {
         return CassError::CASS_ERROR_SSL_INVALID_CERT;

--- a/scylla-rust-wrapper/src/statements/prepared.rs
+++ b/scylla-rust-wrapper/src/statements/prepared.rs
@@ -254,19 +254,20 @@ pub unsafe extern "C" fn cass_prepared_parameter_data_type(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name(
-    prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
-    name: *const c_char,
-) -> CassBorrowedSharedPtr<CassDataType, CConst> {
-    unsafe { cass_prepared_parameter_data_type_by_name_n(prepared_raw, name, strlen(name)) }
+pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name<'a>(
+    prepared_raw: CassBorrowedSharedPtr<'a, CassPrepared, CConst>,
+    name: CassStrNulTerminated<'_>,
+) -> CassBorrowedSharedPtr<'a, CassDataType, CConst> {
+    let (name, name_length) = unsafe { name.as_len_delimited() };
+    unsafe { cass_prepared_parameter_data_type_by_name_n(prepared_raw, name, name_length) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name_n(
-    prepared_raw: CassBorrowedSharedPtr<CassPrepared, CConst>,
-    name: *const c_char,
-    name_length: size_t,
-) -> CassBorrowedSharedPtr<CassDataType, CConst> {
+pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name_n<'a>(
+    prepared_raw: CassBorrowedSharedPtr<'a, CassPrepared, CConst>,
+    name: CassStrLenDelimited<'_>,
+    name_length: CassStrLen,
+) -> CassBorrowedSharedPtr<'a, CassDataType, CConst> {
     let Some(prepared) = ArcFFI::as_ref(prepared_raw) else {
         tracing::error!(
             "Provided null prepared statement pointer to cass_prepared_parameter_data_type_by_name!"
@@ -274,7 +275,7 @@ pub unsafe extern "C" fn cass_prepared_parameter_data_type_by_name_n(
         return ArcFFI::null();
     };
 
-    let parameter_name = match unsafe { ptr_to_cstr_n(name, name_length) } {
+    let parameter_name = match unsafe { name.to_str(name_length) } {
         Ok(name) => name,
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Prepared parameter name pointer is null");

--- a/scylla-rust-wrapper/src/statements/statement.rs
+++ b/scylla-rust-wrapper/src/statements/statement.rs
@@ -287,19 +287,20 @@ impl CassStatement {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_new(
-    query: *const c_char,
+    query: CassStrNulTerminated<'_>,
     parameter_count: size_t,
 ) -> CassOwnedExclusivePtr<CassStatement, CMut> {
-    unsafe { cass_statement_new_n(query, strlen(query), parameter_count) }
+    let (query, query_length) = unsafe { query.as_len_delimited() };
+    unsafe { cass_statement_new_n(query, query_length, parameter_count) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_new_n(
-    query: *const c_char,
-    query_length: size_t,
+    query: CassStrLenDelimited<'_>,
+    query_length: CassStrLen,
     parameter_count: size_t,
 ) -> CassOwnedExclusivePtr<CassStatement, CMut> {
-    let query_str = match unsafe { ptr_to_cstr_n(query, query_length) } {
+    let query_str = match unsafe { query.to_str(query_length) } {
         Ok(v) => v,
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Provided null query pointer to cass_statement_new(_n)!");
@@ -489,24 +490,25 @@ pub unsafe extern "C" fn cass_statement_set_tracing(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_host(
     statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
-    host: *const c_char,
+    host: CassStrNulTerminated<'_>,
     port: c_int,
 ) -> CassError {
-    unsafe { cass_statement_set_host_n(statement_raw, host, strlen(host), port) }
+    let (host, host_length) = unsafe { host.as_len_delimited() };
+    unsafe { cass_statement_set_host_n(statement_raw, host, host_length, port) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_statement_set_host_n(
     statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
-    host: *const c_char,
-    host_length: size_t,
+    host: CassStrLenDelimited<'_>,
+    host_length: CassStrLen,
     port: c_int,
 ) -> CassError {
     let Some(statement) = BoxFFI::as_mut_ref(statement_raw) else {
         tracing::error!("Provided null statement pointer to cass_statement_set_host_n!");
         return CassError::CASS_ERROR_LIB_BAD_PARAMS;
     };
-    let host = match unsafe { ptr_to_cstr_n(host, host_length) } {
+    let host = match unsafe { host.to_str(host_length) } {
         Ok(v) => v,
         Err(PtrToStrError::NullPointer) => {
             tracing::error!("Provided null host pointer to cass_statement_set_host_n!");
@@ -884,7 +886,9 @@ mod tests {
     use std::ptr::addr_of;
     use std::str::FromStr;
 
-    use crate::argconv::{BoxFFI, RefFFI};
+    use crate::argconv::{
+        BoxFFI, CassStrLen, CassStrLenDelimited, CassStrNulTerminated, RefFFI, make_c_str,
+    };
     use crate::cass_error::CassError;
     use crate::cql_types::inet::CassInet;
     use crate::statements::statement::{
@@ -897,32 +901,49 @@ mod tests {
     #[test]
     fn test_statement_set_host() {
         unsafe {
-            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 0);
+            let mut statement_raw =
+                cass_statement_new(CassStrNulTerminated::from_raw(make_c_str!("dummy")), 0);
 
             // cass_statement_set_host
             {
                 // Null statement
                 assert_cass_error_eq!(
                     CassError::CASS_ERROR_LIB_BAD_PARAMS,
-                    cass_statement_set_host(BoxFFI::null_mut(), c"127.0.0.1".as_ptr(), 9042)
+                    cass_statement_set_host(
+                        BoxFFI::null_mut(),
+                        CassStrNulTerminated::from_raw(make_c_str!("127.0.0.1")),
+                        9042
+                    )
                 );
 
                 // Null ip address
                 assert_cass_error_eq!(
                     CassError::CASS_ERROR_LIB_BAD_PARAMS,
-                    cass_statement_set_host(statement_raw.borrow_mut(), std::ptr::null(), 9042)
+                    cass_statement_set_host(
+                        statement_raw.borrow_mut(),
+                        CassStrNulTerminated::from_raw(std::ptr::null()),
+                        9042
+                    )
                 );
 
                 // Unparsable ip address
                 assert_cass_error_eq!(
                     CassError::CASS_ERROR_LIB_BAD_PARAMS,
-                    cass_statement_set_host(statement_raw.borrow_mut(), c"invalid".as_ptr(), 9042)
+                    cass_statement_set_host(
+                        statement_raw.borrow_mut(),
+                        CassStrNulTerminated::from_raw(make_c_str!("invalid")),
+                        9042
+                    )
                 );
 
                 // Negative port
                 assert_cass_error_eq!(
                     CassError::CASS_ERROR_LIB_BAD_PARAMS,
-                    cass_statement_set_host(statement_raw.borrow_mut(), c"127.0.0.1".as_ptr(), -1)
+                    cass_statement_set_host(
+                        statement_raw.borrow_mut(),
+                        CassStrNulTerminated::from_raw(make_c_str!("127.0.0.1")),
+                        -1
+                    )
                 );
 
                 // Port too big
@@ -930,7 +951,7 @@ mod tests {
                     CassError::CASS_ERROR_LIB_BAD_PARAMS,
                     cass_statement_set_host(
                         statement_raw.borrow_mut(),
-                        c"127.0.0.1".as_ptr(),
+                        CassStrNulTerminated::from_raw(make_c_str!("127.0.0.1")),
                         70000
                     )
                 );
@@ -940,7 +961,7 @@ mod tests {
                     CassError::CASS_OK,
                     cass_statement_set_host(
                         statement_raw.borrow_mut(),
-                        c"127.0.0.1".as_ptr(),
+                        CassStrNulTerminated::from_raw(make_c_str!("127.0.0.1")),
                         9042
                     )
                 );
@@ -1035,12 +1056,17 @@ mod tests {
     #[test]
     fn test_bind_string_null_pointer() {
         unsafe {
-            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+            let mut statement_raw =
+                cass_statement_new(CassStrNulTerminated::from_raw(make_c_str!("dummy")), 1);
 
             // NULL pointer to cass_statement_bind_string produces empty string, not a crash.
             assert_cass_error_eq!(
                 CassError::CASS_OK,
-                super::cass_statement_bind_string(statement_raw.borrow_mut(), 0, std::ptr::null())
+                super::cass_statement_bind_string(
+                    statement_raw.borrow_mut(),
+                    0,
+                    CassStrNulTerminated::from_raw(std::ptr::null())
+                )
             );
 
             cass_statement_free(statement_raw);
@@ -1050,7 +1076,8 @@ mod tests {
     #[test]
     fn test_bind_string_n_null_pointer() {
         unsafe {
-            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+            let mut statement_raw =
+                cass_statement_new(CassStrNulTerminated::from_raw(make_c_str!("dummy")), 1);
 
             // NULL pointer with size 0 produces empty string.
             assert_cass_error_eq!(
@@ -1058,8 +1085,8 @@ mod tests {
                 super::cass_statement_bind_string_n(
                     statement_raw.borrow_mut(),
                     0,
-                    std::ptr::null(),
-                    0
+                    CassStrLenDelimited::from_raw(std::ptr::null()),
+                    CassStrLen::from_raw(0)
                 )
             );
 
@@ -1069,8 +1096,8 @@ mod tests {
                 super::cass_statement_bind_string_n(
                     statement_raw.borrow_mut(),
                     0,
-                    std::ptr::null(),
-                    5
+                    CassStrLenDelimited::from_raw(std::ptr::null()),
+                    CassStrLen::from_raw(5)
                 )
             );
 
@@ -1081,7 +1108,8 @@ mod tests {
     #[test]
     fn test_bind_bytes_null_pointer() {
         unsafe {
-            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+            let mut statement_raw =
+                cass_statement_new(CassStrNulTerminated::from_raw(make_c_str!("dummy")), 1);
 
             // NULL pointer with size 0 produces empty blob (matching cpp-driver).
             assert_cass_error_eq!(
@@ -1112,7 +1140,8 @@ mod tests {
     #[test]
     fn test_bind_decimal_null_pointer() {
         unsafe {
-            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+            let mut statement_raw =
+                cass_statement_new(CassStrNulTerminated::from_raw(make_c_str!("dummy")), 1);
 
             // NULL pointer with size 0 produces empty varint decimal.
             assert_cass_error_eq!(
@@ -1145,14 +1174,15 @@ mod tests {
     #[test]
     fn test_bind_by_name_null_name() {
         unsafe {
-            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+            let mut statement_raw =
+                cass_statement_new(CassStrNulTerminated::from_raw(make_c_str!("dummy")), 1);
 
             // NULL name pointer should not crash — returns BAD_PARAMS.
             assert_cass_error_eq!(
                 CassError::CASS_ERROR_LIB_BAD_PARAMS,
                 super::cass_statement_bind_int32_by_name(
                     statement_raw.borrow_mut(),
-                    std::ptr::null(),
+                    CassStrNulTerminated::from_raw(std::ptr::null()),
                     42
                 )
             );
@@ -1162,8 +1192,8 @@ mod tests {
                 CassError::CASS_ERROR_LIB_BAD_PARAMS,
                 super::cass_statement_bind_int32_by_name_n(
                     statement_raw.borrow_mut(),
-                    std::ptr::null(),
-                    0,
+                    CassStrLenDelimited::from_raw(std::ptr::null()),
+                    CassStrLen::from_raw(0),
                     42
                 )
             );
@@ -1175,14 +1205,15 @@ mod tests {
     #[test]
     fn test_bind_by_name_empty_name() {
         unsafe {
-            let mut statement_raw = cass_statement_new(c"dummy".as_ptr(), 1);
+            let mut statement_raw =
+                cass_statement_new(CassStrNulTerminated::from_raw(make_c_str!("dummy")), 1);
 
             // Empty name is a programmer error — returns BAD_PARAMS.
             assert_cass_error_eq!(
                 CassError::CASS_ERROR_LIB_BAD_PARAMS,
                 super::cass_statement_bind_int32_by_name(
                     statement_raw.borrow_mut(),
-                    c"".as_ptr(),
+                    CassStrNulTerminated::from_cstr(c""),
                     42
                 )
             );
@@ -1192,8 +1223,8 @@ mod tests {
                 CassError::CASS_ERROR_LIB_BAD_PARAMS,
                 super::cass_statement_bind_int32_by_name_n(
                     statement_raw.borrow_mut(),
-                    c"x".as_ptr(),
-                    0,
+                    CassStrLenDelimited::from_raw(c"x".as_ptr()),
+                    CassStrLen::from_raw(0),
                     42
                 )
             );

--- a/scylla-rust-wrapper/src/testing/integration.rs
+++ b/scylla-rust-wrapper/src/testing/integration.rs
@@ -386,7 +386,9 @@ pub(crate) mod stubs {
     use std::ffi::c_void;
 
     use super::*;
-    use crate::argconv::{CassOwnedExclusivePtr, CassPtr, ptr_to_cstr_n, strlen};
+    use crate::argconv::{
+        CassOwnedExclusivePtr, CassPtr, CassStrLen, CassStrLenDelimited, CassStrNulTerminated,
+    };
     use crate::cass_authenticator_types::{
         CassAuthenticatorCallbacks, CassAuthenticatorDataCleanupCallback,
     };
@@ -402,21 +404,20 @@ pub(crate) mod stubs {
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn cass_cluster_set_cloud_secure_connection_bundle(
         cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-        path: *const c_char,
+        path: CassStrNulTerminated<'_>,
     ) -> CassError {
-        unsafe {
-            cass_cluster_set_cloud_secure_connection_bundle_n(cluster_raw, path, strlen(path))
-        }
+        let (path, path_length) = unsafe { path.as_len_delimited() };
+        unsafe { cass_cluster_set_cloud_secure_connection_bundle_n(cluster_raw, path, path_length) }
     }
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn cass_cluster_set_cloud_secure_connection_bundle_n(
         _cluster_raw: CassBorrowedExclusivePtr<CassCluster, CMut>,
-        path: *const c_char,
-        path_length: size_t,
+        path: CassStrLenDelimited<'_>,
+        path_length: CassStrLen,
     ) -> CassError {
         // FIXME: Should unzip file associated with the path
-        let zip_file = unsafe { ptr_to_cstr_n(path, path_length) }.unwrap();
+        let zip_file = unsafe { path.to_str(path_length) }.unwrap();
 
         if zip_file == "invalid_filename" {
             return CassError::CASS_ERROR_LIB_BAD_PARAMS;
@@ -481,7 +482,7 @@ pub(crate) mod stubs {
     #[unsafe(no_mangle)]
     pub extern "C" fn cass_statement_set_keyspace(
         _statement: CassBorrowedExclusivePtr<CassStatement, CMut>,
-        _keyspace: *const c_char,
+        _keyspace: CassStrNulTerminated<'_>,
     ) -> CassError {
         CassError::CASS_OK
     }
@@ -590,10 +591,10 @@ pub(crate) mod stubs {
     }
 
     #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn cass_keyspace_meta_function_by_name(
-        _keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
-        _function: *const c_char,
-    ) -> CassBorrowedSharedPtr<CassFunctionMeta, CConst> {
+    pub unsafe extern "C" fn cass_keyspace_meta_function_by_name<'a>(
+        _keyspace_meta: CassBorrowedSharedPtr<'a, CassKeyspaceMeta, CConst>,
+        _function: CassStrNulTerminated<'_>,
+    ) -> CassBorrowedSharedPtr<'a, CassFunctionMeta, CConst> {
         CassPtr::null()
     }
 
@@ -615,10 +616,10 @@ pub(crate) mod stubs {
     }
 
     #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn cass_keyspace_meta_aggregate_by_name(
-        _keyspace_meta: CassBorrowedSharedPtr<CassKeyspaceMeta, CConst>,
-        _aggregate: *const c_char,
-    ) -> CassBorrowedSharedPtr<CassAggregateMeta, CConst> {
+    pub unsafe extern "C" fn cass_keyspace_meta_aggregate_by_name<'a>(
+        _keyspace_meta: CassBorrowedSharedPtr<'a, CassKeyspaceMeta, CConst>,
+        _aggregate: CassStrNulTerminated<'_>,
+    ) -> CassBorrowedSharedPtr<'a, CassAggregateMeta, CConst> {
         CassPtr::null()
     }
 }

--- a/scylla-rust-wrapper/src/testing/utils.rs
+++ b/scylla-rust-wrapper/src/testing/utils.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use crate::{
-    argconv::{CMut, CassOwnedSharedPtr, ptr_to_cstr_n},
+    argconv::{CMut, CassOwnedSharedPtr, CassStrLen, CassStrLenDelimited},
     cass_error::CassError,
     future::{
         CassFuture, cass_future_error_code, cass_future_error_message, cass_future_free,
@@ -29,28 +29,41 @@ pub(crate) fn setup_tracing() {
 macro_rules! assert_cass_error_eq {
     ($expr:expr, $error:expr $(,)?) => {{
         use crate::api::error::cass_error_desc;
-        use crate::argconv::ptr_to_cstr;
         let ___x = $expr;
-        assert_eq!(
-            ___x,
-            $error,
-            "expected \"{}\", instead got \"{}\"",
-            ptr_to_cstr(cass_error_desc($error)).unwrap(),
-            ptr_to_cstr(cass_error_desc(___x)).unwrap()
-        );
+        #[allow(unused_unsafe)] // Sometimes the macro is expanded in an `unsafe` context.
+        //
+        // SAFETY: `cass_error_desc()` is safe to call with any integer,
+        // including invalid error codes. It always returns a valid ASCII string.
+        unsafe {
+            let ___expected = cass_error_desc($error)
+                .to_str()
+                .expect("cass_error_desc() always returns a valid ASCII string");
+            let ___got = cass_error_desc(___x)
+                .to_str()
+                .expect("cass_error_desc() always returns a valid ASCII string");
+            assert_eq!(
+                ___x, $error,
+                "expected \"{___expected}\", instead got \"{___got}\"",
+            );
+        }
     }};
 }
 pub(crate) use assert_cass_error_eq;
 
 macro_rules! assert_cass_future_error_message_eq {
     ($cass_fut:ident, $error_msg_opt:expr) => {
-        use crate::argconv::ptr_to_cstr_n;
+        use crate::argconv::{CassStrLen, CassStrLenDelimited};
         use crate::future::cass_future_error_message;
 
         let mut ___message: *const c_char = ::std::ptr::null();
         let mut ___msg_len: size_t = 0;
         cass_future_error_message($cass_fut.borrow(), &mut ___message, &mut ___msg_len);
-        assert_eq!(ptr_to_cstr_n(___message, ___msg_len).ok(), $error_msg_opt);
+        assert_eq!(
+            CassStrLenDelimited::from_raw(___message)
+                .to_str(CassStrLen::from_raw(___msg_len))
+                .ok(),
+            $error_msg_opt,
+        );
     };
 }
 pub(crate) use assert_cass_future_error_message_eq;
@@ -61,7 +74,10 @@ pub(crate) unsafe fn cass_future_wait_check_and_free(fut: CassOwnedSharedPtr<Cas
         let mut message: *const c_char = std::ptr::null();
         let mut message_len: size_t = 0;
         unsafe { cass_future_error_message(fut.borrow(), &mut message, &mut message_len) };
-        eprintln!("{:?}", unsafe { ptr_to_cstr_n(message, message_len).ok() });
+        let msg_str = CassStrLenDelimited::from_raw(message);
+        eprintln!("{:?}", unsafe {
+            msg_str.to_str(CassStrLen::from_raw(message_len)).ok()
+        });
     }
     unsafe {
         assert_cass_error_eq!(cass_future_error_code(fut.borrow()), CassError::CASS_OK);

--- a/scylla-rust-wrapper/tests/integration/consistency.rs
+++ b/scylla-rust-wrapper/tests/integration/consistency.rs
@@ -1,5 +1,4 @@
 use itertools::Itertools as _;
-use libc::c_char;
 use scylla::frame::types::Consistency;
 use scylla::statement::SerialConsistency;
 use scylla::statement::batch::BatchType;
@@ -33,13 +32,14 @@ use scylla_cpp_driver::api::statement::{
     CassStatement, cass_statement_new, cass_statement_set_consistency,
     cass_statement_set_execution_profile, cass_statement_set_serial_consistency,
 };
-use scylla_cpp_driver::argconv::{CConst, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr};
+use scylla_cpp_driver::argconv::{
+    CConst, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr, CassStrNulTerminated,
+};
 use scylla_cql::frame::protocol_features::ProtocolFeatures;
 use scylla_proxy::{
     Condition, ProxyError, Reaction, RequestFrame, RequestOpcode, RequestReaction, RequestRule,
     TargetShard, WorkerError,
 };
-use std::ffi::CStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::{self, UnboundedReceiver};
 
@@ -82,7 +82,8 @@ fn pairs_of_all_consistencies() -> impl Iterator<Item = (Consistency, Option<Ser
     consistencies.zip(serial_consistencies)
 }
 
-const STATEMENT_CSTR: *const i8 = c"INSERT INTO consistency_tests VALUES (42)" as *const CStr as _;
+const STATEMENT_CSTR: CassStrNulTerminated<'static> =
+    CassStrNulTerminated::from_cstr(c"INSERT INTO consistency_tests VALUES (42)");
 
 fn execute_and_check_statement(
     cass_session: CassBorrowedSharedPtr<'_, CassSession, CMut>,
@@ -202,7 +203,10 @@ fn check_for_all_consistencies_and_setting_options(
     unsafe {
         let mut cass_cluster = cass_cluster_new();
         assert_cass_error_eq(
-            cass_cluster_set_contact_points(cass_cluster.borrow_mut(), contact_points.as_ptr()),
+            cass_cluster_set_contact_points(
+                cass_cluster.borrow_mut(),
+                CassStrNulTerminated::from_raw(contact_points.as_ptr()),
+            ),
             CassError::CASS_OK,
         );
 
@@ -219,6 +223,7 @@ fn check_for_all_consistencies_and_setting_options(
         let cass_session = cass_session_new();
         let mut cass_exec_profile = cass_execution_profile_new();
         let exec_profile_name = c"test_profile".as_ptr();
+        let exec_profile_name_w = CassStrNulTerminated::from_raw(exec_profile_name);
 
         {
             // Connect the session to the cluster. Use default consistency and serial consistency.
@@ -380,7 +385,7 @@ fn check_for_all_consistencies_and_setting_options(
                 assert_cass_error_eq(
                     cass_cluster_set_execution_profile(
                         cass_cluster.borrow_mut(),
-                        exec_profile_name,
+                        CassStrNulTerminated::from_raw(exec_profile_name),
                         cass_exec_profile.borrow_mut(),
                     ),
                     CassError::CASS_OK,
@@ -447,7 +452,7 @@ fn check_for_all_consistencies_and_setting_options(
                     assert_cass_error_eq(
                         cass_statement_set_execution_profile(
                             cass_statement_unprepared.borrow_mut(),
-                            exec_profile_name,
+                            exec_profile_name_w.clone(),
                         ),
                         CassError::CASS_OK,
                     );
@@ -465,7 +470,7 @@ fn check_for_all_consistencies_and_setting_options(
                     assert_cass_error_eq(
                         cass_statement_set_execution_profile(
                             cass_statement_prepared.borrow_mut(),
-                            exec_profile_name,
+                            exec_profile_name_w.clone(),
                         ),
                         CassError::CASS_OK,
                     );
@@ -483,7 +488,7 @@ fn check_for_all_consistencies_and_setting_options(
                     assert_cass_error_eq(
                         cass_statement_set_execution_profile(
                             cass_statement_prepared_from_existing.borrow_mut(),
-                            exec_profile_name,
+                            exec_profile_name_w.clone(),
                         ),
                         CassError::CASS_OK,
                     );
@@ -503,7 +508,7 @@ fn check_for_all_consistencies_and_setting_options(
                     assert_cass_error_eq(
                         cass_batch_set_execution_profile(
                             cass_batch.borrow_mut(),
-                            exec_profile_name,
+                            exec_profile_name_w.clone(),
                         ),
                         CassError::CASS_OK,
                     );
@@ -561,7 +566,7 @@ fn check_for_all_consistencies_and_setting_options(
                 assert_cass_error_eq(
                     cass_statement_set_execution_profile(
                         cass_statement_unprepared.borrow_mut(),
-                        std::ptr::null::<c_char>(),
+                        CassStrNulTerminated::from_raw(std::ptr::null()),
                     ),
                     CassError::CASS_OK,
                 );
@@ -570,7 +575,7 @@ fn check_for_all_consistencies_and_setting_options(
                 assert_cass_error_eq(
                     cass_statement_set_execution_profile(
                         cass_statement_prepared.borrow_mut(),
-                        std::ptr::null::<c_char>(),
+                        CassStrNulTerminated::from_raw(std::ptr::null()),
                     ),
                     CassError::CASS_OK,
                 );
@@ -579,7 +584,7 @@ fn check_for_all_consistencies_and_setting_options(
                 assert_cass_error_eq(
                     cass_statement_set_execution_profile(
                         cass_statement_prepared_from_existing.borrow_mut(),
-                        std::ptr::null::<c_char>(),
+                        CassStrNulTerminated::from_raw(std::ptr::null()),
                     ),
                     CassError::CASS_OK,
                 );
@@ -588,7 +593,7 @@ fn check_for_all_consistencies_and_setting_options(
                 assert_cass_error_eq(
                     cass_batch_set_execution_profile(
                         cass_batch.borrow_mut(),
-                        std::ptr::null::<c_char>(),
+                        CassStrNulTerminated::from_raw(std::ptr::null()),
                     ),
                     CassError::CASS_OK,
                 );

--- a/scylla-rust-wrapper/tests/integration/session.rs
+++ b/scylla-rust-wrapper/tests/integration/session.rs
@@ -1,9 +1,8 @@
 use std::{
-    ffi::{CStr, c_void},
+    ffi::c_void,
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use libc::c_char;
 use rusty_fork::rusty_fork_test;
 use scylla::errors::DbError;
 use scylla_cpp_driver::{
@@ -14,9 +13,8 @@ use scylla_cpp_driver::{
         },
         cluster::{
             cass_cluster_free, cass_cluster_new, cass_cluster_set_client_id,
-            cass_cluster_set_contact_points, cass_cluster_set_contact_points_n,
-            cass_cluster_set_execution_profile, cass_cluster_set_latency_aware_routing,
-            cass_cluster_set_retry_policy,
+            cass_cluster_set_contact_points, cass_cluster_set_execution_profile,
+            cass_cluster_set_latency_aware_routing, cass_cluster_set_retry_policy,
         },
         error::CassError,
         execution_profile::{
@@ -42,7 +40,9 @@ use scylla_cpp_driver::{
         },
         uuid::CassUuid,
     },
-    argconv::{ArcFFI, CConst, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr},
+    argconv::{
+        ArcFFI, CConst, CMut, CassBorrowedExclusivePtr, CassBorrowedSharedPtr, CassStrNulTerminated,
+    },
     types::cass_bool_t,
 };
 use scylla_cql::Consistency;
@@ -54,7 +54,7 @@ use tracing::instrument::WithSubscriber as _;
 use crate::utils::{
     assert_cass_error_eq, cass_future_wait_check_and_free, generic_drop_queries_rules,
     handshake_rules, make_c_str, mock_init_rules, proxy_uris_to_contact_points, setup_tracing,
-    str_to_c_str_n, test_with_3_node_dry_mode_cluster,
+    test_with_3_node_dry_mode_cluster,
 };
 
 #[tokio::test]
@@ -129,7 +129,10 @@ fn retry_policy_on_statement_and_batch_is_handled_properly_do(
         let contact_points = proxy_uris_to_contact_points(proxy_uris);
 
         assert_cass_error_eq(
-            cass_cluster_set_contact_points(cluster_raw.borrow_mut(), contact_points.as_ptr()),
+            cass_cluster_set_contact_points(
+                cluster_raw.borrow_mut(),
+                CassStrNulTerminated::from_raw(contact_points.as_ptr()),
+            ),
             CassError::CASS_OK,
         );
 
@@ -152,7 +155,7 @@ fn retry_policy_on_statement_and_batch_is_handled_properly_do(
         );
 
         let query = make_c_str!("SELECT host_id FROM system.local WHERE key='local'");
-        let mut statement_raw = cass_statement_new(query, 0);
+        let mut statement_raw = cass_statement_new(CassStrNulTerminated::from_raw(query), 0);
         let mut batch_raw = cass_batch_new(CassBatchType::CASS_BATCH_TYPE_LOGGED);
         assert_cass_error_eq(
             cass_batch_add_statement(batch_raw.borrow_mut(), statement_raw.borrow()),
@@ -162,7 +165,7 @@ fn retry_policy_on_statement_and_batch_is_handled_properly_do(
         assert_cass_error_eq(
             cass_cluster_set_execution_profile(
                 cluster_raw.borrow_mut(),
-                profile_name_c_str,
+                CassStrNulTerminated::from_raw(profile_name_c_str),
                 profile_raw.borrow_mut(),
             ),
             CassError::CASS_OK,
@@ -245,14 +248,14 @@ fn retry_policy_on_statement_and_batch_is_handled_properly_do(
             }
 
             unsafe fn set_provided_exec_profile(
-                name: *const i8,
+                name: CassStrNulTerminated<'_>,
                 statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
                 batch_raw: CassBorrowedExclusivePtr<CassBatch, CMut>,
             ) {
                 // Set statement/batch exec profile.
                 unsafe {
                     assert_cass_error_eq(
-                        cass_statement_set_execution_profile(statement_raw, name),
+                        cass_statement_set_execution_profile(statement_raw, name.clone()),
                         CassError::CASS_OK,
                     );
                     assert_cass_error_eq(
@@ -262,7 +265,7 @@ fn retry_policy_on_statement_and_batch_is_handled_properly_do(
                 }
             }
             unsafe fn set_exec_profile(
-                profile_name_c_str: *const c_char,
+                profile_name_c_str: CassStrNulTerminated<'_>,
                 statement_raw: CassBorrowedExclusivePtr<CassStatement, CMut>,
                 batch_raw: CassBorrowedExclusivePtr<CassBatch, CMut>,
             ) {
@@ -273,7 +276,11 @@ fn retry_policy_on_statement_and_batch_is_handled_properly_do(
                 batch_raw: CassBorrowedExclusivePtr<CassBatch, CMut>,
             ) {
                 unsafe {
-                    set_provided_exec_profile(std::ptr::null::<i8>(), statement_raw, batch_raw)
+                    set_provided_exec_profile(
+                        CassStrNulTerminated::from_raw(std::ptr::null()),
+                        statement_raw,
+                        batch_raw,
+                    )
                 };
             }
             unsafe fn set_retry_policy_on_stmt(
@@ -314,7 +321,7 @@ fn retry_policy_on_statement_and_batch_is_handled_properly_do(
 
             // F D -
             set_exec_profile(
-                profile_name_c_str,
+                CassStrNulTerminated::from_raw(profile_name_c_str),
                 statement_raw.borrow_mut(),
                 batch_raw.borrow_mut(),
             );
@@ -349,7 +356,7 @@ fn retry_policy_on_statement_and_batch_is_handled_properly_do(
 
             // F D F
             set_exec_profile(
-                profile_name_c_str,
+                CassStrNulTerminated::from_raw(profile_name_c_str),
                 statement_raw.borrow_mut(),
                 batch_raw.borrow_mut(),
             );
@@ -441,7 +448,7 @@ fn retry_policy_on_statement_and_batch_is_handled_properly_do(
 
             // F D D
             set_exec_profile(
-                profile_name_c_str,
+                CassStrNulTerminated::from_raw(profile_name_c_str),
                 statement_raw.borrow_mut(),
                 batch_raw.borrow_mut(),
             );
@@ -480,11 +487,13 @@ fn session_with_latency_aware_load_balancing_does_not_panic() {
         let mut cluster_raw = cass_cluster_new();
 
         // An IP with very little chance of having a ScyllaDB node listening
-        let ip = "127.0.1.231";
-        let (c_ip, c_ip_len) = str_to_c_str_n(ip);
+        let ip = make_c_str!("127.0.1.231");
 
         assert_cass_error_eq(
-            cass_cluster_set_contact_points_n(cluster_raw.borrow_mut(), c_ip, c_ip_len),
+            cass_cluster_set_contact_points(
+                cluster_raw.borrow_mut(),
+                CassStrNulTerminated::from_raw(ip),
+            ),
             CassError::CASS_OK,
         );
         cass_cluster_set_latency_aware_routing(cluster_raw.borrow_mut(), true as cass_bool_t);
@@ -500,7 +509,7 @@ fn session_with_latency_aware_load_balancing_does_not_panic() {
         let profile_name = make_c_str!("latency_aware");
         cass_cluster_set_execution_profile(
             cluster_raw.borrow_mut(),
-            profile_name,
+            CassStrNulTerminated::from_raw(profile_name),
             profile_raw.borrow_mut(),
         );
         {
@@ -520,15 +529,14 @@ rusty_fork_test! {
     #[test]
     fn cluster_is_not_referenced_by_session_connect_future() {
         // An IP with very little chance of having a ScyllaDB node listening
-        let ip = "127.0.1.231";
-        let (c_ip, c_ip_len) = str_to_c_str_n(ip);
+        let ip = make_c_str!("127.0.1.231");
         let profile_name = make_c_str!("latency_aware");
 
         unsafe {
             let mut cluster_raw = cass_cluster_new();
 
             assert_cass_error_eq(
-                cass_cluster_set_contact_points_n(cluster_raw.borrow_mut(), c_ip, c_ip_len),
+            cass_cluster_set_contact_points(cluster_raw.borrow_mut(), CassStrNulTerminated::from_raw(ip)),
                 CassError::CASS_OK
             );
             cass_cluster_set_latency_aware_routing(cluster_raw.borrow_mut(), true as cass_bool_t);
@@ -538,7 +546,7 @@ rusty_fork_test! {
                 cass_execution_profile_set_latency_aware_routing(profile_raw.borrow_mut(), true as cass_bool_t),
                 CassError::CASS_OK
             );
-            cass_cluster_set_execution_profile(cluster_raw.borrow_mut(), profile_name, profile_raw.borrow_mut());
+            cass_cluster_set_execution_profile(cluster_raw.borrow_mut(), CassStrNulTerminated::from_raw(profile_name), profile_raw.borrow_mut());
             {
                 let cass_future = cass_session_connect(session_raw.borrow(), cluster_raw.borrow().into_c_const());
 
@@ -572,7 +580,7 @@ async fn test_cass_session_get_client_id_on_disconnected_session() {
                 assert_cass_error_eq(
                     cass_cluster_set_contact_points(
                         cluster_raw.borrow_mut(),
-                        contact_points.as_ptr(),
+                        CassStrNulTerminated::from_raw(contact_points.as_ptr()),
                     ),
                     CassError::CASS_OK,
                 );
@@ -639,7 +647,10 @@ fn session_free_waits_for_requests_to_complete_do(
         let contact_points = proxy_uris_to_contact_points(proxy_uris);
 
         assert_cass_error_eq(
-            cass_cluster_set_contact_points(cluster_raw.borrow_mut(), contact_points.as_ptr()),
+            cass_cluster_set_contact_points(
+                cluster_raw.borrow_mut(),
+                CassStrNulTerminated::from_raw(contact_points.as_ptr()),
+            ),
             CassError::CASS_OK,
         );
         let session_raw = cass_session_new();
@@ -650,9 +661,10 @@ fn session_free_waits_for_requests_to_complete_do(
 
         tracing::debug!("Session connected, starting to execute requests...");
 
-        let statement =
-            c"SELECT host_id FROM system.local WHERE key='local'" as *const CStr as *const c_char;
-        let statement_raw = cass_statement_new(statement, 0);
+        let statement = CassStrNulTerminated::from_raw(
+            c"SELECT host_id FROM system.local WHERE key='local'".as_ptr(),
+        );
+        let statement_raw = cass_statement_new(statement.clone(), 0);
 
         let mut batch_raw = cass_batch_new(CassBatchType::CASS_BATCH_TYPE_LOGGED);
         // This batch is obviously invalid, because it contains a SELECT statement. This is OK for us,
@@ -675,7 +687,7 @@ fn session_free_waits_for_requests_to_complete_do(
         let futures = (0..ITERATIONS)
             .flat_map(|_| {
                 // Prepare a statement
-                let prepare_fut = cass_session_prepare(session_raw.borrow(), statement);
+                let prepare_fut = cass_session_prepare(session_raw.borrow(), statement.clone());
 
                 // Execute a statement
                 let statement_fut = cass_session_execute(

--- a/scylla-rust-wrapper/tests/integration/utils.rs
+++ b/scylla-rust-wrapper/tests/integration/utils.rs
@@ -5,7 +5,7 @@ use scylla_cpp_driver::api::future::{
     CassFuture, cass_future_error_code, cass_future_error_message, cass_future_free,
     cass_future_wait,
 };
-use scylla_cpp_driver::argconv::{CMut, CassOwnedSharedPtr, ptr_to_cstr, ptr_to_cstr_n};
+use scylla_cpp_driver::argconv::{CMut, CassOwnedSharedPtr, CassStrLen, CassStrLenDelimited};
 use scylla_cpp_driver::types::size_t;
 use std::collections::HashMap;
 use std::ffi::CString;
@@ -25,26 +25,9 @@ pub(crate) fn setup_tracing() {
         .try_init();
 }
 
-unsafe fn write_str_to_c(s: &str, c_str: *mut *const c_char, c_strlen: *mut size_t) {
-    unsafe {
-        *c_str = s.as_ptr() as *const c_char;
-        *c_strlen = s.len() as u64;
-    }
-}
-
-pub(crate) fn str_to_c_str_n(s: &str) -> (*const c_char, size_t) {
-    let mut c_str = std::ptr::null();
-    let mut c_strlen = size_t::default();
-
-    // SAFETY: The pointers that are passed to `write_str_to_c` are compile-checked references.
-    unsafe { write_str_to_c(s, &mut c_str, &mut c_strlen) };
-
-    (c_str, c_strlen)
-}
-
 macro_rules! make_c_str {
     ($str:literal) => {
-        concat!($str, "\0").as_ptr() as *const c_char
+        concat!($str, "\0").as_ptr() as *const std::ffi::c_char
     };
 }
 pub(crate) use make_c_str;
@@ -89,8 +72,8 @@ pub(crate) fn assert_cass_error_eq(errcode1: CassError, errcode2: CassError) {
             errcode1,
             errcode2,
             "expected \"{}\", instead got \"{}\"",
-            ptr_to_cstr(cass_error_desc(errcode1)).unwrap(),
-            ptr_to_cstr(cass_error_desc(errcode2)).unwrap()
+            cass_error_desc(errcode1).to_str().unwrap(),
+            cass_error_desc(errcode2).to_str().unwrap()
         );
     }
 }
@@ -105,8 +88,10 @@ pub(crate) unsafe fn cass_future_wait_check_and_free(fut: CassOwnedSharedPtr<Cas
         unsafe { cass_future_error_message(fut.borrow(), &mut message, &mut message_len) };
         panic!(
             "Expected CASS_OK, got an error: <{:?}>, with message: {:?}",
-            unsafe { ptr_to_cstr(cass_error_desc(errcode)) },
-            unsafe { ptr_to_cstr_n(message, message_len) },
+            unsafe { cass_error_desc(errcode).to_str() },
+            unsafe {
+                CassStrLenDelimited::from_raw(message).to_str(CassStrLen::from_raw(message_len))
+            },
         );
     }
 
@@ -129,8 +114,10 @@ pub(crate) unsafe fn cass_future_result_wait_expect_server_error_and_free(
             unsafe { cass_future_error_message(fut.borrow(), &mut message, &mut message_len) };
             panic!(
                 "Expected CASS_ERROR_SERVER_SERVER_ERROR, got a different error: <{:?}>, with message: {:?}",
-                unsafe { ptr_to_cstr(cass_error_desc(errcode)) },
-                unsafe { ptr_to_cstr_n(message, message_len) },
+                unsafe { cass_error_desc(errcode).to_str() },
+                unsafe {
+                    CassStrLenDelimited::from_raw(message).to_str(CassStrLen::from_raw(message_len))
+                },
             );
         }
     }


### PR DESCRIPTION
Fixes: #301
Based on: #448

-----

## What's done

This PR introduces FFI abstractions for C string types:
- `CassStrNulTerminated` - represents a nul-terminated C string passed by a pointer;
- `CassStrLenDelimited` - represents a string slice passed by a pointer, paired with
- `CassStrLen` - represents length of `CassStrLenDelimited`. I decided to make a newtype for this to increase type safety.

All abstractions are `repr(transparent)`, and they appear in FFI functions' signatures. They provide convenient constructors and conversion methods.

### What we gain

#### Type safety

It's now harder to misuse one of string pointer as another.

#### Borrow checks

Both `CassStrNulTerminated` and `CassStrLenDelimited` carry a lifetime, which prevents UAFs.

#### Self-documenting code

The code is much more explicit and clear in what it does with strings.

The names are a bit verbose, but this is in line with our FFI approach (see long names of `CassPtr` abstractions, such as `CassBorrowedSharedPtr`).

-----

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
