### PR TITLE
bump Rust Driver to 1.8.0

### DIFF
--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1195,8 +1195,8 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "1.7.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
+version = "1.8.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.8.0#d704be5ea64bffc0e2e9c90fc856bf753a08225b"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1224,7 +1224,7 @@ dependencies = [
 [[package]]
 name = "scylla-ccm-bridge"
 version = "0.0.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.8.0#d704be5ea64bffc0e2e9c90fc856bf753a08225b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1240,8 +1240,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "1.7.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
+version = "1.8.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.8.0#d704be5ea64bffc0e2e9c90fc856bf753a08225b"
 dependencies = [
  "byteorder",
  "bytes",
@@ -1259,8 +1259,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql-core"
-version = "1.7.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
+version = "1.8.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.8.0#d704be5ea64bffc0e2e9c90fc856bf753a08225b"
 dependencies = [
  "byteorder",
  "bytes",
@@ -1273,8 +1273,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "1.7.0"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
+version = "1.8.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.8.0#d704be5ea64bffc0e2e9c90fc856bf753a08225b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1284,8 +1284,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-proxy"
-version = "0.0.6"
-source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=9ab7216d4d32eb249dbd9929c9d3592711b800da#9ab7216d4d32eb249dbd9929c9d3592711b800da"
+version = "0.0.7"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=v1.8.0#d704be5ea64bffc0e2e9c90fc856bf753a08225b"
 dependencies = [
  "bytes",
  "futures",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.88"
 
 [dependencies]
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9ab7216d4d32eb249dbd9929c9d3592711b800da", features = [
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.8.0", features = [
     "openssl-010",
     "metrics",
     "unstable-cpp-rs",
@@ -38,9 +38,9 @@ bindgen = "0.65"
 chrono = "0.4.20"
 
 [dev-dependencies]
-scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9ab7216d4d32eb249dbd9929c9d3592711b800da" }
-scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9ab7216d4d32eb249dbd9929c9d3592711b800da" }
-scylla-ccm-bridge = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "9ab7216d4d32eb249dbd9929c9d3592711b800da" }
+scylla-proxy = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.8.0" }
+scylla-cql = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.8.0" }
+scylla-ccm-bridge = { git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "v1.8.0" }
 bytes = "1.10.0"
 itertools = "0.10.3"
 assert_matches = "1.5.0"

--- a/tests/src/integration/tests/test_control_connection.cpp
+++ b/tests/src/integration/tests/test_control_connection.cpp
@@ -132,7 +132,8 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests, ConnectUsingInvalidIpAddres
   CHECK_FAILURE;
 
   // Attempt to connect to the server using an invalid IP address
-  logger_.add_critera("Could not fetch metadata, error: "
+  logger_.add_critera("Failed to establish control connection, "
+                      "control_connection_address: 1.1.1.1:9042, error: "
                       "Control connection pool error: The pool is broken; "
                       "Last connection failed with: Connect timeout elapsed");
   Cluster cluster = Cluster::build().with_contact_points("1.1.1.1");
@@ -204,7 +205,8 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests, ConnectUsingUnbindableLocal
   CHECK_FAILURE;
 
   // Attempt to connect to the server using an unbindable local IP address
-  logger_.add_critera("Could not fetch metadata, error: "
+  logger_.add_critera("Failed to establish control connection, "
+                      "control_connection_address: 127.0.0.1:9042, error: "
                       "Control connection pool error: The pool is broken; "
                       "Last connection failed with: Cannot assign requested address");
   Cluster cluster = default_cluster().with_local_address("1.1.1.1");
@@ -236,7 +238,8 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests,
   // Attempt to connect to the server using an valid local IP address
   // but invalid remote address. The specified remote is not routable
   // from the specified local.
-  logger_.add_critera("Could not fetch metadata, error: "
+  logger_.add_critera("Failed to establish control connection, "
+                      "control_connection_address: 1.1.1.1:9042, error: "
                       "Control connection pool error: The pool is broken; "
                       "Last connection failed with: Invalid argument");
   Cluster cluster = Cluster::build().with_contact_points("1.1.1.1").with_local_address("127.0.0.1");

--- a/tests/src/integration/tests/test_control_connection.cpp
+++ b/tests/src/integration/tests/test_control_connection.cpp
@@ -206,7 +206,8 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests, ConnectUsingUnbindableLocal
 
   // Attempt to connect to the server using an unbindable local IP address
   logger_.add_critera("Failed to establish control connection, "
-                      "control_connection_address: 127.0.0.1:9042, error: "
+                      "control_connection_address: " + ccm_->get_ip_prefix() +
+                      "1:9042, error: "
                       "Control connection pool error: The pool is broken; "
                       "Last connection failed with: Cannot assign requested address");
   Cluster cluster = default_cluster().with_local_address("1.1.1.1");


### PR DESCRIPTION
As a result of the bump, some tests from ControlConnectionTests broke, because some log messages changed. The tests are adjusted for the new contents.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
