### PR TITLE
packaging: fix macOS smoke-test Scylla address

### DIFF
--- a/packaging/smoke-test-app/docker-compose.yml
+++ b/packaging/smoke-test-app/docker-compose.yml
@@ -11,11 +11,13 @@ services:
     image: scylladb/scylla
     ports:
       - "127.0.0.1:9042:9042"
+      - "127.0.0.1:19042:19042"
     networks:
       public:
         ipv4_address: 172.44.0.2
     command: |
       --rpc-address 172.44.0.2
+      --broadcast-rpc-address 127.0.0.1
       --listen-address 172.44.0.2
       --skip-wait-for-gossip-to-settle 0
       --ring-delay-ms 0


### PR DESCRIPTION
## Summary

- publish Scylla shard-aware CQL port 19042 in the packaging smoke-test compose file
- set `--broadcast-rpc-address 127.0.0.1` so the host-side smoke app uses a host-reachable address on macOS Docker/Colima

## Reason

The macOS package job runs the smoke app on the host while Scylla runs inside a Docker/Colima VM. With the Rust driver bump, the driver can use the RPC address advertised by Scylla metadata; without a host-reachable broadcast RPC address, that can become the compose bridge IP `172.44.0.2`, which is not routable from the macOS host. Publishing `19042` also lets shard-aware connections reach the single-node test instance.

## Testing

- `docker compose -f packaging/smoke-test-app/docker-compose.yml config`

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have implemented Rust unit tests for the features/changes introduced.
- [ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
- [ ] I added appropriate `Fixes:` annotations to PR description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing infrastructure configuration to improve service communication settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scylladb/cpp-rs-driver/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->