### PR TITLE
Ensure openssl 3.0 compatibility of released packages

### DIFF
--- a/.github/workflows/build-cpack-packages.yml
+++ b/.github/workflows/build-cpack-packages.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Build and test DEB packages
         run: make test-package-deb
 
+      - name: Verify static driver links against OpenSSL 3.0 (issue #455)
+        run: make verify-openssl-3.0-compat
+
       - name: Collect artifacts
         if: inputs.save-artifacts
         run: make collect-package-artifacts

--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -47,6 +47,9 @@ jobs:
         id: build-integration-test-bin
         run: make build-integration-test-bin
 
+      - name: Verify static driver links against OpenSSL 3.0 (issue #455)
+        run: make verify-openssl-3.0-compat
+
       - name: Save integration test binary
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: save-integration-test-bin

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ endif
 FULL_RUSTFLAGS := --cfg scylla_unstable --cfg cpp_integration_testing
 
 CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-BUILD_DIR := "${CURRENT_DIR}build"
+BUILD_DIR := $(CURRENT_DIR)build
 INTEGRATION_TEST_BIN := ${BUILD_DIR}/cassandra-integration-tests
 CMAKE_FLAGS ?=
 CMAKE_BUILD_TYPE ?= Release

--- a/Makefile
+++ b/Makefile
@@ -560,7 +560,7 @@ test-package-rpm: build-package
 		fedora:latest \
 		bash -c ' \
 			set -euo pipefail; \
-			dnf -y install make cmake gcc-c++ findutils rpm-build createrepo_c; \
+			dnf -y install make cmake gcc-c++ findutils rpm-build zlib-devel createrepo_c; \
 			$(MAKE) -C $(SMOKE_TEST_DIR) verify-driver-dev-rpm; \
 			$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-dev-rpm || true; \
 			$(MAKE) -C $(SMOKE_TEST_DIR) remove-driver-rpm || true; \

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,49 @@ build-integration-test-bin-if-missing:
 	@cd "${BUILD_DIR}"
 	cmake -DCASS_BUILD_INTEGRATION_TESTS=ON -DCMAKE_BUILD_TYPE=Release .. && (make -j 4 || make)
 
+# =============================================================================
+# OpenSSL 3.0 Compatibility Verification
+# =============================================================================
+# Regression test for issue #455: ensures the static driver archive can link
+# against OpenSSL 3.0 (our minimum supported version). Rather than rebuilding
+# from source, this target uses the artifact already produced by the default
+# build (which enables both shared and static). If the archive references
+# symbols only available in OpenSSL >3.0 (e.g. due to build environment
+# contamination), the link fails.
+#
+# This target is Linux/amd64-only (matches our release artifact platform).
+# =============================================================================
+
+OPENSSL_3_0_COMPAT_SYSROOT := /tmp/openssl-3.0-compat-sysroot
+OPENSSL_3_0_LIBSSL_DEV_URL := https://launchpad.net/ubuntu/+archive/primary/+files/libssl-dev_3.0.2-0ubuntu1_amd64.deb
+OPENSSL_3_0_LIBSSL_DEV_SHA256 := f3671a9f01aa92928db200b3d28f1acb782366882fe318a940649bd02363ceb6
+OPENSSL_3_0_LIBSSL_DEV_PATH := /tmp/libssl-dev_3.0.2.deb
+
+verify-openssl-3.0-compat:
+	@echo "=== Verifying static driver links against OpenSSL 3.0 (issue #455) ==="
+	rm -rf "$(OPENSSL_3_0_COMPAT_SYSROOT)"
+	DESTDIR="$(OPENSSL_3_0_COMPAT_SYSROOT)" cmake --install "$(BUILD_DIR)"
+	curl -fL -o "$(OPENSSL_3_0_LIBSSL_DEV_PATH)" "$(OPENSSL_3_0_LIBSSL_DEV_URL)"
+	echo "$(OPENSSL_3_0_LIBSSL_DEV_SHA256)  $(OPENSSL_3_0_LIBSSL_DEV_PATH)" | sha256sum --check
+	dpkg-deb -x "$(OPENSSL_3_0_LIBSSL_DEV_PATH)" "$(OPENSSL_3_0_COMPAT_SYSROOT)"
+	rm -f "$(OPENSSL_3_0_COMPAT_SYSROOT)/usr/lib/x86_64-linux-gnu/libssl.so"
+	rm -f "$(OPENSSL_3_0_COMPAT_SYSROOT)/usr/lib/x86_64-linux-gnu/libcrypto.so"
+	PKG_CONFIG_SYSROOT_DIR="$(OPENSSL_3_0_COMPAT_SYSROOT)" \
+	PKG_CONFIG_PATH="$(OPENSSL_3_0_COMPAT_SYSROOT)/usr/local/lib/x86_64-linux-gnu/pkgconfig:$(OPENSSL_3_0_COMPAT_SYSROOT)/usr/lib/x86_64-linux-gnu/pkgconfig" \
+	pkg-config --libs --static scylladb_static
+	cc \
+		$$(PKG_CONFIG_SYSROOT_DIR="$(OPENSSL_3_0_COMPAT_SYSROOT)" \
+		   PKG_CONFIG_PATH="$(OPENSSL_3_0_COMPAT_SYSROOT)/usr/local/lib/x86_64-linux-gnu/pkgconfig:$(OPENSSL_3_0_COMPAT_SYSROOT)/usr/lib/x86_64-linux-gnu/pkgconfig" \
+		   pkg-config --cflags scylladb_static) \
+		examples/ssl/ssl.c \
+		$$(PKG_CONFIG_SYSROOT_DIR="$(OPENSSL_3_0_COMPAT_SYSROOT)" \
+		   PKG_CONFIG_PATH="$(OPENSSL_3_0_COMPAT_SYSROOT)/usr/local/lib/x86_64-linux-gnu/pkgconfig:$(OPENSSL_3_0_COMPAT_SYSROOT)/usr/lib/x86_64-linux-gnu/pkgconfig" \
+		   pkg-config --libs --static scylladb_static) \
+		-o /tmp/openssl-3.0-compat-link-test
+	@echo "=== OpenSSL 3.0 compatibility verified ==="
+	rm -rf "$(OPENSSL_3_0_COMPAT_SYSROOT)" \
+		"$(OPENSSL_3_0_LIBSSL_DEV_PATH)" /tmp/openssl-3.0-compat-link-test
+
 build-examples:
 	@echo "Building examples to ${EXAMPLES_DIR}"
 	@mkdir "${BUILD_DIR}" >/dev/null 2>&1 || true

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ BUILD_DIR := $(CURRENT_DIR)build
 INTEGRATION_TEST_BIN := ${BUILD_DIR}/cassandra-integration-tests
 CMAKE_FLAGS ?=
 CMAKE_BUILD_TYPE ?= Release
+OPENSSL_WIN_VERSION ?= 1.1.1u
 
 ifeq ($(OS_TYPE),macos)
   CMAKE_INSTALL_PREFIX ?= /usr/local
@@ -345,7 +346,7 @@ endif
 
 .package-configure: .package-build-prepare
 ifeq ($(OS_TYPE),windows)
-	cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DOPENSSL_VERSION=1.1.1u $(CMAKE_FLAGS)
+	cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DOPENSSL_VERSION=$(OPENSSL_WIN_VERSION) $(CMAKE_FLAGS)
 else
 	cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX) $(CMAKE_FLAGS)
 endif

--- a/ci/generate-build-info.sh
+++ b/ci/generate-build-info.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Generate BUILD_INFO metadata file capturing the build environment.
+# Usage: ci/generate-build-info.sh <output-path>
+#
+# The script degrades gracefully: fields that cannot be determined are
+# printed as "unknown". If bash is not available, CMake will skip this
+# step without failing the build (see CMakeLists.txt).
+
+set -euo pipefail
+
+OUTPUT="${1:?Usage: $0 <output-path>}"
+BUILD_DIR="$(cd "$(dirname "$OUTPUT")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- Helpers ---
+
+cmake_cache_get() {
+    local key="$1"
+    local cache="$BUILD_DIR/CMakeCache.txt"
+    if [ -f "$cache" ]; then
+        grep "^${key}:" "$cache" 2>/dev/null | cut -d= -f2- || echo "unknown"
+    else
+        echo "unknown"
+    fi
+}
+
+# --- Driver version ---
+
+VERSION=$(cd "$SOURCE_DIR" && git describe --tags --always 2>/dev/null || echo "unknown")
+
+# --- Platform ---
+
+ARCH=$(uname -m 2>/dev/null || echo "unknown")
+KERNEL=$(uname -r 2>/dev/null || echo "unknown")
+
+case "${OSTYPE:-}" in
+    linux-gnu*|linux*)
+        if [ -f /etc/os-release ]; then
+            OS=$(. /etc/os-release && echo "${PRETTY_NAME:-unknown}")
+        else
+            OS="Linux (unknown distro)"
+        fi
+        GLIBC=$(ldd --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+$' || echo "unknown")
+        ;;
+    darwin*)
+        OS="macOS $(sw_vers -productVersion 2>/dev/null || echo unknown)"
+        GLIBC="N/A"
+        ;;
+    msys*|cygwin*|mingw*)
+        OS="Windows"
+        GLIBC="N/A"
+        ;;
+    *)
+        OS="unknown (${OSTYPE:-not set})"
+        GLIBC="unknown"
+        ;;
+esac
+
+# --- Toolchain ---
+
+RUST_VERSION=$(rustc --version 2>/dev/null || echo "unknown")
+CARGO_VERSION=$(cargo --version 2>/dev/null || echo "unknown")
+CMAKE_VERSION_STR=$(cmake --version 2>/dev/null | head -1 || echo "unknown")
+CC_VERSION=$(${CC:-cc} --version 2>/dev/null | head -1 || echo "unknown")
+
+# --- OpenSSL (from openssl-sys build script output) ---
+
+OPENSSL_SYS_OUTPUT=""
+# The output file is at target/<profile>/build/openssl-sys-<hash>/output
+# Search within the cargo target directory used by this build.
+CARGO_TARGET_DIR=$(cmake_cache_get "CARGO_TARGET_DIR")
+if [ "$CARGO_TARGET_DIR" = "unknown" ] || [ ! -d "$CARGO_TARGET_DIR" ]; then
+    # Fallback: search in the standard location
+    CARGO_TARGET_DIR="$SOURCE_DIR/scylla-rust-wrapper/target"
+fi
+if [ -d "$CARGO_TARGET_DIR" ]; then
+    OPENSSL_SYS_OUTPUT=$(find "$CARGO_TARGET_DIR" -path "*/openssl-sys-*/output" -type f 2>/dev/null | head -1)
+fi
+
+if [ -n "$OPENSSL_SYS_OUTPUT" ] && [ -f "$OPENSSL_SYS_OUTPUT" ]; then
+    OPENSSL_VERSION_HEX=$(grep "^cargo:version_number=" "$OPENSSL_SYS_OUTPUT" | cut -d= -f2 || echo "")
+    OPENSSL_INCLUDE=$(grep "^cargo:include=" "$OPENSSL_SYS_OUTPUT" | cut -d= -f2 || echo "unknown")
+    OSSLCONF_FLAGS=$(grep "^cargo:rustc-cfg=osslconf=" "$OPENSSL_SYS_OUTPUT" | sed 's/cargo:rustc-cfg=osslconf="\(.*\)"/\1/' | paste -sd ' ' || echo "none")
+
+    # Quoting from openssl docs:
+    # > A build script can be used to detect the OpenSSL or LibreSSL version at compile time if needed. The `openssl-sys`
+    # > crate propagates the version via the `DEP_OPENSSL_VERSION_NUMBER` and `DEP_OPENSSL_LIBRESSL_VERSION_NUMBER`
+    # > environment variables to build scripts. The version format is a hex-encoding of the OpenSSL release version:
+    # > `0xMNNFFPPS`. For example, version 1.0.2g’s encoding is `0x1_00_02_07_0`.
+    #
+    # However, OpenSSL 3.x changed the displaying, while encoding is still the same.
+    # - In version 1.2.3.c, 3 was Fix and c was Patch.
+    # - In version 3.2.1, 3 is Patch and Fix is not present (0).
+    # We're only interested in OpenSSL 3+, so we can assume the version is in the Major.Minor.Patch format.
+    if [ -n "$OPENSSL_VERSION_HEX" ]; then
+        dec=$((16#$OPENSSL_VERSION_HEX))
+        major=$(( (dec >> 28) & 0xF ))
+        minor=$(( (dec >> 20) & 0xFF ))
+        patch=$(( (dec >> 4) & 0xFF ))
+        OPENSSL_VERSION="${major}.${minor}.${patch}"
+    else
+        OPENSSL_VERSION="unknown"
+    fi
+else
+    OPENSSL_VERSION=$(pkg-config --modversion openssl 2>/dev/null || echo "unknown")
+    OPENSSL_INCLUDE=$(pkg-config --variable=includedir openssl 2>/dev/null || echo "unknown")
+    OSSLCONF_FLAGS="unknown (openssl-sys build output not found)"
+fi
+
+# --- Build configuration (from Cargo.toml) ---
+
+CARGO_TOML="$SOURCE_DIR/scylla-rust-wrapper/Cargo.toml"
+if [ -f "$CARGO_TOML" ]; then
+    LTO=$(grep "^lto" "$CARGO_TOML" | head -1 | sed 's/.*=[ ]*//' | tr -d '"' || echo "unknown")
+    PANIC=$(grep "^panic" "$CARGO_TOML" | head -1 | sed 's/.*=[ ]*//' | tr -d '"' || echo "unknown")
+else
+    LTO="unknown"
+    PANIC="unknown"
+fi
+
+# --- CMake options ---
+
+CMAKE_BUILD_TYPE=$(cmake_cache_get "CMAKE_BUILD_TYPE")
+CMAKE_INSTALL_PREFIX=$(cmake_cache_get "CMAKE_INSTALL_PREFIX")
+CASS_BUILD_SHARED=$(cmake_cache_get "CASS_BUILD_SHARED")
+CASS_BUILD_STATIC=$(cmake_cache_get "CASS_BUILD_STATIC")
+
+# --- Write output ---
+
+cat > "$OUTPUT" <<EOF
+Build Information for scylla-cpp-driver $VERSION
+
+Platform
+--------
+OS:             $OS
+Architecture:   $ARCH
+Kernel:         $KERNEL
+glibc:          $GLIBC
+
+Toolchain
+---------
+Rust:           $RUST_VERSION
+Cargo:          $CARGO_VERSION
+CMake:          $CMAKE_VERSION_STR
+CC:             $CC_VERSION
+
+OpenSSL (detected by openssl-sys at build time)
+------------------------------------------------
+Version:        $OPENSSL_VERSION
+Include path:   $OPENSSL_INCLUDE
+Disabled (osslconf): ${OSSLCONF_FLAGS:-none}
+
+Build Configuration
+-------------------
+CMAKE_BUILD_TYPE:       $CMAKE_BUILD_TYPE
+CMAKE_INSTALL_PREFIX:   $CMAKE_INSTALL_PREFIX
+CASS_BUILD_SHARED:      $CASS_BUILD_SHARED
+CASS_BUILD_STATIC:      $CASS_BUILD_STATIC
+LTO:                    $LTO
+Panic strategy:         $PANIC
+
+Static Library Compatibility Notes
+----------------------------------
+The static archive (libscylladb_static.a) requires consumers to
+provide OpenSSL >= 3.0 at link time. The minimum OpenSSL version
+is determined by the build-time detection performed by the
+openssl-sys crate.
+
+Consumers linking on systems with a different OpenSSL configuration
+(e.g. different osslconf flags) may encounter undefined symbol errors
+for conditionally-compiled functions.
+EOF
+
+echo "Generated: $OUTPUT"

--- a/scylla-rust-wrapper/CMakeLists.txt
+++ b/scylla-rust-wrapper/CMakeLists.txt
@@ -301,6 +301,13 @@ if(CASS_INSTALL_HEADER)
     COMPONENT ${SCYLLA_DRIVER_DEV_COMPONENT_NAME})
 endif()
 
+# Build metadata goes to dev package
+if(TARGET build_info)
+  install(FILES ${CMAKE_BINARY_DIR}/BUILD_INFO
+    DESTINATION share/doc/scylla-cpp-driver
+    COMPONENT ${SCYLLA_DRIVER_DEV_COMPONENT_NAME})
+endif()
+
 # Install the dynamic/shared library
 if(CASS_BUILD_SHARED)
   # Versioned shared library goes to runtime package

--- a/scylla-rust-wrapper/CMakeLists.txt
+++ b/scylla-rust-wrapper/CMakeLists.txt
@@ -31,6 +31,7 @@ if(CASS_BUILD_INTEGRATION_TESTS OR CASS_BUILD_EXAMPLES)
   set(CMAKE_Rust_FLAGS "${CMAKE_Rust_FLAGS} --cfg cpp_integration_testing")
 endif()
 
+# Shared library names and linker flags differ across platforms, so set them up here.
 if(APPLE)
   set(INSTALL_NAME_SHARED "libscylladb.${PROJECT_VERSION_STRING}.dylib")
   set(INSTALL_NAME_SHARED_SYMLINK_VERSION "libscylladb.${PROJECT_VERSION_MAJOR}.dylib")
@@ -44,7 +45,7 @@ elseif(WIN32)
   set(CMAKE_Rust_FLAGS_SONAME "")
   set(CASSANDRA_COMPAT_SHARED_SYMLINK "cassandra.dll")
   set(CASSANDRA_COMPAT_STATIC_SYMLINK "cassandra_static.lib")
-else()
+else() # Assume Unix-like (e.g. Linux).
   set(INSTALL_NAME_SHARED "libscylladb.so.${PROJECT_VERSION_STRING}")
   set(INSTALL_NAME_SHARED_SYMLINK_VERSION "libscylladb.so.${PROJECT_VERSION_MAJOR}")
   set(INSTALL_NAME_SHARED_SYMLINK_NO_VERSION "libscylladb.so")
@@ -52,16 +53,21 @@ else()
   set(CASSANDRA_COMPAT_SHARED_SYMLINK "libcassandra.so")
   set(CASSANDRA_COMPAT_STATIC_SYMLINK "libcassandra_static.a")
 endif()
+
+# Static library names are more consistent across platforms, but still differ on Windows.
 if(WIN32)
   set(INSTALL_NAME_STATIC "scylladb_static.lib")
 else()
   set(INSTALL_NAME_STATIC "libscylladb_static.a")
 endif()
+
+# Make rustc pass the SONAME flag to the linker when building the shared library.
 if(DEFINED CMAKE_Rust_FLAGS)
   set(CMAKE_Rust_FLAGS "${CMAKE_Rust_FLAGS} ${CMAKE_Rust_FLAGS_SONAME}")
 else()
   set(CMAKE_Rust_FLAGS "${CMAKE_Rust_FLAGS_SONAME}")
 endif()
+
 if(CASS_BUILD_SHARED)
   cargo_build(NAME scylladb CRATE_TYPE cdylib)
   create_copy($<TARGET_FILE:scylladb_cdylib> ${INSTALL_NAME_SHARED})
@@ -83,6 +89,7 @@ if(CASS_BUILD_SHARED)
     endif()
   endif()
 endif()
+
 if(CASS_BUILD_STATIC)
   cargo_build(NAME scylladb CRATE_TYPE staticlib)
   create_copy($<TARGET_FILE:scylladb_staticlib> ${INSTALL_NAME_STATIC})

--- a/scylla-rust-wrapper/CMakeLists.txt
+++ b/scylla-rust-wrapper/CMakeLists.txt
@@ -128,46 +128,92 @@ if(CASS_BUILD_STATIC)
   # The word "INTERFACE" in CMake doesn't mean "public API" in the C++ sense — it means "propagated to consumers."
   # For an IMPORTED static library, ALL transitive dependencies are necessarily interface dependencies because
   # the static archive is opaque to CMake (it can't see inside it to know what symbols are needed).
+  #
+  # ## Comparison with `Libs.private` in pkg-config
+  #
+  # This is the CMake equivalent of `Libs.private` in the `.pc` file — both say
+  # "consumers need these additional libraries when linking statically."
+  # The naming is confusing but semantically correct:
+  # - pkg-config: `Libs.private` = "needed by consumers for static linking"
+  # - CMake: `INTERFACE_LINK_LIBRARIES` on IMPORTED STATIC = "needed by consumers"
   set(_STATIC_INTERFACE_LIBS "")
+
+  # These variables are used to generate the static library pkg-config file,
+  # and are separate from _STATIC_INTERFACE_LIBS because pkg-config requires
+  # a different format (e.g. "-lssl -lcrypto" instead of a list of library paths).
+  set(scylladb_static_requires_private "")
+  set(scylladb_static_libs_private "")
 
   if(CASS_USE_OPENSSL AND OPENSSL_LIBRARIES)
     list(APPEND _STATIC_INTERFACE_LIBS ${OPENSSL_LIBRARIES})
+    list(APPEND scylladb_static_requires_private openssl)
   endif()
 
   if(WIN32)
     # Windows system libraries required by Rust runtime and its dependencies
     list(APPEND _STATIC_INTERFACE_LIBS ws2_32 bcrypt ntdll userenv crypt32 secur32 ncrypt)
+    list(APPEND scylladb_static_libs_private
+      "-lws2_32" "-lbcrypt" "-lntdll" "-luserenv" "-lcrypt32" "-lsecur32" "-lncrypt")
   elseif(APPLE)
     list(APPEND _STATIC_INTERFACE_LIBS ${CMAKE_DL_LIBS} m)
+    if(CMAKE_DL_LIBS)
+      list(APPEND scylladb_static_libs_private "-l${CMAKE_DL_LIBS}")
+    endif()
+    list(APPEND scylladb_static_libs_private "-lm")
     find_package(Threads)
     if(Threads_FOUND)
       list(APPEND _STATIC_INTERFACE_LIBS Threads::Threads)
+      if(CMAKE_THREAD_LIBS_INIT)
+        list(APPEND scylladb_static_libs_private "${CMAKE_THREAD_LIBS_INIT}")
+      endif()
     endif()
     # CoreFoundation is needed by the iana-time-zone crate on macOS
     find_library(COREFOUNDATION_LIBRARY CoreFoundation)
     if(COREFOUNDATION_LIBRARY)
       list(APPEND _STATIC_INTERFACE_LIBS ${COREFOUNDATION_LIBRARY})
+      list(APPEND scylladb_static_libs_private "-framework CoreFoundation")
     endif()
     # SystemConfiguration and Security may also be needed on macOS
     find_library(SYSTEMCONFIGURATION_LIBRARY SystemConfiguration)
     if(SYSTEMCONFIGURATION_LIBRARY)
       list(APPEND _STATIC_INTERFACE_LIBS ${SYSTEMCONFIGURATION_LIBRARY})
+      list(APPEND scylladb_static_libs_private "-framework SystemConfiguration")
     endif()
     find_library(SECURITY_LIBRARY Security)
     if(SECURITY_LIBRARY)
       list(APPEND _STATIC_INTERFACE_LIBS ${SECURITY_LIBRARY})
+      list(APPEND scylladb_static_libs_private "-framework Security")
     endif()
   else() # non-Windows and non-Apple - assume Unix-like, such as Linux
     list(APPEND _STATIC_INTERFACE_LIBS ${CMAKE_DL_LIBS} m)
+    if(CMAKE_DL_LIBS)
+      list(APPEND scylladb_static_libs_private "-l${CMAKE_DL_LIBS}")
+    endif()
+    list(APPEND scylladb_static_libs_private "-lm")
     find_package(Threads)
     if(Threads_FOUND)
       list(APPEND _STATIC_INTERFACE_LIBS Threads::Threads)
+      if(CMAKE_THREAD_LIBS_INIT)
+        list(APPEND scylladb_static_libs_private "${CMAKE_THREAD_LIBS_INIT}")
+      endif()
     endif()
   endif()
 
   if(_STATIC_INTERFACE_LIBS)
     set_target_properties(scylladb_static PROPERTIES
       INTERFACE_LINK_LIBRARIES "${_STATIC_INTERFACE_LIBS}")
+  endif()
+
+  if(scylladb_static_requires_private)
+    list(REMOVE_DUPLICATES scylladb_static_requires_private)
+    string(JOIN " " scylladb_static_requires_private
+      ${scylladb_static_requires_private})
+  endif()
+
+  if(scylladb_static_libs_private)
+    list(REMOVE_DUPLICATES scylladb_static_libs_private)
+    string(JOIN " " scylladb_static_libs_private
+      ${scylladb_static_libs_private})
   endif()
 endif()
 

--- a/scylla-rust-wrapper/CMakeLists.txt
+++ b/scylla-rust-wrapper/CMakeLists.txt
@@ -218,6 +218,30 @@ if(CASS_BUILD_STATIC)
 endif()
 
 #-------------------------------------
+# Build metadata
+#-------------------------------------
+
+# Generate BUILD_INFO capturing the build environment. The script is
+# bash-specific; if bash is unavailable the target is skipped silently.
+find_program(BASH_EXECUTABLE bash)
+if(BASH_EXECUTABLE)
+  add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/BUILD_INFO
+    COMMAND ${BASH_EXECUTABLE} ${CASS_ROOT_DIR}/ci/generate-build-info.sh
+            ${CMAKE_BINARY_DIR}/BUILD_INFO
+    WORKING_DIRECTORY ${CASS_ROOT_DIR}
+    COMMENT "Generating BUILD_INFO"
+    VERBATIM
+  )
+  add_custom_target(build_info ALL DEPENDS ${CMAKE_BINARY_DIR}/BUILD_INFO)
+  if(TARGET scylladb_staticlib_target)
+    add_dependencies(build_info scylladb_staticlib_target)
+  elseif(TARGET scylladb_cdylib_target)
+    add_dependencies(build_info scylladb_cdylib_target)
+  endif()
+endif()
+
+#-------------------------------------
 # Installation
 #-------------------------------------
 

