### PR TITLE
tests: fix static link order

### DIFF
--- a/tests/src/integration/CMakeLists.txt
+++ b/tests/src/integration/CMakeLists.txt
@@ -62,8 +62,8 @@ target_include_directories(cassandra-integration-tests PRIVATE
   ${CASS_INCLUDES})
 
 target_link_libraries(cassandra-integration-tests
-  ${CASS_LIBS}
   ${PROJECT_LIB_NAME_TARGET}
+  ${CASS_LIBS}
   ${INTEGRATION_TESTS_LIBSSH2_LIBRARIES})
 
 set_target_properties(cassandra-integration-tests PROPERTIES


### PR DESCRIPTION
### What's done

Place the driver target before `CASS_LIBS` in `target_link_libraries` for integration tests. With static linking the linker resolves symbols left-to-right, so the archive providing symbols must precede the libraries that define them.

It's fascinating that the bug comes from the DataStax CPP Driver's build system. They must have never tested static linkage with integration tests.

### Verification

```sh
cmake\
-DCASS_BUILD_INTEGRATION_TESTS=ON \
-DCASS_USE_STATIC_LIBS=ON \
-B build \
&& (cd build && make)
```
now works. Before, it would fails with undefined references to OpenSSL symbols.

### Further work

#438 apart of containing this fix, introduced **a lot** of changes and static linkage verification using the smoke test app. I'm working on making the changes more granular, better documented, and hence mergable.

Fixes: #164

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
