### PR TITLE
IT: fight flakiness in C++ integration test_metrics

### DIFF
--- a/tests/src/integration/tests/test_metrics.cpp
+++ b/tests/src/integration/tests/test_metrics.cpp
@@ -16,6 +16,12 @@
 
 #include "integration.hpp"
 
+#ifdef _WIN32
+#include <stdlib.h>
+#else
+#include <unistd.h>
+#endif
+
 #define SPECULATIVE_EXECUTION_SELECT_FORMAT "SELECT timeout(value) FROM %s.%s WHERE key=%d"
 #define SPECULATIVE_EXECUTION_CREATE_TIMEOUT_UDF_FORMAT   \
   "CREATE OR REPLACE FUNCTION %s.timeout(arg int) "       \
@@ -55,7 +61,15 @@ CASSANDRA_INTEGRATION_TEST_F(MetricsTests, StatsConnections) {
   EXPECT_EQ(1u, metrics.stats.total_connections);
 
   start_node(1);
-  metrics = session.metrics();
+  // `start_node()` finish may race with driver's reconnecting to the node.
+  // Let's give the driver more time to reconnect to fight flakiness.
+  for (unsigned i = 0; i < 50; ++i) {
+    metrics = session.metrics();
+    if (metrics.stats.total_connections == 2) {
+        break;
+    }
+    msleep(1);
+  }
   EXPECT_EQ(2u, metrics.stats.total_connections);
 }
 


### PR DESCRIPTION
The CI suddenly started failing the test. I added a short sleep loop to recover if a suspected race occurs.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
