### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ The driver inherits almost all the features of C/C++ and Rust drivers, such as:
  * Retry policies
  * SSL
  * Authentication
- * [Tuples](https://cpp-rs-driver.docs.scylladb.com/stable/topics/basics/data-types/tuples/) and [UDTs](http://https://cpp-rs-driver.docs.scylladb.com/stable/topics/basics/data-types/user-defined-types/)
- * [Nested collections](https://cpp-rs-driver.docs.scylladb.com/stable/topics/basics/binding-parameters/#nested-collections)
- * [Data types](https://cpp-rs-driver.docs.scylladb.com/stable/topics/basics/data-types/)
+ * [Tuples](https://cpp-rs-driver.docs.scylladb.com/stable/topics/using/data-types/tuples/) and [UDTs](https://cpp-rs-driver.docs.scylladb.com/stable/topics/using/data-types/user-defined-types/)
+ * [Nested collections](https://cpp-rs-driver.docs.scylladb.com/stable/topics/using/binding-parameters/#nested-collections)
+ * [Data types](https://cpp-rs-driver.docs.scylladb.com/stable/topics/using/data-types/)
  * Schema metadata (keyspace metadata, materialized views, etc.)
 
 # Limitations

--- a/docs/source/topics/architecture-overview.md
+++ b/docs/source/topics/architecture-overview.md
@@ -63,7 +63,7 @@ without incurring extra allocations.
 
 **NOTE:** Advancing an iterator invalidates the value it previously returned.
 
-[`cass_int32_t`]: https://cpp-rs-driver.docs.scylladb.com/stable/api/cassandra.h#cass-int32-t
+[`cass_int32_t`]: https://cpp-rs-driver.docs.scylladb.com/stable/api/group.BasicTypes.html#_CPPv412cass_int32_t
 [`cass_cluster_set_num_threads_io()`]: https://cpp-rs-driver.docs.scylladb.com/stable/api/struct.CassCluster#function-cass_cluster_set_num_threads_io
 [`CassCluster`]: https://cpp-rs-driver.docs.scylladb.com/stable/api/struct.CassCluster
 [`CassFuture`]: https://cpp-rs-driver.docs.scylladb.com/stable/api/struct.CassFuture

--- a/docs/source/topics/configuration/performance-tips.md
+++ b/docs/source/topics/configuration/performance-tips.md
@@ -39,7 +39,7 @@ to wait for one or more nodes to respond back to the coordinator node before a
 request can complete. In multi-datacenter configurations, consistency levels such as
 `EACH_QUORUM` can cause a request to wait for replication across a slower cross
 datacenter network link.  More information about setting the consistency level
-can be found [here](https://cpp-rs-driver.docs.scylladb.com/stable/topics/basics/consistency/).
+can be found [here](https://cpp-rs-driver.docs.scylladb.com/stable/topics/using/consistency/).
 
 ## Driver Tuning
 
@@ -87,6 +87,6 @@ recommended that your application decrease this value if computationally
 expensive or long-running future callbacks are used (via
 `cass_future_set_callback()`), otherwise this can be left unchanged.
 
-[token-aware]: https://cpp-rs-driver.docs.scylladb.com/stable/topics/configuration/load-balancing#latency-aware-routing
-[latency-aware]: https://cpp-rs-driver.docs.scylladb.com/stable/topics/configuration/load-balancing#token-aware-routing
-[paging]: https://cpp-rs-driver.docs.scylladb.com/stable/topics/basics/handling-results#paging
+[token-aware]: https://cpp-rs-driver.docs.scylladb.com/stable/topics/configuration/load-balancing#token-aware-routing
+[latency-aware]: https://cpp-rs-driver.docs.scylladb.com/stable/topics/configuration/load-balancing#latency-aware-routing
+[paging]: https://cpp-rs-driver.docs.scylladb.com/stable/topics/using/handling-results#paging

--- a/docs/source/topics/getting-started.md
+++ b/docs/source/topics/getting-started.md
@@ -216,9 +216,8 @@ void handle_query_result(CassFuture* future) {
 [cpp-rs-driver-releases]: https://github.com/scylladb/cpp-rs-driver/releases
 
 [built from source]: https://cpp-rs-driver.docs.scylladb.com/stable/topics/building/
-[prepared statements]: https://cpp-rs-driver.docs.scylladb.com/stable/topics/basics/prepared-statements/
+[prepared statements]: https://cpp-rs-driver.docs.scylladb.com/stable/topics/using/prepared-statements/
 
-[`cass_int32_t`]: https://cpp-rs-driver.docs.scylladb.com/stable/api/cassandra.h#cass-int32-t
 [`cass_result_first_row()`]: https://cpp-rs-driver.docs.scylladb.com/stable/api/struct.CassResult#cass-result-first-row
 [`CassCluster`]: https://cpp-rs-driver.docs.scylladb.com/stable/api/struct.CassCluster
 [`CassSession`]: https://cpp-rs-driver.docs.scylladb.com/stable/api/struct.CassSession


### PR DESCRIPTION
They were broken because of the restructuring of the documentation.