### PR TITLE
Release 1.1.1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,16 +15,16 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Global variables
 
 # Builds documentation for the following tags and branches.
-TAGS = ["v1.0.0", "v1.0.1", "v1.1.0"]
+TAGS = ["v1.0.0", "v1.0.1", "v1.1.0", "v1.1.1"]
 BRANCHES = [
     "master",
 ]
 # Sets the latest version.
-LATEST_VERSION = "v1.1.0"
+LATEST_VERSION = "v1.1.1"
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ["v1.0.0", "v1.0.1"]
+DEPRECATED_VERSIONS = ["v1.0.0", "v1.0.1", "v1.1.0"]
 # Sets custom build.
 FLAGS = ["theme"]
 

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -53,7 +53,7 @@
 
 #define CASS_VERSION_MAJOR 1
 #define CASS_VERSION_MINOR 1
-#define CASS_VERSION_PATCH 0
+#define CASS_VERSION_PATCH 1
 #define CASS_VERSION_SUFFIX ""
 
 #ifdef __cplusplus

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-rust-wrapper"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arc-swap",
  "assert_matches",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-rust-wrapper"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"
 repository = "https://github.com/scylladb/scylla-rust-driver"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB CPP RS Driver 1.1.1, an API-compatible rewrite of https://github.com/scylladb/cpp-driver as a wrapper for the Rust driver. It fully replaces the CPP driver, which has already reached its End of Life.

Some minor features still need to be included. See Limitations section in README.md.

The underlying Rust Driver used version: 9ab7216d4d32eb249dbd9929c9d3592711b800da (a commit on main branch, on top of 1.7.0).

## Changes since 1.1.0:

Changes from Rust Driver that can impact this driver are included in the changelog. Those changes are be marked with the crab emoji 🦀.

Entries that require special attention (e.g. because of potential build system or application breakage) are marked with the warning emoji ⚠️.

**Enhancements / new features:**
- Bumped Rust Driver to 9ab7216d4d32eb249dbd9929c9d3592711b800da ([#489](https://github.com/scylladb/cpp-rs-driver/pull/489)).
- 🦀 Improved hostname resolution logic. ([#1805](https://github.com/scylladb/scylla-rust-driver/pull/1805)).
- 🦀 Info about tablet keyspaces is now fetched from `system_schema.scylla_keyspaces` ([#1720](https://github.com/scylladb/scylla-rust-driver/pull/1720)).
- 🦀 More robust Scylla recognition ([#1719](https://github.com/scylladb/scylla-rust-driver/pull/1719)).
- 🦀 Back off from advanced shard awareness on shard mismatch, avoiding pointless connection attempts in NAT scenarios ([#1804](https://github.com/scylladb/scylla-rust-driver/pull/1804)).
- 🦀 Immediate keepalive is now triggered on STATUS_CHANGE DOWN, reducing delay in recognizing that a node is down and avoiding routing requests to it ([#1806](https://github.com/scylladb/scylla-rust-driver/pull/1806)).
- 🦀 Out-of-range shard ids in sharding info is now correctly rejected ([#1712](https://github.com/scylladb/scylla-rust-driver/pull/1712)).

**Bug fixes:**
- ⚠️ Fixed TLS verification settings ([#488](https://github.com/scylladb/cpp-rs-driver/pull/488)):
  - `CASS_SSL_VERIFY_PEER_CERT` is now correctly supported. Before, it would also verify peer's identity, behaving as `CASS_SSL_VERIFY_PEER_IDENTITY`.
  - `CASS_SSL_VERIFY_PEER_CERT` is now really set by default, respecting what documentation said; your application may have worked with invalid certificates because `CASS_SSL_VERIFY_NONE` was wrongly set as the default. Now, as the default is truly `CASS_SSL_VERIFY_PEER_CERT`, it might break; this is a bug fix which unhides misconfiguration.
  - `CASS_SSL_VERIFY_PEER_IDENTITY` is now supported.
- 🦀 Fixed bug in `Metrics::get_latency_percentile_ms` ([#1749](https://github.com/scylladb/scylla-rust-driver/pull/1749)).
- 🦀 Fixed tablets Materialized Views bug ([#1778](https://github.com/scylladb/scylla-rust-driver/pull/1778)).
- 🦀 Fixed shard set in Coordinator ([#1765](https://github.com/scylladb/scylla-rust-driver/pull/1765)).
- 🦀 Fixed paged request metrics ([#1775](https://github.com/scylladb/scylla-rust-driver/pull/1775)).

**Documentation:**
- Updated docs dependencies ([#483](https://github.com/scylladb/cpp-rs-driver/pull/483)).
- Bumped sphinx-scylladb-theme from 1.9.2 to 1.9.3 in /docs ([#487](https://github.com/scylladb/cpp-rs-driver/pull/487)).
- Made documentation build each version's API reference from its own headers ([#491](https://github.com/scylladb/cpp-rs-driver/pull/491)).
- Fixed llms.txt generation under multiversion ([#492](https://github.com/scylladb/cpp-rs-driver/pull/492)).

**CI / testing improvements:**
- Added TLS testing via CCM ([#489](https://github.com/scylladb/cpp-rs-driver/pull/489)).
- Fought flakiness in C++ integration test_metrics ([#490](https://github.com/scylladb/cpp-rs-driver/pull/490)).
- Migrated RequestTimeout test to Rust using proxy ([#493](https://github.com/scylladb/cpp-rs-driver/pull/493)).

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/cpp-rs-driver](https://github.com/scylladb/cpp-rs-driver)

Contributions are most welcome!

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!


Contributors since 1.1.0:

| commits | author                 |
|---------|------------------------|
| 32      |  Wojciech Przytuła     |
|  3      |  David Garcia          |
|  1      |  Anna Stuchlik         |
|  1      |  Karol Baryła          |
|  1      |  dependabot[bot]       |
