### PR TITLE
packaging: harden smoke-test cluster startup

### DIFF
--- a/packaging/smoke-test-app/Makefile
+++ b/packaging/smoke-test-app/Makefile
@@ -410,6 +410,7 @@ test-app-package: .prepare-for-test
 		"$$smoke_bin" $(SCYLLA_HOST);\
 	else\
 		dc="";\
+		compose_file="${MAKEFILE_PATH}/docker-compose.yml";\
 		if docker compose version >/dev/null 2>&1; then\
 			dc="docker compose";\
 		elif command -v docker-compose >/dev/null 2>&1; then\
@@ -420,11 +421,36 @@ test-app-package: .prepare-for-test
 		fi;\
 		cleanup() {\
 			if [ -n "$$dc" ]; then\
-				sudo $$dc -f ${MAKEFILE_PATH}/docker-compose.yml down --remove-orphans;\
+				sudo $$dc -f "$$compose_file" down --remove-orphans >/dev/null 2>&1 || true;\
 			fi;\
 		};\
+		start_cluster() {\
+			for attempt in 1 2 3; do\
+				cid="";\
+				status="";\
+				if ! sudo $$dc -f "$$compose_file" up -d; then\
+					echo "docker compose up failed on attempt $$attempt";\
+				fi;\
+				cid="$$(sudo $$dc -f "$$compose_file" ps -q scylla 2>/dev/null || true)";\
+				if [ -n "$$cid" ]; then\
+					for _ in $$(seq 1 60); do\
+						status="$$(sudo docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$$cid" 2>/dev/null || true)";\
+						if [ "$$status" = "healthy" ]; then\
+							return 0;\
+						fi;\
+						sleep 2;\
+					done;\
+				fi;\
+				echo "Cluster did not become healthy on attempt $$attempt";\
+				sudo $$dc -f "$$compose_file" ps || true;\
+				sudo $$dc -f "$$compose_file" logs --tail=200 scylla || true;\
+				cleanup;\
+				sleep 5;\
+			done;\
+			return 1;\
+		};\
 		trap cleanup EXIT;\
-		sudo $$dc -f ${MAKEFILE_PATH}/docker-compose.yml up -d --wait;\
+		start_cluster;\
 		"$$smoke_bin" $(SCYLLA_HOST);\
 	fi
 endif


### PR DESCRIPTION
## Summary
- harden the non-Windows smoke-test cluster startup path used by package tests
- retry `docker compose up`, wait for the Scylla container to become healthy, and dump compose state/logs when startup fails
- keep compose cleanup non-fatal so transient teardown errors do not hide the real startup failure

## Testing
- not run locally on macOS in this branch split; logic was originally validated on the combined branch via `make test-package-linux` and by the succeeding macOS package CI job after the hardening was introduced

## Checklist
- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- [ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
- [ ] I added appropriate `Fixes:` annotations to PR description.