--- a/scylla-rust-wrapper/CMakeLists.txt
+++ b/scylla-rust-wrapper/CMakeLists.txt
@@ -99,6 +99,76 @@ if(CASS_BUILD_STATIC)
   if(CASS_INSTALL_CASSANDRA_COMPAT AND NOT WIN32)
     create_symlink(${INSTALL_NAME_STATIC} ${CASSANDRA_COMPAT_STATIC_SYMLINK})
   endif()
+
+  # The Rust staticlib contains unresolved references to OpenSSL and system
+  # libraries.  Declare them as transitive (INTERFACE) dependencies so that
+  # any target linking against scylladb_static automatically pulls
+  # in the required symbols in the correct order.
+  #
+  # NOTE: Some of these libraries (e.g. OpenSSL, ws2_32, crypt32, userenv on
+  # Windows) also appear in CASS_LIBS (populated by cmake/Dependencies.cmake).
+  # This causes them to appear twice on the linker command line, which is
+  # intentional and harmless -- linkers silently ignore duplicate inputs --
+  # but it keeps the static target self-contained so it works correctly even
+  # when linked outside the integration-test build where CASS_LIBS is set.
+
+  # ## `INTERFACE_LINK_LIBRARIES` on an IMPORTED target
+  # For an **IMPORTED** target (which `scylladb_static` is — `add_library(scylladb_static STATIC IMPORTED GLOBAL)`),
+  # the `INTERFACE_LINK_LIBRARIES` property means: "when something links against this target,
+  # also link against these libraries. This is actually the **correct** property to use here. The distinction:
+  # - `LINK_LIBRARIES` — libraries used to build the target itself (irrelevant for IMPORTED targets
+  #   since they're pre-built)
+  # - `INTERFACE_LINK_LIBRARIES` — libraries that **consumers** of this target must also link against
+  #
+  # Since `scylladb_static` is a pre-built static archive, it doesn't get "built" by CMake — it's already compiled.
+  # But any executable that links against it (like `cassandra-integration-tests`) needs to also link
+  # `-lssl -lcrypto -ldl -lm -lpthread` to resolve the symbols that the archive references.
+  # That's exactly what `INTERFACE_LINK_LIBRARIES` communicates.
+  #
+  # The word "INTERFACE" in CMake doesn't mean "public API" in the C++ sense — it means "propagated to consumers."
+  # For an IMPORTED static library, ALL transitive dependencies are necessarily interface dependencies because
+  # the static archive is opaque to CMake (it can't see inside it to know what symbols are needed).
+  set(_STATIC_INTERFACE_LIBS "")
+
+  if(CASS_USE_OPENSSL AND OPENSSL_LIBRARIES)
+    list(APPEND _STATIC_INTERFACE_LIBS ${OPENSSL_LIBRARIES})
+  endif()
+
+  if(WIN32)
+    # Windows system libraries required by Rust runtime and its dependencies
+    list(APPEND _STATIC_INTERFACE_LIBS ws2_32 bcrypt ntdll userenv crypt32 secur32 ncrypt)
+  elseif(APPLE)
+    list(APPEND _STATIC_INTERFACE_LIBS ${CMAKE_DL_LIBS} m)
+    find_package(Threads)
+    if(Threads_FOUND)
+      list(APPEND _STATIC_INTERFACE_LIBS Threads::Threads)
+    endif()
+    # CoreFoundation is needed by the iana-time-zone crate on macOS
+    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+    if(COREFOUNDATION_LIBRARY)
+      list(APPEND _STATIC_INTERFACE_LIBS ${COREFOUNDATION_LIBRARY})
+    endif()
+    # SystemConfiguration and Security may also be needed on macOS
+    find_library(SYSTEMCONFIGURATION_LIBRARY SystemConfiguration)
+    if(SYSTEMCONFIGURATION_LIBRARY)
+      list(APPEND _STATIC_INTERFACE_LIBS ${SYSTEMCONFIGURATION_LIBRARY})
+    endif()
+    find_library(SECURITY_LIBRARY Security)
+    if(SECURITY_LIBRARY)
+      list(APPEND _STATIC_INTERFACE_LIBS ${SECURITY_LIBRARY})
+    endif()
+  else() # non-Windows and non-Apple - assume Unix-like, such as Linux
+    list(APPEND _STATIC_INTERFACE_LIBS ${CMAKE_DL_LIBS} m)
+    find_package(Threads)
+    if(Threads_FOUND)
+      list(APPEND _STATIC_INTERFACE_LIBS Threads::Threads)
+    endif()
+  endif()
+
+  if(_STATIC_INTERFACE_LIBS)
+    set_target_properties(scylladb_static PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${_STATIC_INTERFACE_LIBS}")
+  endif()
 endif()
 
 #-------------------------------------

--- a/scylla-rust-wrapper/scylladb_static.pc.in
+++ b/scylla-rust-wrapper/scylladb_static.pc.in
@@ -6,7 +6,8 @@ includedir=@includedir@
 Name: scylladb
 Description: ScyllaDB CPP RS Driver
 Version: @version@
-Requires: openssl
+Requires.private: @scylladb_static_requires_private@
 Libs: -L${libdir} -lscylladb_static
+Libs.private: @scylladb_static_libs_private@
 Cflags: -I${includedir}
 URL: https://github.com/scylladb/cpp-rs-driver/


### PR DESCRIPTION
Fixes: #455

## Problem recap

#455 correctly observed that linking the static driver library included in release 1.0.0 (1.0.1 is also impacted) against an older OpenSSL fails, because the lib has undefined symbols that are only supplied by OpenSSL 3.3/3.4/3.5 or newer. Considering our OpenSSL minimum requirements is 3.0.2 (should be enough - this is present on Ubuntu 22.04, so quite an old one), this should be considered a bug in our build/release CI.

There are three problems in particular:

#### Problem 1: We have built packages with **_too new_** OpenSSL headers.

This led to including functions not available at 3.0.x as unresolved symbols.

#### Problem 2: We haven't verified that the released packages link against OpenSSL 3.0.x correctly.

#### Problem 3: We didn't put any build info manifest in the released package.
This @vladzcloudius noted in #455 as the minimum to address the issue.

## Solution

### Problem 2: OpenSSL 3.0.2 linking verification

This PR introduces an OpenSSL verification Makefile recipe. Outline:
    1. copy the already-built static archive and pkg-config metadata into a sysroot;
    2. alongside, put OpenSSL 3.0.2 headers and static libraries from a pinned Launchpad deb;
    3. attempt to compile and link `examples/ssl/ssl.c`.
    
If the build environment was contaminated (e.g. by a newer OpenSSL with IDEA or 3.3+ APIs), the archive will contain symbol references that don't exist in OpenSSL 3.0 and the link will fail — catching the regression from issue #455.
    
The verification runs in both PR CI (after `build-integration-test-bin`) and packaging CI (after `test-package-deb`), since both produce the static archive in `build/`.


### Problem 1: _too new_ OpenSSL in the building/packaging CI workflow

The plot twist is that one week after we released 1.0.1 with **no** support for OpenSSL 3.0.x, once I freshly rebuilt the 1.0.1 package (in the same CI workflow) and attempted linkage against OpenSSL 3.0.2 using the new verification procedure, **it succeeded**. Investigation revealed that the fresh lib has much different _cgus_ (compile gen units) - different number and sizes. Most likely explanation: LTO in the Rust toolchain improved during that week, fixing the problem in our building/packaging CI.

If the problem happens to strike back, our verification step will immediately catch it. We're thus guarded and safe.

### Problem 3: lack of build info in the package

It makes sense to generate plaintext build info manifest (`Key: Value` lines) during build and put it in the built dev package. Exact contents of this build info is subject to discussion; this PR introduces what Opus came up with (and I believe it's a fine list of properties).

## PR contents in detail

### First 3 commits

They are extracted from #438. These are small fixes.

### Next 3 commits

Also extracted from #438.

1. Adds comments to existing logic in `scylla-rust-wrapper/CMakeLists.txt`.
2. Registers transitive deps for the driver in the CMake dep resolution subsystem, so that those who use the driver as a CMake dependency will get driver's deps pulled in into the dependency graph, resulting in correct linker invocation.
3. Publishes transitive deps in `scylladb_static.pc` (`pkg-config` manifest). This supports a common (according to my research) way that people configure their compiler & linker. More details in the commit message.

### Next commit

Introduces the OpenSSL 3.0.2 compatibility verification, described earlier.

### Last 2 commits

Introduce `BUILD_INFO` generation and include it in the generated `dev` packages. This addresses the main request of #455.

<details><summary>`BUILD_INFO` contents when built on my machine:</summary>
<p>
Build Information for scylla-cpp-driver v1.0.0-145-g541cb277

Platform
--------
OS:             Ubuntu 25.10
Architecture:   x86_64
Kernel:         6.17.0-35-generic
glibc:          2.42

Toolchain
---------
Rust:           rustc 1.96.0 (ac68faa20 2026-05-25)
Cargo:          cargo 1.96.0 (30a34c682 2026-05-25)
CMake:          cmake version 3.31.6
CC:             cc (Ubuntu 15.2.0-4ubuntu4) 15.2.0

OpenSSL (detected by openssl-sys at build time)
------------------------------------------------
Version:        3.5.0
Include path:   /usr/include
Disabled (osslconf): OPENSSL_NO_IDEA OPENSSL_NO_SSL3_METHOD

Build Configuration
-------------------
CMAKE_BUILD_TYPE:       Release
CMAKE_INSTALL_PREFIX:   /usr
CASS_BUILD_SHARED:      ON
CASS_BUILD_STATIC:      ON
LTO:                    true
Panic strategy:         abort

Static Library Compatibility Notes
----------------------------------
The static archive (libscylladb_static.a) requires consumers to
provide OpenSSL >= 3.0 at link time. The minimum OpenSSL version
is determined by the build-time detection performed by the
openssl-sys crate.

Consumers linking on systems with a different OpenSSL configuration
(e.g. different osslconf flags) may encounter undefined symbol errors
for conditionally-compiled functions.
</p>
</details>


<details><summary>`BUILD_INFO` contents when built in the CI:</summary>
<p>

Build Information for scylla-cpp-driver 6eff933

Platform
--------
OS:             Ubuntu 22.04.5 LTS
Architecture:   x86_64
Kernel:         6.8.0-1052-azure
glibc:          2.35
unknown

Toolchain
---------
Rust:           rustc 1.96.0 (ac68faa20 2026-05-25)
Cargo:          cargo 1.96.0 (30a34c682 2026-05-25)
CMake:          cmake version 3.31.6
CC:             cc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0

OpenSSL (detected by openssl-sys at build time)
------------------------------------------------
Version:        3.0.2
Include path:   /usr/include
Disabled (osslconf): unknown (openssl-sys build output not found)

Build Configuration
-------------------
CMAKE_BUILD_TYPE:       Release
CMAKE_INSTALL_PREFIX:   /usr
CASS_BUILD_SHARED:      ON
CASS_BUILD_STATIC:      ON
LTO:                    true
Panic strategy:         abort

Static Library Compatibility Notes
----------------------------------
The static archive (libscylladb_static.a) requires consumers to
provide OpenSSL >= 3.0 at link time. The minimum OpenSSL version
is determined by the build-time detection performed by the
openssl-sys crate.

Consumers linking on systems with a different OpenSSL configuration
(e.g. different osslconf flags) may encounter undefined symbol errors
for conditionally-compiled functions.


</p>
</details> 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
