### PR TITLE
Enable more ControlConnectionTests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_RoundRobin\
 :ExecutionProfileTest.Integration_Cassandra_TokenAwareRouting\
 :ExecutionProfileTest.Integration_Cassandra_SpeculativeExecutionPolicy\
-:ControlConnectionTests.Integration_Cassandra_TopologyChange\
 :ControlConnectionTests.Integration_Cassandra_TerminatedUsingMultipleIoThreadsWithError\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionAlreadyExists\

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ SCYLLA_TEST_FILTER := $(subst ${SPACE},${EMPTY},ClusterTests.*\
 :ExecutionProfileTest.Integration_Cassandra_TokenAwareRouting\
 :ExecutionProfileTest.Integration_Cassandra_SpeculativeExecutionPolicy\
 :ControlConnectionTests.Integration_Cassandra_TopologyChange\
-:ControlConnectionTests.Integration_Cassandra_FullOutage\
 :ControlConnectionTests.Integration_Cassandra_TerminatedUsingMultipleIoThreadsWithError\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure\
 :ServerSideFailureTests.Integration_Cassandra_ErrorFunctionAlreadyExists\

--- a/tests/src/integration/ccm/bridge.cpp
+++ b/tests/src/integration/ccm/bridge.cpp
@@ -653,6 +653,8 @@ unsigned int CCM::Bridge::add_node(const std::string& data_center /*= ""*/) {
   }
   if (is_dse()) {
     add_node_command.push_back("--dse");
+  } else if (is_scylla_) {
+    add_node_command.push_back("--scylla");
   }
   add_node_command.push_back(generate_node_name(node));
   execute_ccm_command(add_node_command);

--- a/tests/src/integration/tests/test_control_connection.cpp
+++ b/tests/src/integration/tests/test_control_connection.cpp
@@ -577,7 +577,7 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests, FullOutage) {
   for (unsigned short i = 0; i < cluster_ip_addresses.size(); ++i) {
     nodes.insert(i + 1);
   }
-  reset_logger_criteria("reconnect for host ", nodes);
+  reset_logger_criteria("Node is now reachable again: ", nodes);
 
   // Restart the cluster and wait for the nodes to reconnect
   ccm_->start_cluster();

--- a/tests/src/integration/tests/test_control_connection.cpp
+++ b/tests/src/integration/tests/test_control_connection.cpp
@@ -327,7 +327,9 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests, TopologyChange) {
   Session session = cluster.connect();
 
   // Bootstrap a second node and ensure all hosts are actively used
-  logger_.add_critera("New node " + (ccm_->get_ip_prefix() + "2") + " added");
+  // Match the tail of "Node added to cluster: <host_id> - <address>" since the
+  // host_id is not known ahead of time.
+  logger_.add_critera("- " + (ccm_->get_ip_prefix() + "2") + ":9042");
   EXPECT_EQ(2u, ccm_->bootstrap_node()); // Triggers a `NEW_NODE` event
   EXPECT_TRUE(wait_for_logger(1));
   std::set<unsigned short> expected_nodes;


### PR DESCRIPTION
This PR enables some tests from `ControlConnectionTests` suite: `FullOutage` and `TopologyChange`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- [x] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
