### PR TITLE
future: Fix double callback execution

### DIFF
--- a/scylla-rust-wrapper/src/future.rs
+++ b/scylla-rust-wrapper/src/future.rs
@@ -424,7 +424,7 @@ impl ResolvableFuture {
         // Check if the callback is already set (in such case we must error out).
         // If it is not set, we store the callback in the state, so that no different
         // callback can be set.
-        {
+        let should_invoke_callback = {
             let mut lock = self.state.lock().unwrap();
             if lock.callback.is_some() {
                 // Another callback has been already set
@@ -434,9 +434,11 @@ impl ResolvableFuture {
             // Store the callback, so that no other callback can be set from now on.
             // Rationale: only one callback can be set for the whole lifetime of a future.
             lock.callback = Some(bound_cb);
-        }
 
-        if self.result.get().is_some() {
+            self.result.get().is_some()
+        };
+
+        if should_invoke_callback {
             // The value is already available, we need to call the callback ourselves
             bound_cb.invoke(self_ptr);
             return CassError::CASS_OK;


### PR DESCRIPTION
`ResolvableFuture::set_callback` first set a callback under lock, released the lock, and then checked if result is set. If it is, then it invoked the callback.
The other path for callback calling is in future execution: when setting the result (under lock) new_from_future also reads a callback. If it exsits, then it is called.
the following race is possible:
- `set_callback` sets callback, releases lock
- `new_from_future` produces result, sees the callback, calls it
- `set_callback` checks for the result, sees it exists, calls the callback.

This results in double callback execution, potentially causing UB and other issues.
This commit fixes that: in `set_callback`, while still under lock, we check if callback should be called. Then outside of lock we call it if needed. It is important to call the callback outside the lock, to avoid various deadlocks.

Fixes: https://scylladb.atlassian.net/browse/CUSTOMER-409

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have implemented Rust unit tests for the features/changes introduced.~~ - no clue how to test that
- [ ] ~~I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
