### PR TITLE
docs: build each version's API reference from its own headers

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import re
+import subprocess
 import sys
 import warnings
 import xml.etree.ElementTree as ET
@@ -144,12 +145,11 @@ def _generate_groups(outdir, groups, project):
             )
 
 
-def _generate_doxygen_rst(xmldir, outdir):
+def _generate_doxygen_rst(xml_path, outdir):
     """Autogenerate doxygen docs in the designated outdir folder"""
     structs = []
     groups = []
     group_structs = set()
-    xml_path = os.path.join(os.path.dirname(__file__), xmldir)
     files = os.listdir(xml_path)
     for file_name in files:
         if file_name.startswith("group__") and file_name.endswith(".xml"):
@@ -176,9 +176,22 @@ def _generate_doxygen_rst(xmldir, outdir):
     _generate_groups(outdir, groups, breathe_default_project)
 
 
+def _resolve_doxygen_xml(xmldir, srcdir):
+    real_xml = os.path.abspath(os.path.join(os.path.dirname(__file__), xmldir))
+    checkout_xml = os.path.abspath(os.path.join(srcdir, xmldir))
+    if checkout_xml != real_xml:
+        checkout_root = os.path.abspath(os.path.join(srcdir, "..", ".."))
+        subprocess.run(["doxygen", "Doxyfile.in"], cwd=checkout_root, check=True)
+        return checkout_xml
+    return real_xml
+
+
 def generate_doxygen(app):
-    DOXYGEN_XML_DIR = breathe_projects[breathe_default_project]
-    _generate_doxygen_rst(DOXYGEN_XML_DIR, app.builder.srcdir / "api")
+    xml_path = _resolve_doxygen_xml(
+        breathe_projects[breathe_default_project], app.builder.srcdir
+    )
+    app.config.breathe_projects = {breathe_default_project: xml_path}
+    _generate_doxygen_rst(xml_path, app.builder.srcdir / "api")
 
 
 # -- Options for sitemap extension

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import re
+import shutil
 import subprocess
 import sys
 import warnings
@@ -180,8 +181,11 @@ def _resolve_doxygen_xml(xmldir, srcdir):
     real_xml = os.path.abspath(os.path.join(os.path.dirname(__file__), xmldir))
     checkout_xml = os.path.abspath(os.path.join(srcdir, xmldir))
     if checkout_xml != real_xml:
+        doxygen = shutil.which("doxygen")
+        if doxygen is None:
+            raise RuntimeError("doxygen not found in PATH (run 'make setup')")
         checkout_root = os.path.abspath(os.path.join(srcdir, "..", ".."))
-        subprocess.run(["doxygen", "Doxyfile.in"], cwd=checkout_root, check=True)
+        subprocess.run([doxygen, "Doxyfile.in"], cwd=checkout_root, check=True)
         return checkout_xml
     return real_xml
 


### PR DESCRIPTION
## Problem

Doxygen runs once against the working tree (default branch), and sphinx-multiversion builds every version with that single XML output. As a result, all published versions render the API reference from master's headers. For example, `v1.0.0` shows `group.*` pages even though grouping did not exist in its headers yet.

## Solution

Run `doxygen Doxyfile.in` inside each version's git checkout and point breathe at that output, so each version's API reference is built from its own headers.

## How to test

```sh
cd docs
make multiversion
```

- `_build/dirhtml/v1.0.0/api/` contains only `struct.*` pages (39, no `group.*`), matching its headers.
- `_build/dirhtml/master/api/` and `stable/api/` contain the `group.*` pages (45 total).