### PR TITLE
docs: fix llms.txt generation under multiversion

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,6 +81,14 @@ notfound_urls_prefix = ""
 
 sitemap_url_scheme = "/stable/{link}"
 
+# -- Options for llms.txt extension ---------------------------------
+
+# Run the llms.txt markdown pass after the main build finishes. Under
+# sphinx-multiversion the markdown subprocess re-reads the temporary git
+# checkout with the checked-out conf.py, which rewrites the generated
+# api/*.rst sources; building sequentially avoids racing the main build.
+llms_txt_build_parallel = False
+
 # -- Options for multiversion extension -----------------------------
 
 # Whitelist pattern for tags


### PR DESCRIPTION
Closes https://github.com/scylladb/scylladb-docs-homepage/issues/254

Fixes broken links (llms.txt and .md file) not generated in API related pages.

## How to test

```sh
cd docs
make multiversion
```

For each version directory in `docs/_build/dirhtml/` (`v1.0.0/`, `v1.0.1/`, `v1.1.0/`, `stable/`, `master/`):

- `llms.txt` and `llms-full.txt` exist, with links prefixed by that version.
- Flat `.md` files exist next to the pages, including `api/*.md` and `topics/**/*.md`.