### PR TITLE
Gtest IT: log also to stderr, not only to file

### DIFF
--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
   RUST_LOG: trace
   # Should include `INTEGRATION_TEST_BIN` from the `Makefile`
   # TODO: Remove `build/libscylla-cpp-driver.*` after https://github.com/scylladb/cpp-rs-driver/issues/164 is fixed.

--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_LOG: trace
   # Should include `INTEGRATION_TEST_BIN` from the `Makefile`
   # TODO: Remove `build/libscylla-cpp-driver.*` after https://github.com/scylladb/cpp-rs-driver/issues/164 is fixed.
   INTEGRATION_TEST_BIN: |

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -5,7 +5,7 @@ other information / procedures useful for maintainers. It is heavily inspired by
 
 ## Documentation
 
-TODO (no docs written yet)
+Comprehensive Sphinx-compatible documentation lives at /docs.
 Note: Due to API compatibility, cpp-driver docs apply to cpp-rs-driver in general. Though, some discrepancies should be well-documented in cpp-rs-driver (some of them are already mentioned in `cassandra.h`).
 
 ## Version bump commit

--- a/tests/src/integration/logger.cpp
+++ b/tests/src/integration/logger.cpp
@@ -32,11 +32,13 @@ using namespace test::driver;
 #ifdef _WIN32
 #define FILE_MODE 0
 #define LOCALTIME(tm, time) localtime_s(tm, time)
+#define GMTIME(tm, time) gmtime_s(tm, time)
 #include <io.h>
 #define IS_STDERR_TTY() _isatty(_fileno(stderr))
 #else
 #define FILE_MODE S_IRWXU | S_IRWXG | S_IROTH
 #define LOCALTIME(tm, time) localtime_r(time, tm)
+#define GMTIME(tm, time) gmtime_r(time, tm)
 #include <unistd.h>
 #define IS_STDERR_TTY() isatty(STDERR_FILENO)
 #endif
@@ -147,7 +149,14 @@ void Logger::log(const CassLogMessage* log, void* data) {
       default: color = "\033[31m"; break;
     }
   }
-  std::cerr << log->time_ms << " [" << color << severity << reset << "] "
+  cass_uint64_t const epoch_secs = log->time_ms / 1000;
+  unsigned short const ms = log->time_ms % 1000;
+  time_t const raw = static_cast<time_t>(epoch_secs);
+  struct tm utc;
+  GMTIME(&utc, &raw);
+  char ts[24];
+  strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", &utc);
+  std::cerr << ts << "." << std::setfill('0') << std::setw(3) << ms << "Z" << " [" << color << severity << reset << "] "
             << dim << "(" << log->file << ":" << log->line << ")" << reset
             << " " << message << std::endl;
 

--- a/tests/src/integration/logger.cpp
+++ b/tests/src/integration/logger.cpp
@@ -32,9 +32,13 @@ using namespace test::driver;
 #ifdef _WIN32
 #define FILE_MODE 0
 #define LOCALTIME(tm, time) localtime_s(tm, time)
+#include <io.h>
+#define IS_STDERR_TTY() _isatty(_fileno(stderr))
 #else
 #define FILE_MODE S_IRWXU | S_IRWXG | S_IROTH
 #define LOCALTIME(tm, time) localtime_r(time, tm)
+#include <unistd.h>
+#define IS_STDERR_TTY() isatty(STDERR_FILENO)
 #endif
 
 Logger::Logger()
@@ -128,8 +132,24 @@ void Logger::log(const CassLogMessage* log, void* data) {
                    << log->file << ":" << log->line << ") " << std::endl;
 
   // Also log to stderr so that CI output captures driver logs in real-time.
-  std::cerr << log->time_ms << " [" << severity << "] ("
-            << log->file << ":" << log->line << ") " << message << std::endl;
+  static bool use_color = IS_STDERR_TTY();
+  const char* color = "";
+  const char* reset = "";
+  const char* dim = "";
+  if (use_color) {
+    reset = "\033[0m";
+    dim = "\033[2m";
+    switch (log->severity) {
+      case CASS_LOG_TRACE: color = "\033[35m"; break;
+      case CASS_LOG_DEBUG: color = "\033[34m"; break;
+      case CASS_LOG_INFO: color = "\033[32m"; break;
+      case CASS_LOG_WARN: color = "\033[33m"; break;
+      default: color = "\033[31m"; break;
+    }
+  }
+  std::cerr << log->time_ms << " [" << color << severity << reset << "] "
+            << dim << "(" << log->file << ":" << log->line << ")" << reset
+            << " " << message << std::endl;
 
   // Determine if the log message matches any of the criteria
   for (std::vector<std::string>::const_iterator iterator = logger->search_criteria_.begin();

--- a/tests/src/integration/logger.cpp
+++ b/tests/src/integration/logger.cpp
@@ -125,7 +125,11 @@ void Logger::log(const CassLogMessage* log, void* data) {
   // Create the formatted log message and output to the file
   std::string severity = cass_log_level_string(log->severity);
   logger->output_ << date.str() << " " << time.str() << " " << severity << ": " << message << " ("
-                  << log->file << ":" << log->line << ") " << std::endl;
+                   << log->file << ":" << log->line << ") " << std::endl;
+
+  // Also log to stderr so that CI output captures driver logs in real-time.
+  std::cerr << log->time_ms << " [" << severity << "] ("
+            << log->file << ":" << log->line << ") " << message << std::endl;
 
   // Determine if the log message matches any of the criteria
   for (std::vector<std::string>::const_iterator iterator = logger->search_criteria_.begin();


### PR DESCRIPTION
## Motivation

[A recent CI run](https://github.com/scylladb/cpp-rs-driver/actions/runs/26300848077/job/77426773254?pr=456) experienced a panic inside the Rust Driver. I couldn't debug it, because no logs were printed.

## What's done

### C++ Gtest Logger output

#### Destination

Before, the logs were only output to a file. Now, they are additionally printed to stderr.

#### Format

1. Timestamp display was improved, made in line with Rust tracing subscriber's one.
2. Log level is now coloured (IFF stderr points to a terminal). It uses the same palette as, again, Rust tracing subscriber.

### CI

1. `RUST_LOG=trace` is now passed, so the logs are visible in the CI run console.
2. `RUST_BACKTRACE=full` is now passed, which will aid in debugging. 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
