### PR TITLE
Revert "gtest IT: print logs to stderr unconditionally"

### DIFF
--- a/tests/src/integration/logger.cpp
+++ b/tests/src/integration/logger.cpp
@@ -32,15 +32,9 @@ using namespace test::driver;
 #ifdef _WIN32
 #define FILE_MODE 0
 #define LOCALTIME(tm, time) localtime_s(tm, time)
-#define GMTIME(tm, time) gmtime_s(tm, time)
-#include <io.h>
-#define IS_STDERR_TTY() _isatty(_fileno(stderr))
 #else
 #define FILE_MODE S_IRWXU | S_IRWXG | S_IROTH
 #define LOCALTIME(tm, time) localtime_r(time, tm)
-#define GMTIME(tm, time) gmtime_r(time, tm)
-#include <unistd.h>
-#define IS_STDERR_TTY() isatty(STDERR_FILENO)
 #endif
 
 Logger::Logger()
@@ -131,34 +125,7 @@ void Logger::log(const CassLogMessage* log, void* data) {
   // Create the formatted log message and output to the file
   std::string severity = cass_log_level_string(log->severity);
   logger->output_ << date.str() << " " << time.str() << " " << severity << ": " << message << " ("
-                   << log->file << ":" << log->line << ") " << std::endl;
-
-  // Also log to stderr so that CI output captures driver logs in real-time.
-  static bool use_color = IS_STDERR_TTY();
-  const char* color = "";
-  const char* reset = "";
-  const char* dim = "";
-  if (use_color) {
-    reset = "\033[0m";
-    dim = "\033[2m";
-    switch (log->severity) {
-      case CASS_LOG_TRACE: color = "\033[35m"; break;
-      case CASS_LOG_DEBUG: color = "\033[34m"; break;
-      case CASS_LOG_INFO: color = "\033[32m"; break;
-      case CASS_LOG_WARN: color = "\033[33m"; break;
-      default: color = "\033[31m"; break;
-    }
-  }
-  cass_uint64_t const epoch_secs = log->time_ms / 1000;
-  unsigned short const ms = log->time_ms % 1000;
-  time_t const raw = static_cast<time_t>(epoch_secs);
-  struct tm utc;
-  GMTIME(&utc, &raw);
-  char ts[24];
-  strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", &utc);
-  std::cerr << ts << "." << std::setfill('0') << std::setw(3) << ms << "Z" << " [" << color << severity << reset << "] "
-            << dim << "(" << log->file << ":" << log->line << ")" << reset
-            << " " << message << std::endl;
+                  << log->file << ":" << log->line << ") " << std::endl;
 
   // Determine if the log message matches any of the criteria
   for (std::vector<std::string>::const_iterator iterator = logger->search_criteria_.begin();


### PR DESCRIPTION
This reverts commits that introduced unconditional logging to stderr in gtest integration tests:
- 6b9b54542e779eaddf7253b373537c16aa2bc890,
- 2db8a26b20ad3b257a90eba6a7e296dd93903bf8,
- 7ffd09318df45f509fed30747c4146ee0656f93e.

Rationale:
CI got unstable because two tests that issue many requests (~4000) now timeout every time, because stderr logging (unbuffered!) of each request is too slow.
I'm unable to think of a better way to capture logs in CI, so I'm reverting the change for now and will hopefully look into a more robust solution later.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
