### PR TITLE
Add TLS testing via CCM

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,8 @@
 - [ ] I have split my patch into logically separate commits.
 - [ ] All commit messages clearly explain what they change and why.
 - [ ] PR description sums up the changes and reasons why they should be introduced.
+- [ ] I have provided docstrings for the public items that I want to introduce.
+- [ ] I have adjusted the documentation in `./docs/source/`.
 - [ ] I have implemented Rust unit tests for the features/changes introduced.
 - [ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
 - [ ] I added appropriate `Fixes:` annotations to PR description.

--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -18,7 +18,12 @@ env:
   INTEGRATION_TEST_BIN_CACHE_KEY: integration-test-bin-${{ github.sha }}
   # Goes to `Makefile` to let it pickup cached binary
   DONT_REBUILD_INTEGRATION_BIN: true
-  CCM_LOGS_PATTERN: /tmp/ccm*/ccm*/node*/logs/*
+  # Log directories to upload on integration-test failure. The first glob
+  # matches the C++ suite's CCM layout; the second matches the Rust CCM tests,
+  # which use CCM_ROOT_DIR=/tmp/ccm-rust (see `run-test-integration-scylla`).
+  CCM_LOGS_PATTERN: |
+    /tmp/ccm*/ccm*/node*/logs/*
+    /tmp/ccm-rust/*/*/node*/logs/*
 
 jobs:
   build-lint-and-unit-test:
@@ -141,6 +146,10 @@ jobs:
 
       - name: Run integration tests on Scylla ${{ steps.scylla-version.outputs.value }}
         id: run-integration-tests
+        env:
+          # Preserve failed Rust CCM clusters (and their /tmp/ccm-rust node
+          # logs) so the "Upload CCM logs" step can collect diagnostics.
+          TEST_KEEP_CLUSTER_ON_FAILURE: "true"
         run: SCYLLA_VERSION="release:${{ steps.scylla-version.outputs.value }}" make run-test-integration-scylla
 
       - name: Upload test logs

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ ifndef CCM_COMMIT_ID
 endif
 
 ifndef SCYLLA_VERSION
-	SCYLLA_VERSION := release:2025.3
+	SCYLLA_VERSION := release:2026.2.2
 endif
 
 ifndef CASSANDRA_VERSION

--- a/Makefile
+++ b/Makefile
@@ -509,7 +509,10 @@ endif
 
 run-test-unit: install-cargo-if-missing
 	@cd ${CURRENT_DIR}/scylla-rust-wrapper
-	RUSTFLAGS="${FULL_RUSTFLAGS}" cargo test
+	@# The `ccm` tests require a running CCM environment and a real cluster,
+	@# so they are excluded here. They are run as part of the integration
+	@# test targets instead (see `run-test-integration-scylla`).
+	RUSTFLAGS="${FULL_RUSTFLAGS}" cargo test -- --skip ccm
 
 # Currently not used.
 CQLSH := cqlsh

--- a/Makefile
+++ b/Makefile
@@ -495,6 +495,18 @@ endif
 	valgrind --error-exitcode=123 --leak-check=full --errors-for-leak-kinds=definite build/cassandra-integration-tests --scylla --version=${SCYLLA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${SCYLLA_TEST_FILTER}"
 	@echo "Running timeout sensitive tests on scylla ${SCYLLA_VERSION}"
 	build/cassandra-integration-tests --scylla --version=${SCYLLA_VERSION} --category=CASSANDRA --verbose=ccm --gtest_filter="${SCYLLA_NO_VALGRIND_TEST_FILTER}"
+	@echo "Running Rust CCM integration tests on scylla ${SCYLLA_VERSION}"
+	@cd ${CURRENT_DIR}/scylla-rust-wrapper
+	@# These tests start real, TLS-enabled clusters via CCM and drive the
+	@# driver through its C API. `SCYLLA_TEST_CLUSTER` selects the CCM version
+	@# (see the scylla-ccm-bridge crate). Ignored tests (documenting not-yet
+	@# implemented behavior) are intentionally not run.
+	@#
+	@# Prefer a fully-qualified SCYLLA_VERSION (e.g. release:2025.3.8 rather
+	@# than release:2025.3): scylla-ccm re-resolves the version on every `ccm`
+	@# invocation, and a partial one forces it to list an S3 bucket and sleep
+	@# for a random 0-5 seconds each time, which dominates the test runtime.
+	SCYLLA_TEST_CLUSTER="${SCYLLA_VERSION}" CCM_ROOT_DIR=/tmp/ccm-rust RUSTFLAGS="${FULL_RUSTFLAGS}" cargo test --test integration ccm
 
 run-test-integration-cassandra: install-java8-if-missing
 ifdef DONT_REBUILD_INTEGRATION_BIN

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -4309,7 +4309,7 @@ cass_ssl_add_trusted_cert_n(CassSsl* ssl,
  * common name or one of its subject alternative names. This implies the
  * certificate is also present. Hostname resolution must also be enabled.
  *
- * <b>Default:</b> CASS_SSL_VERIFY_PEER_CERT
+ * <b>Default:</b> CASS_SSL_VERIFY_NONE
  *
  * @public @memberof CassSsl
  *

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -27,16 +27,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -49,20 +43,20 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bigdecimal"
@@ -72,7 +66,7 @@ checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -95,8 +89,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.119",
  "which",
 ]
 
@@ -108,15 +102,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -126,18 +120,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -157,9 +151,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -170,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -187,9 +181,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "darling"
@@ -212,7 +206,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -223,14 +217,14 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -242,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"
@@ -264,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -303,9 +297,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -318,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -328,15 +322,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -345,38 +339,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -408,28 +402,26 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasip2",
- "wasip3",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "hashbrown"
@@ -450,32 +442,26 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "histogram"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e05f6bebaf5e4ae9ffac23c348518ceda3775c3b5edabdd95c3c0abee0c040"
+checksum = "099d45a031296a7a40e01137b56c0c552f2a545568ef6058e47d674046def0db"
 dependencies = [
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -503,12 +489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,14 +496,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -545,18 +523,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -573,16 +546,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -623,15 +590,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
  "twox-hash",
 ]
@@ -656,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"
@@ -668,9 +635,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -742,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -781,17 +748,17 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -807,14 +774,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -853,15 +820,15 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "ppv-lite86"
@@ -879,23 +846,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -908,9 +875,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -922,10 +889,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -934,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -995,14 +968,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1012,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1023,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
@@ -1039,7 +1012,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1052,7 +1025,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -1061,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -1098,13 +1071,13 @@ dependencies = [
  "histogram",
  "itertools 0.14.0",
  "openssl",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_pcg",
  "scylla-cql",
  "scylla-cql-core",
  "smallvec",
  "socket2 0.5.10",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-openssl",
  "tracing",
@@ -1124,7 +1097,7 @@ dependencies = [
  "scylla-cql-core",
  "snap",
  "stable_deref_trait",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "uuid",
  "yoke",
@@ -1140,7 +1113,7 @@ dependencies = [
  "chrono",
  "itertools 0.14.0",
  "scylla-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "uuid",
 ]
 
@@ -1152,7 +1125,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1166,9 +1139,9 @@ dependencies = [
  "chrono",
  "futures",
  "num-bigint 0.3.3",
- "rand 0.9.2",
+ "rand 0.9.5",
  "scylla-cql",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "uuid",
@@ -1192,7 +1165,7 @@ dependencies = [
  "num-traits",
  "openssl",
  "openssl-sys",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rusty-fork",
  "scylla",
  "scylla-cql",
@@ -1205,51 +1178,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1266,6 +1211,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1285,15 +1236,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snap"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
@@ -1307,12 +1258,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1340,9 +1291,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1357,17 +1319,17 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -1384,11 +1346,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -1399,34 +1361,34 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -1434,20 +1396,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1463,18 +1425,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1484,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -1510,7 +1472,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1536,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1554,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "unicode-ident"
@@ -1565,18 +1527,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1610,27 +1566,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1641,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1651,58 +1598,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1760,7 +1673,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1771,7 +1684,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1804,7 +1717,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1813,16 +1726,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1840,31 +1744,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1874,22 +1761,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1898,22 +1773,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1922,22 +1785,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1946,28 +1797,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -1983,103 +1822,15 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2088,59 +1839,53 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -42,6 +42,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bindgen"
 version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +130,15 @@ dependencies = [
  "shlex 1.3.0",
  "syn 2.0.119",
  "which",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -224,6 +278,43 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -677,6 +768,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,12 +795,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -769,6 +894,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +914,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -913,6 +1054,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,10 +1106,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rustix"
@@ -980,6 +1158,15 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -1128,6 +1315,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "rand 0.8.7",
+ "rcgen",
  "rusty-fork",
  "scylla",
  "scylla-ccm-bridge",
@@ -1138,6 +1326,16 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1338,6 +1536,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,6 +1706,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uuid"
@@ -1666,6 +1900,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -1771,6 +2014,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,3 +2104,9 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -59,19 +59,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "bigdecimal"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
-dependencies = [
- "autocfg",
- "libm",
- "num-bigint 0.4.8",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,9 +174,9 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -197,27 +184,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -276,9 +262,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -431,9 +417,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -441,16 +427,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
 name = "histogram"
-version = "0.11.5"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099d45a031296a7a40e01137b56c0c552f2a545568ef6058e47d674046def0db"
+checksum = "8ebb5d42df947561c11a73414c53d14c4a0e3193e761a4cdca16ca3d941a2302"
 dependencies = [
  "thiserror 2.0.19",
 ]
@@ -515,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -562,12 +542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,9 +570,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -697,27 +671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,15 +679,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1059,7 +1003,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scylla"
 version = "1.7.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.7.0#5ecb2de4a76159ef306553bf478927112f24016b"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1067,16 +1011,16 @@ dependencies = [
  "chrono",
  "dashmap",
  "futures",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "histogram",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "openssl",
  "rand 0.9.5",
  "rand_pcg",
  "scylla-cql",
  "scylla-cql-core",
  "smallvec",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.19",
  "tokio",
  "tokio-openssl",
@@ -1087,12 +1031,12 @@ dependencies = [
 [[package]]
 name = "scylla-cql"
 version = "1.7.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.7.0#5ecb2de4a76159ef306553bf478927112f24016b"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
 dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lz4_flex",
  "scylla-cql-core",
  "snap",
@@ -1106,12 +1050,12 @@ dependencies = [
 [[package]]
 name = "scylla-cql-core"
 version = "1.7.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.7.0#5ecb2de4a76159ef306553bf478927112f24016b"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
 dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "scylla-macros",
  "thiserror 2.0.19",
  "uuid",
@@ -1120,31 +1064,26 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "1.7.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.7.0#5ecb2de4a76159ef306553bf478927112f24016b"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "scylla-proxy"
 version = "0.0.6"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.7.0#5ecb2de4a76159ef306553bf478927112f24016b"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
 dependencies = [
- "bigdecimal",
- "byteorder",
  "bytes",
- "chrono",
  "futures",
- "num-bigint 0.3.3",
  "rand 0.9.5",
  "scylla-cql",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -1245,16 +1184,6 @@ name = "snap"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -1396,7 +1325,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1709,15 +1638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
 ]
 
 [[package]]

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1035,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "scylla-ccm-bridge"
+version = "0.0.1"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "itertools 0.15.0",
+ "rand 0.9.5",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "scylla-cql"
 version = "1.7.0"
 source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
@@ -1107,6 +1130,7 @@ dependencies = [
  "rand 0.8.7",
  "rusty-fork",
  "scylla",
+ "scylla-ccm-bridge",
  "scylla-cql",
  "scylla-proxy",
  "thiserror 1.0.69",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -46,6 +46,7 @@ itertools = "0.10.3"
 assert_matches = "1.5.0"
 ntest = "0.9.3"
 rusty-fork = "0.3.0"
+rcgen = "0.14"
 
 [lib]
 name = "scylladb"

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.88"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.7.0", features = [
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9ab7216d4d32eb249dbd9929c9d3592711b800da", features = [
     "openssl-010",
     "metrics",
     "unstable-cpp-rs",
@@ -38,8 +38,8 @@ bindgen = "0.65"
 chrono = "0.4.20"
 
 [dev-dependencies]
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.7.0" }
-scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.7.0" }
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9ab7216d4d32eb249dbd9929c9d3592711b800da" }
+scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9ab7216d4d32eb249dbd9929c9d3592711b800da" }
 bytes = "1.10.0"
 itertools = "0.10.3"
 assert_matches = "1.5.0"

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -40,6 +40,7 @@ chrono = "0.4.20"
 [dev-dependencies]
 scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9ab7216d4d32eb249dbd9929c9d3592711b800da" }
 scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9ab7216d4d32eb249dbd9929c9d3592711b800da" }
+scylla-ccm-bridge = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9ab7216d4d32eb249dbd9929c9d3592711b800da" }
 bytes = "1.10.0"
 itertools = "0.10.3"
 assert_matches = "1.5.0"

--- a/scylla-rust-wrapper/tests/integration/ccm/mod.rs
+++ b/scylla-rust-wrapper/tests/integration/ccm/mod.rs
@@ -1,0 +1,77 @@
+//! Integration tests that require a real ScyllaDB cluster, started via CCM
+//! (Cassandra Cluster Manager) through the `scylla-ccm-bridge` crate.
+//!
+//! These tests are excluded from `make run-test-unit` (which runs no cluster)
+//! and are executed as part of the Scylla integration job instead. The
+//! exclusion is done by test-path substring `ccm` — keep every test in this
+//! module tree under the `ccm::` path.
+
+use scylla_ccm_bridge::CLUSTER_VERSION;
+
+mod tls;
+
+/// Returns whether `version` is a *partial* (not fully-qualified) `scylla-ccm`
+/// cluster version, i.e. one that ccm cannot resolve to an install directory
+/// without hitting S3.
+///
+/// See [`warn_if_partial_cluster_version`] for why this matters.
+fn is_partial_version(version: &str) -> bool {
+    match version.split_once(':') {
+        // A release version needs a patch component to name a directory,
+        // unless it is a release candidate (e.g. `release:2026.1.0~rc3`).
+        Some(("release", rest)) => !rest.contains('~') && rest.split('.').count() < 3,
+        // Unstable versions are pinned by build timestamp; `latest` is not.
+        Some((_, rest)) => rest == "latest",
+        // Without a prefix there is nothing for ccm to resolve against S3, so
+        // treat a bare version (e.g. `2026.2`) as fully-qualified.
+        None => false,
+    }
+}
+
+/// Warns (once per test binary) if the configured cluster version is not a
+/// fully-qualified one.
+///
+/// `scylla-ccm` re-resolves the cluster version on *every* `ccm` invocation,
+/// ignoring the install directory it already recorded in `cluster.conf`. If
+/// the version names an already-downloaded directory (e.g. `release:2026.1.0`),
+/// resolving it is a local directory lookup and costs nothing. If it is partial
+/// (e.g. `release:2026.1`), ccm has to list an S3 bucket to find the matching
+/// patch release, and on top of that sleeps for a random 0-5 seconds. That adds
+/// several seconds to *each* `ccm` call, which then dominates the runtime of
+/// these tests.
+pub(crate) fn warn_if_partial_cluster_version() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+
+    ONCE.call_once(|| {
+        let version: &str = &CLUSTER_VERSION;
+        if is_partial_version(version) {
+            tracing::warn!(
+                "SCYLLA_TEST_CLUSTER is set to the partial version {version:?}. \
+                 Every `ccm` invocation will hit S3 to resolve it, adding several \
+                 seconds each. Use a fully-qualified version (e.g. \
+                 \"release:2026.1.0\") to make these tests much faster."
+            );
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_partial_version;
+
+    #[test]
+    fn classifies_cluster_versions() {
+        // A release with a patch component names a directory directly.
+        assert!(!is_partial_version("release:2026.2.2"));
+        // A release candidate is fully-qualified even without a third component.
+        assert!(!is_partial_version("release:2026.1.0~rc3"));
+        // A release without a patch component must be resolved against S3.
+        assert!(is_partial_version("release:2026.2"));
+        // `latest` is a moving target and must be resolved against S3.
+        assert!(is_partial_version("unstable/master:latest"));
+        // A timestamp-pinned unstable version is fully-qualified.
+        assert!(!is_partial_version("unstable/master:2026-01-01T00-00-00Z"));
+        // A bare version without a prefix is treated as fully-qualified.
+        assert!(!is_partial_version("2026.2"));
+    }
+}

--- a/scylla-rust-wrapper/tests/integration/ccm/tls.rs
+++ b/scylla-rust-wrapper/tests/integration/ccm/tls.rs
@@ -7,6 +7,7 @@
 
 use std::ffi::CString;
 use std::net::{IpAddr, Ipv4Addr};
+use std::os::raw::c_char;
 use std::sync::Arc;
 
 use futures::StreamExt as _;
@@ -31,7 +32,8 @@ use scylladb::api::session::{
     cass_session_new,
 };
 use scylladb::api::ssl::{
-    cass_ssl_add_trusted_cert, cass_ssl_free, cass_ssl_new, cass_ssl_set_verify_flags,
+    cass_ssl_add_trusted_cert, cass_ssl_free, cass_ssl_new, cass_ssl_set_cert,
+    cass_ssl_set_private_key, cass_ssl_set_verify_flags,
 };
 use scylladb::api::statement::{cass_statement_free, cass_statement_new};
 use scylladb::argconv::CassStrNulTerminated;
@@ -189,6 +191,7 @@ unsafe fn connect_and_healthcheck(
     contact_points: &str,
     verify_flags: Option<i32>,
     trust_ca_pem: Option<&str>,
+    client_cert_and_key_pem: Option<(&str, &str)>,
 ) -> CassError {
     unsafe {
         let mut cluster_raw = cass_cluster_new();
@@ -210,6 +213,29 @@ unsafe fn connect_and_healthcheck(
                 cass_ssl_add_trusted_cert(
                     ssl_raw.borrow(),
                     CassStrNulTerminated::from_cstr(&ca_pem_c),
+                ),
+            );
+        }
+        if let Some((cert_pem, key_pem)) = client_cert_and_key_pem {
+            let cert_pem_c = CString::new(cert_pem).unwrap();
+            assert_cass_error_eq(
+                CassError::CASS_OK,
+                cass_ssl_set_cert(
+                    ssl_raw.borrow(),
+                    CassStrNulTerminated::from_cstr(&cert_pem_c),
+                ),
+            );
+
+            let key_pem_c = CString::new(key_pem).unwrap();
+            // The rcgen-generated key is unencrypted, but the C API still
+            // requires a non-null password pointer, so pass an empty string.
+            let mut empty_password: [c_char; 1] = [0];
+            assert_cass_error_eq(
+                CassError::CASS_OK,
+                cass_ssl_set_private_key(
+                    ssl_raw.borrow(),
+                    CassStrNulTerminated::from_cstr(&key_pem_c),
+                    empty_password.as_mut_ptr(),
                 ),
             );
         }
@@ -260,6 +286,7 @@ async fn try_tls_connect(
     cluster: &Cluster,
     verify_flags: Option<i32>,
     trust_ca_pem: Option<String>,
+    client_cert_and_key_pem: Option<(String, String)>,
 ) -> CassError {
     let contact_points = cluster
         .nodes()
@@ -269,7 +296,14 @@ async fn try_tls_connect(
         .join(",");
 
     tokio::task::spawn_blocking(move || unsafe {
-        connect_and_healthcheck(&contact_points, verify_flags, trust_ca_pem.as_deref())
+        connect_and_healthcheck(
+            &contact_points,
+            verify_flags,
+            trust_ca_pem.as_deref(),
+            client_cert_and_key_pem
+                .as_ref()
+                .map(|(cert, key)| (cert.as_str(), key.as_str())),
+        )
     })
     .await
     .unwrap()
@@ -302,6 +336,7 @@ async fn connect_tls_no_client_auth() {
                 cluster,
                 Some(CASS_SSL_VERIFY_PEER_IDENTITY),
                 Some(ca_pem.clone()),
+                None,
             )
             .await,
         );
@@ -309,18 +344,18 @@ async fn connect_tls_no_client_auth() {
         // NONE: verification disabled -> connects even without a trusted CA.
         assert_cass_error_eq(
             CassError::CASS_OK,
-            try_tls_connect(cluster, Some(CASS_SSL_VERIFY_NONE), None).await,
+            try_tls_connect(cluster, Some(CASS_SSL_VERIFY_NONE), None, None).await,
         );
 
         // default: verification disabled -> connects even without a trusted CA.
         assert_cass_error_eq(
             CassError::CASS_OK,
-            try_tls_connect(cluster, None, None).await,
+            try_tls_connect(cluster, None, None, None).await,
         );
 
         // PEER_IDENTITY without a trusted CA -> certificate chain validation
         // fails, so the connection is rejected.
-        let err = try_tls_connect(cluster, Some(CASS_SSL_VERIFY_PEER_IDENTITY), None).await;
+        let err = try_tls_connect(cluster, Some(CASS_SSL_VERIFY_PEER_IDENTITY), None, None).await;
         assert_ne!(
             err,
             CassError::CASS_OK,
@@ -358,6 +393,7 @@ async fn tls_verifies_hostname() {
             cluster,
             Some(CASS_SSL_VERIFY_PEER_IDENTITY),
             Some(ca_pem.clone()),
+            None,
         )
         .await;
         assert_ne!(
@@ -370,9 +406,75 @@ async fn tls_verifies_hostname() {
         // connection succeeds.
         assert_cass_error_eq(
             CassError::CASS_OK,
-            try_tls_connect(cluster, Some(CASS_SSL_VERIFY_NONE), Some(ca_pem)).await,
+            try_tls_connect(cluster, Some(CASS_SSL_VERIFY_NONE), Some(ca_pem), None).await,
         );
     }
 
     run_ccm_tls_test(prepare_cert, async |c| c, test).await
+}
+
+/// Checks that the driver can still connect when the server requires client
+/// authentication (`require_client_auth = true`): connecting without a client
+/// certificate must fail, while connecting with a certificate/key signed by the
+/// trusted CA must succeed.
+///
+/// Port of the Rust Driver's `test_connect_tls_with_client_auth`.
+#[tokio::test]
+async fn connect_tls_with_client_auth() {
+    setup_tracing();
+
+    // Each node's certificate has a SAN matching its own broadcast RPC address.
+    fn prepare_cert(mut params: CertificateParams, node: &Node) -> CertificateParams {
+        params
+            .subject_alt_names
+            .push(SanType::IpAddress(node.broadcast_rpc_address()));
+        params
+    }
+
+    async fn require_client_auth(mut cluster: Cluster) -> Cluster {
+        cluster
+            .updateconf([("client_encryption_options.require_client_auth", "true")])
+            .await
+            .unwrap();
+        cluster
+    }
+
+    async fn test(ca: &CertifiedIssuer<'static, KeyPair>, cluster: &mut Cluster) {
+        let ca_pem = ca.pem();
+
+        // Sanity check: without a client certificate, the server rejects us.
+        let err = try_tls_connect(
+            cluster,
+            Some(CASS_SSL_VERIFY_PEER_IDENTITY),
+            Some(ca_pem.clone()),
+            None,
+        )
+        .await;
+        assert_ne!(
+            err,
+            CassError::CASS_OK,
+            "expected connection to fail: server requires client authentication"
+        );
+
+        // With a client certificate and key signed by the trusted CA, we
+        // authenticate successfully and connect.
+        let client_key = KeyPair::generate().unwrap();
+        let client_cert = CertificateParams::new(vec![])
+            .unwrap()
+            .signed_by(&client_key, ca)
+            .unwrap();
+
+        assert_cass_error_eq(
+            CassError::CASS_OK,
+            try_tls_connect(
+                cluster,
+                Some(CASS_SSL_VERIFY_PEER_IDENTITY),
+                Some(ca_pem),
+                Some((client_cert.pem(), client_key.serialize_pem())),
+            )
+            .await,
+        );
+    }
+
+    run_ccm_tls_test(prepare_cert, require_client_auth, test).await
 }

--- a/scylla-rust-wrapper/tests/integration/ccm/tls.rs
+++ b/scylla-rust-wrapper/tests/integration/ccm/tls.rs
@@ -1,0 +1,331 @@
+//! End-to-end TLS tests against a real, TLS-enabled ScyllaDB cluster started
+//! via CCM. The driver is exercised exclusively through its C API, mirroring
+//! how a C/C++ consumer would use it.
+//!
+//! These tests are ports of the ScyllaDB Rust Driver's `ccm::tls` integration
+//! tests, adapted to drive this driver through the C API.
+
+use std::ffi::CString;
+use std::sync::Arc;
+
+use futures::StreamExt as _;
+use rcgen::{
+    BasicConstraints, CertificateParams, CertifiedIssuer, DistinguishedName, DnType, IsCa, KeyPair,
+    SanType,
+};
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt as _;
+
+use scylla_ccm_bridge::cluster::{Cluster, ClusterOptions};
+use scylla_ccm_bridge::node::Node;
+use scylla_ccm_bridge::{CLUSTER_VERSION, run_ccm_test_with_configuration};
+
+use scylladb::api::cluster::{
+    cass_cluster_free, cass_cluster_new, cass_cluster_set_contact_points, cass_cluster_set_ssl,
+};
+use scylladb::api::error::CassError;
+use scylladb::api::future::{cass_future_error_code, cass_future_free, cass_future_wait};
+use scylladb::api::session::{
+    cass_session_close, cass_session_connect, cass_session_execute, cass_session_free,
+    cass_session_new,
+};
+use scylladb::api::ssl::{
+    cass_ssl_add_trusted_cert, cass_ssl_free, cass_ssl_new, cass_ssl_set_verify_flags,
+};
+use scylladb::api::statement::{cass_statement_free, cass_statement_new};
+use scylladb::argconv::CassStrNulTerminated;
+
+use crate::utils::{assert_cass_error_eq, setup_tracing};
+
+use super::warn_if_partial_cluster_version;
+
+// Verification flag values, as defined by the C API (`cassandra.h`).
+// The Rust constants in the driver are crate-private, so we redefine the ABI
+// values here, exactly as a C consumer would use them.
+const CASS_SSL_VERIFY_NONE: i32 = 0x00;
+const CASS_SSL_VERIFY_PEER_IDENTITY: i32 = 0x02;
+
+fn cluster_3_nodes() -> ClusterOptions {
+    ClusterOptions {
+        name: "cluster_tls_3_node".to_string(),
+        version: CLUSTER_VERSION.clone(),
+        nodes_per_dc: vec![3],
+        ..ClusterOptions::default()
+    }
+}
+
+/// Generates and installs a per-node server certificate (signed by `ca`) and
+/// enables `client_encryption_options` on the node.
+///
+/// `prepare_cert` customizes the certificate parameters (e.g. its SANs) based
+/// on the node it is generated for.
+async fn configure_node_tls(
+    node: &mut Node,
+    ca: &CertifiedIssuer<'static, KeyPair>,
+    prepare_cert: impl FnOnce(CertificateParams, &Node) -> CertificateParams,
+) {
+    let params = prepare_cert(CertificateParams::new(vec![]).unwrap(), node);
+    let key = KeyPair::generate().unwrap();
+    let cert = params.signed_by(&key, ca).unwrap();
+
+    let cert_file_path = node.node_dir().join("db.cert");
+    let mut cert_file = File::create_new(&cert_file_path).await.unwrap();
+    cert_file.write_all(cert.pem().as_bytes()).await.unwrap();
+
+    let key_file_path = node.node_dir().join("db.key");
+    let mut key_file = File::create_new(&key_file_path).await.unwrap();
+    key_file
+        .write_all(key.serialize_pem().as_bytes())
+        .await
+        .unwrap();
+
+    let args = [
+        ("client_encryption_options.enabled", "true"),
+        (
+            "client_encryption_options.certificate",
+            cert_file_path.to_str().unwrap(),
+        ),
+        (
+            "client_encryption_options.keyfile",
+            key_file_path.to_str().unwrap(),
+        ),
+    ];
+    node.updateconf(args).await.unwrap();
+}
+
+fn prepare_authority_cert_params() -> CertificateParams {
+    let mut params =
+        CertificateParams::new(vec!["cpp_rs_driver_integration_test_ca".to_owned()]).unwrap();
+    params.distinguished_name = {
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CountryName, "PL");
+        dn.push(DnType::OrganizationName, "scylladb");
+        dn.push(DnType::OrganizationalUnitName, "cpp_rs_driver_ccm_tests");
+        dn.push(DnType::CommonName, "cpp_rs_driver_ccm_tests");
+        dn
+    };
+    params.use_authority_key_identifier_extension = true;
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+
+    params
+}
+
+/// Runs a TLS integration test against a fresh 3-node cluster.
+///
+/// - `prepare_cert` customizes each node's server certificate.
+/// - `cluster_config` applies extra cluster-wide configuration before the
+///   nodes are configured (e.g. enabling client authentication).
+/// - `test` is the actual test body; it receives the CA (so it can build a
+///   matching client trust store) and the running cluster.
+async fn run_ccm_tls_test(
+    prepare_cert: impl Fn(CertificateParams, &Node) -> CertificateParams,
+    cluster_config: impl AsyncFnOnce(Cluster) -> Cluster,
+    test: impl AsyncFnOnce(&CertifiedIssuer<'static, KeyPair>, &mut Cluster),
+) {
+    warn_if_partial_cluster_version();
+
+    let ca_key = KeyPair::generate().unwrap();
+    let params = prepare_authority_cert_params();
+    let ca = Arc::new(CertifiedIssuer::self_signed(params, ca_key).unwrap());
+
+    run_ccm_test_with_configuration(
+        cluster_3_nodes,
+        {
+            let ca = Arc::clone(&ca);
+            |mut cluster: Cluster| async move {
+                let ca_key_file_path = cluster.cluster_dir().join("ca.key");
+                let mut ca_key_file = File::create_new(&ca_key_file_path).await.unwrap();
+                ca_key_file
+                    .write_all(ca.key().serialize_pem().as_bytes())
+                    .await
+                    .unwrap();
+
+                let ca_cert_file_path = cluster.cluster_dir().join("ca.crt");
+                let mut ca_cert_file = File::create_new(&ca_cert_file_path).await.unwrap();
+                ca_cert_file.write_all(ca.pem().as_bytes()).await.unwrap();
+
+                cluster
+                    .updateconf([(
+                        "client_encryption_options.truststore",
+                        ca_cert_file_path.to_str().unwrap(),
+                    )])
+                    .await
+                    .unwrap();
+
+                let mut cluster = cluster_config(cluster).await;
+
+                // The nodes must be configured one at a time. Every `ccm`
+                // invocation loads the whole cluster, reading every node's
+                // `node.conf` (`ClusterFactory.load` -> `Node.load`), while
+                // `ccm <node> updateconf` rewrites its own `node.conf` in
+                // place: `open(path, 'w')` truncates it and only then dumps
+                // the new contents. Run concurrently, one process reads
+                // another's momentarily empty file and ccm dies with
+                // "TypeError: 'NoneType' object is not subscriptable".
+                futures::stream::iter(cluster.nodes_mut().iter_mut())
+                    .for_each(|node| configure_node_tls(node, &ca, &prepare_cert))
+                    .await;
+
+                cluster
+            }
+        },
+        async |cluster: &mut Cluster| test(&ca, cluster).await,
+    )
+    .await
+}
+
+/// Establishes a TLS-enabled session to `contact_points` through the C API and,
+/// if the connection succeeds, runs a trivial health-check query.
+///
+/// Returns the first non-OK [`CassError`] encountered (from connect or from the
+/// health-check), or `CASS_OK` if everything succeeded.
+///
+/// # Safety
+///
+/// Must be called on a thread where blocking is acceptable (it blocks on the
+/// driver futures via `cass_future_wait`).
+unsafe fn connect_and_healthcheck(
+    contact_points: &str,
+    verify_flags: Option<i32>,
+    trust_ca_pem: Option<&str>,
+) -> CassError {
+    unsafe {
+        let mut cluster_raw = cass_cluster_new();
+
+        let contact_points_c = CString::new(contact_points).unwrap();
+        assert_cass_error_eq(
+            CassError::CASS_OK,
+            cass_cluster_set_contact_points(
+                cluster_raw.borrow_mut(),
+                CassStrNulTerminated::from_cstr(&contact_points_c),
+            ),
+        );
+
+        let ssl_raw = cass_ssl_new();
+        if let Some(ca_pem) = trust_ca_pem {
+            let ca_pem_c = CString::new(ca_pem).unwrap();
+            assert_cass_error_eq(
+                CassError::CASS_OK,
+                cass_ssl_add_trusted_cert(
+                    ssl_raw.borrow(),
+                    CassStrNulTerminated::from_cstr(&ca_pem_c),
+                ),
+            );
+        }
+        if let Some(flags) = verify_flags {
+            cass_ssl_set_verify_flags(ssl_raw.borrow(), flags);
+        }
+        cass_cluster_set_ssl(cluster_raw.borrow_mut(), ssl_raw.borrow());
+
+        let session_raw = cass_session_new();
+
+        let connect_fut =
+            cass_session_connect(session_raw.borrow(), cluster_raw.borrow().into_c_const());
+        cass_future_wait(connect_fut.borrow());
+        let connect_err = cass_future_error_code(connect_fut.borrow());
+        cass_future_free(connect_fut);
+
+        let result = if connect_err == CassError::CASS_OK {
+            let query = c"SELECT host_id FROM system.local WHERE key='local'";
+            let statement_raw = cass_statement_new(CassStrNulTerminated::from_cstr(query), 0);
+            let exec_fut =
+                cass_session_execute(session_raw.borrow(), statement_raw.borrow().into_c_const());
+            cass_future_wait(exec_fut.borrow());
+            let exec_err = cass_future_error_code(exec_fut.borrow());
+            cass_future_free(exec_fut);
+            cass_statement_free(statement_raw);
+
+            let close_fut = cass_session_close(session_raw.borrow());
+            cass_future_wait(close_fut.borrow());
+            cass_future_free(close_fut);
+
+            exec_err
+        } else {
+            connect_err
+        };
+
+        cass_session_free(session_raw);
+        cass_ssl_free(ssl_raw);
+        cass_cluster_free(cluster_raw);
+
+        result
+    }
+}
+
+/// Convenience wrapper around [`connect_and_healthcheck`] that derives the
+/// contact points from the cluster and runs the blocking C-API work off the
+/// async runtime.
+async fn try_tls_connect(
+    cluster: &Cluster,
+    verify_flags: Option<i32>,
+    trust_ca_pem: Option<String>,
+) -> CassError {
+    let contact_points = cluster
+        .nodes()
+        .iter()
+        .map(|node| node.broadcast_rpc_address().to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    tokio::task::spawn_blocking(move || unsafe {
+        connect_and_healthcheck(&contact_points, verify_flags, trust_ca_pem.as_deref())
+    })
+    .await
+    .unwrap()
+}
+
+/// Basic TLS test, with the server not requiring client authentication.
+///
+/// Checks that the driver can connect to a TLS-enabled cluster and execute
+/// requests, both with full identity verification and with verification
+/// disabled, and that connecting without a trusted CA fails.
+#[tokio::test]
+async fn connect_tls_no_client_auth() {
+    setup_tracing();
+
+    // Each node's certificate has a SAN matching its own broadcast RPC address.
+    fn prepare_cert(mut params: CertificateParams, node: &Node) -> CertificateParams {
+        params
+            .subject_alt_names
+            .push(SanType::IpAddress(node.broadcast_rpc_address()));
+        params
+    }
+
+    async fn test(ca: &CertifiedIssuer<'static, KeyPair>, cluster: &mut Cluster) {
+        let ca_pem = ca.pem();
+
+        // PEER_IDENTITY: trusted CA, cert SAN matches the node IP -> connects.
+        assert_cass_error_eq(
+            CassError::CASS_OK,
+            try_tls_connect(
+                cluster,
+                Some(CASS_SSL_VERIFY_PEER_IDENTITY),
+                Some(ca_pem.clone()),
+            )
+            .await,
+        );
+
+        // NONE: verification disabled -> connects even without a trusted CA.
+        assert_cass_error_eq(
+            CassError::CASS_OK,
+            try_tls_connect(cluster, Some(CASS_SSL_VERIFY_NONE), None).await,
+        );
+
+        // default: verification disabled -> connects even without a trusted CA.
+        assert_cass_error_eq(
+            CassError::CASS_OK,
+            try_tls_connect(cluster, None, None).await,
+        );
+
+        // PEER_IDENTITY without a trusted CA -> certificate chain validation
+        // fails, so the connection is rejected.
+        let err = try_tls_connect(cluster, Some(CASS_SSL_VERIFY_PEER_IDENTITY), None).await;
+        assert_ne!(
+            err,
+            CassError::CASS_OK,
+            "expected connection to fail when the server CA is not trusted"
+        );
+    }
+
+    run_ccm_tls_test(prepare_cert, async |c| c, test).await
+}

--- a/scylla-rust-wrapper/tests/integration/ccm/tls.rs
+++ b/scylla-rust-wrapper/tests/integration/ccm/tls.rs
@@ -6,6 +6,7 @@
 //! tests, adapted to drive this driver through the C API.
 
 use std::ffi::CString;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
 use futures::StreamExt as _;
@@ -324,6 +325,52 @@ async fn connect_tls_no_client_auth() {
             err,
             CassError::CASS_OK,
             "expected connection to fail when the server CA is not trusted"
+        );
+    }
+
+    run_ccm_tls_test(prepare_cert, async |c| c, test).await
+}
+
+/// Verifies that identity verification is actually enforced: if a node presents
+/// a certificate whose subject alternative name does not match the node's IP
+/// address, the driver must refuse to connect under `PEER_IDENTITY`, while
+/// still connecting under `NONE` (which disables verification entirely).
+///
+/// Port of the Rust Driver's `test_tls_verifies_hostname`.
+#[tokio::test]
+async fn tls_verifies_hostname() {
+    setup_tracing();
+
+    // Every node gets a certificate with a SAN that does not match its IP.
+    fn prepare_cert(mut params: CertificateParams, _node: &Node) -> CertificateParams {
+        params
+            .subject_alt_names
+            .push(SanType::IpAddress(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+        params
+    }
+
+    async fn test(ca: &CertifiedIssuer<'static, KeyPair>, cluster: &mut Cluster) {
+        let ca_pem = ca.pem();
+
+        // PEER_IDENTITY: chain is valid but the SAN does not match the node IP
+        // -> identity verification fails, so the connection is rejected.
+        let err = try_tls_connect(
+            cluster,
+            Some(CASS_SSL_VERIFY_PEER_IDENTITY),
+            Some(ca_pem.clone()),
+        )
+        .await;
+        assert_ne!(
+            err,
+            CassError::CASS_OK,
+            "expected connection to fail: certificate SAN does not match the node IP"
+        );
+
+        // NONE: verification disabled -> the SAN mismatch is ignored and the
+        // connection succeeds.
+        assert_cass_error_eq(
+            CassError::CASS_OK,
+            try_tls_connect(cluster, Some(CASS_SSL_VERIFY_NONE), Some(ca_pem)).await,
         );
     }
 

--- a/scylla-rust-wrapper/tests/integration/ccm/tls.rs
+++ b/scylla-rust-wrapper/tests/integration/ccm/tls.rs
@@ -46,6 +46,7 @@ use super::warn_if_partial_cluster_version;
 // The Rust constants in the driver are crate-private, so we redefine the ABI
 // values here, exactly as a C consumer would use them.
 const CASS_SSL_VERIFY_NONE: i32 = 0x00;
+const CASS_SSL_VERIFY_PEER_CERT: i32 = 0x01;
 const CASS_SSL_VERIFY_PEER_IDENTITY: i32 = 0x02;
 
 fn cluster_3_nodes() -> ClusterOptions {
@@ -477,4 +478,47 @@ async fn connect_tls_with_client_auth() {
     }
 
     run_ccm_tls_test(prepare_cert, require_client_auth, test).await
+}
+
+/// Documents the *desired* semantics of `CASS_SSL_VERIFY_PEER_CERT`: it should
+/// validate the certificate chain only, without checking the peer identity
+/// (IP SAN). This is not implemented yet — currently `PEER_CERT` is equivalent
+/// to `PEER_IDENTITY` because the underlying Rust driver always verifies the
+/// node IP. The test is therefore `#[ignore]`d; un-ignore it once chain-only
+/// `PEER_CERT` support lands.
+#[tokio::test]
+#[ignore = "PEER_CERT currently behaves like PEER_IDENTITY (verifies the IP SAN); \
+            chain-only PEER_CERT support is not implemented yet"]
+async fn tls_peer_cert_verifies_chain_only() {
+    setup_tracing();
+
+    // The SAN deliberately does not match the node IP, to prove that PEER_CERT
+    // ignores the peer identity while still validating the certificate chain.
+    fn prepare_cert(mut params: CertificateParams, _node: &Node) -> CertificateParams {
+        params
+            .subject_alt_names
+            .push(SanType::IpAddress(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+        params
+    }
+
+    async fn test(ca: &CertifiedIssuer<'static, KeyPair>, cluster: &mut Cluster) {
+        let ca_pem = ca.pem();
+
+        // Desired: PEER_CERT verifies only the chain, so a SAN mismatch is
+        // tolerated as long as the CA is trusted.
+        assert_cass_error_eq(
+            CassError::CASS_OK,
+            try_tls_connect(cluster, Some(CASS_SSL_VERIFY_PEER_CERT), Some(ca_pem), None).await,
+        );
+
+        // But the chain is still validated: an untrusted CA must be rejected.
+        let err = try_tls_connect(cluster, Some(CASS_SSL_VERIFY_PEER_CERT), None, None).await;
+        assert_ne!(
+            err,
+            CassError::CASS_OK,
+            "PEER_CERT must still validate the certificate chain"
+        );
+    }
+
+    run_ccm_tls_test(prepare_cert, async |c| c, test).await
 }

--- a/scylla-rust-wrapper/tests/integration/main.rs
+++ b/scylla-rust-wrapper/tests/integration/main.rs
@@ -1,3 +1,4 @@
+mod ccm;
 mod consistency;
 mod session;
 mod utils;


### PR DESCRIPTION
## Background / Motivation

Someone noticed that our TLS verification default did not match what we
document. `include/cassandra.h` claimed:

```
 * <b>Default:</b> CASS_SSL_VERIFY_PEER_CERT
```

while `cass_ssl_new_no_lib_init()` actually did:

```rust
SSL_CTX_set_verify(ssl_context, CASS_SSL_VERIFY_NONE, None);
```

`CASS_SSL_VERIFY_NONE` is `0x00`, which happens to be `SSL_VERIFY_NONE` too, so the effective default was **no peer verification whatsoever** — the exact opposite of what the header promised, and a security-relevant discrepancy: a
user who read the docs and did not call `cass_ssl_set_verify_flags()` believed the server certificate was being validated when it was not.

Looking into it, I found the more fundamental problem: **none of this was tested**. There was no coverage of TLS at all on the Rust side — no test would have caught the wrong default, and no test would catch us breaking it again.
`cass_ssl_set_verify_flags()` was similarly untested, and it showed: unknown flag values silently fell through to a catch-all arm that enabled `SSL_VERIFY_PEER`, so passing garbage quietly changed the security settings.

This PR does one thing: **adds real end-to-end TLS tests**.
A follow up PR will use them to validate the fixed defaults and the flag handling, and finally implement correctly the one flag (`CASS_SSL_VERIFY_PEER_CERT`) we did not respect before due to Rust Driver's behavioural change (turning on hostname verification in OpenSSL - https://github.com/scylladb/scylla-rust-driver/pull/1491).

## What's done

### Appetizers

- added docstring and docs checkboxes to the PR template. They were missing.
- Makefile: bumped ScyllaDB version to 2026.2.2. This also reduce testing time via CCM enormously, because the previous version was not a full SemVer release - it was missing patch number - which caused a web request to S3 on each ccm operation (see https://github.com/scylladb/scylla-ccm/issues/771 for more details).

### Updated docs to mention TLS verification's actual default

There was a discrepancy between the documentation and the actual default value of the SSL verification option in the `cassandra.h` header file. The documentation stated that the default was `CASS_SSL_VERIFY_PEER_CERT`, but in reality, it was set to `CASS_SSL_VERIFY_NONE`.
Note that this change is only to align the documentation with the actual behavior of the code. The default value of the SSL verification option should likely be changed to enable verification, but that requires further changes, so is left for a follow-up.

### Bumped Rust Driver

- ran `cargo update`.
- got new Rust Driver's fixes.
- got access to recently extracted `scylla-ccm-bridge`, which we will use for writing CCM tests in Rust.

### Tests written

End-to-end TLS tests that drive the driver through its **C API**, exactly as a C/C++ consumer would, against a real TLS-enabled ScyllaDB cluster. They are ports of the Rust Driver's `ccm::tls` tests.

The clusters are managed from Rust via the **`scylla-ccm-bridge` crate from the Rust Driver**, added as a dev-dependency. That lets us write CCM tests in Rust rather than going through the C++ CCM harness, which makes them far easier to maintain. Certificates are generated on the fly with `rcgen`, so there is nothing checked in and nothing to rotate: the harness creates a CA, issues a per-node server certificate, installs it via `ccm <node> updateconf`, and hands the CA to the test so it can build a matching client trust store.

One practical note for anyone running these locally: pass a **fully-qualified** cluster version. `scylla-ccm` re-resolves the version on *every* `ccm` invocation, and a partial one such as `release:2026.2` makes it list an S3 bucket and sleep for a random 0–5 seconds each time, which dominates the runtime (~31 s vs ~8 s for the whole suite). The default in the Makefile is fully qualified, and the harness warns if `SCYLLA_TEST_CLUSTER` is not.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have implemented Rust unit tests for the features/changes introduced.
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~

