### PR TITLE
Allow changing log level on the fly

### DIFF
--- a/docs/source/topics/observability/logging.md
+++ b/docs/source/topics/observability/logging.md
@@ -2,11 +2,11 @@
 
 The driver's logging system uses `stderr` by default and the log level `CASS_LOG_WARN`. Both of these settings can be changed using the driver's `cass_log_*()` configuration functions.
 
-**Important**: Logging configuration must be done before calling any other driver function.
+Logging can be configured at any point of the driver's lifetime, any number of times. Note, though, that events emitted before a custom logging callback is installed are handled by the default one, i.e. printed to `stderr`.
 
 ## Log Level
 
-To update the log level use `cass_log_set_level()`.
+To update the log level use `cass_log_set_level()`. It may be called at any time, and as many times as needed - the new level applies to all events emitted afterwards. Pass `CASS_LOG_DISABLED` to silence the driver completely.
 
 ```c
 cass_log_set_level(CASS_LOG_INFO);

--- a/docs/source/topics/observability/logging.md
+++ b/docs/source/topics/observability/logging.md
@@ -2,11 +2,13 @@
 
 The driver's logging system uses `stderr` by default and the log level `CASS_LOG_WARN`. Both of these settings can be changed using the driver's `cass_log_*()` configuration functions.
 
-Logging can be configured at any point of the driver's lifetime, any number of times. Note, though, that events emitted before a custom logging callback is installed are handled by the default one, i.e. printed to `stderr`.
+**Important**: Only setting the log level before any other interaction with the driver's API is fully supported. Support for altering the log level during the driver's operation is experimental, might misbehave (by displaying more or fewer logs than expected), and may be removed in the future.
 
 ## Log Level
 
-To update the log level use `cass_log_set_level()`. It may be called at any time, and as many times as needed - the new level applies to all events emitted afterwards. Pass `CASS_LOG_DISABLED` to silence the driver completely.
+To update the log level use `cass_log_set_level()`. Pass `CASS_LOG_DISABLED` to silence the driver completely.
+
+Set the level once, before calling any other driver function. Setting it later, or more than once, is experimental - see the notice above. Note also that events emitted before a custom logging callback is installed are handled by the default one, i.e. printed to `stderr`.
 
 ```c
 cass_log_set_level(CASS_LOG_INFO);

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -10296,6 +10296,12 @@ cass_error_desc(CassError error);
  *
  * @ingroup Logging
  *
+ * <b>Note:</b> Only setting the log level before any other interaction with
+ * the driver's API is fully supported. Support for altering the log level
+ * during the driver's operation is experimental, might misbehave (by
+ * displaying more or fewer logs than expected), and may be removed in the
+ * future.
+ *
  * <b>Default:</b> CASS_LOG_WARN
  *
  * @param[in] log_level

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -10296,9 +10296,6 @@ cass_error_desc(CassError error);
  *
  * @ingroup Logging
  *
- * <b>Note:</b> This needs to be done before any call that might log, such as
- * any of the cass_cluster_*() or cass_ssl_*() functions.
- *
  * <b>Default:</b> CASS_LOG_WARN
  *
  * @param[in] log_level

--- a/scylla-rust-wrapper/src/cluster.rs
+++ b/scylla-rust-wrapper/src/cluster.rs
@@ -11,6 +11,7 @@ use crate::host_listener::CCallbackBasedHostListener;
 use crate::load_balancing::{
     CassHostFilter, DcRestriction, LoadBalancingConfig, LoadBalancingKind,
 };
+use crate::logging::init_logging;
 use crate::retry_policy::CassRetryPolicy;
 use crate::runtime::{RUNTIMES, Runtime};
 use crate::ssl::CassSsl;
@@ -220,6 +221,8 @@ impl CassCluster {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_cluster_new() -> CassOwnedExclusivePtr<CassCluster, CMut> {
+    init_logging();
+
     let default_execution_profile_builder = ExecutionProfileBuilder::default()
         .consistency(DEFAULT_CONSISTENCY)
         .serial_consistency(DEFAULT_SERIAL_CONSISTENCY)

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -271,3 +271,101 @@ pub unsafe extern "C" fn cass_log_get_callback_and_data(
         *data_out = logger.data;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::os::raw::c_void;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use rusty_fork::rusty_fork_test;
+    use tracing::{error, info, warn};
+
+    use crate::argconv::{CConst, CassBorrowedSharedPtr};
+    use crate::cass_log_types::{CassLogLevel, CassLogMessage};
+
+    use super::{cass_log_set_callback, cass_log_set_level};
+
+    /// Counts the log events that made it through the driver's filter
+    /// to the user-provided log callback.
+    #[derive(Default)]
+    struct EventCounter(AtomicUsize);
+
+    impl EventCounter {
+        /// Returns the number of events captured since the previous call.
+        fn take(&self) -> usize {
+            self.0.swap(0, Ordering::SeqCst)
+        }
+    }
+
+    unsafe extern "C" fn counting_log_callback(
+        _message: CassBorrowedSharedPtr<CassLogMessage, CConst>,
+        data: *mut c_void,
+    ) {
+        let counter = unsafe { &*(data as *const EventCounter) };
+        counter.0.fetch_add(1, Ordering::SeqCst);
+    }
+
+    rusty_fork_test! {
+        #[test]
+        /// Verifies that the log level can be set at any point of the driver's
+        /// lifetime, any number of times.
+        ///
+        /// This is run with rusty_fork in order to have a fresh process. The
+        /// tracing subscriber is global and can only be installed once, so the
+        /// test must neither share a process with other tests (which install
+        /// their own subscriber via `setup_tracing`) nor with another run of
+        /// itself. For the same reason the test must not call `setup_tracing`.
+        fn log_level_is_mutable() {
+            let counter = EventCounter::default();
+            let data = std::ptr::from_ref(&counter).cast::<c_void>().cast_mut();
+
+            // Each of these emits from a single tracing callsite, no matter how
+            // many times it is called. Reusing them across log level changes is
+            // what makes this test cover the invalidation of tracing's interest
+            // cache, which memoizes per-callsite whether anyone is interested
+            // in its events.
+            let emit_info = || info!("An INFO event");
+            let emit_warn = || warn!("A WARN event");
+            let emit_error = || error!("An ERROR event");
+
+            // An event emitted before any `cass_log_set_level` call already
+            // reaches the callback, at the default (WARN) level...
+            unsafe { cass_log_set_callback(Some(counting_log_callback), data) };
+            emit_warn();
+            assert_eq!(counter.take(), 1);
+
+            // ...and one below that level does not.
+            emit_info();
+            assert_eq!(counter.take(), 0);
+
+            // Lowering the level admits more events, including from callsites
+            // whose events were already filtered out above.
+            unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_TRACE) };
+            counter.take(); // Discard the driver's own log about the change.
+            emit_info();
+            assert_eq!(counter.take(), 1);
+
+            // Raising it filters them out again - the level is mutable both
+            // ways, also for callsites that were admitted a moment ago.
+            unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_ERROR) };
+            counter.take();
+            emit_info();
+            emit_warn();
+            assert_eq!(counter.take(), 0);
+            emit_error();
+            assert_eq!(counter.take(), 1);
+
+            // Logging can be disabled entirely...
+            unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_DISABLED) };
+            counter.take();
+            emit_error();
+            assert_eq!(counter.take(), 0);
+
+            // ...and enabled back again.
+            unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_WARN) };
+            counter.take();
+            emit_warn();
+            assert_eq!(counter.take(), 1);
+        }
+    }
+}

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -7,6 +7,7 @@ use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::fmt::Write;
 use std::os::raw::{c_char, c_void};
+use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::Level;
 use tracing::debug;
@@ -15,6 +16,7 @@ use tracing_subscriber::Layer;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::prelude::*;
+use tracing_subscriber::reload;
 
 impl FFI for CassLogMessage {
     type Origin = FromRef;
@@ -154,28 +156,63 @@ where
     }
 }
 
-// Sets tracing subscriber with specified `level`.
-// The subscriber is valid for the duration of the entire program.
-pub(crate) fn set_tracing_subscriber_with_level(level: Level) {
+/// The log level that the driver starts with, before the user calls
+/// [`cass_log_set_level`]. It matches the cpp-driver's default.
+const DEFAULT_LOG_LEVEL: Level = Level::WARN;
+
+/// A handle that allows mutating the level of the filter of the tracing
+/// subscriber installed by the driver.
+type LogLevelHandle = reload::Handle<LevelFilter, tracing_subscriber::Registry>;
+
+/// Installs the driver's global tracing subscriber upon first access,
+/// and yields the handle used to mutate its log level later on.
+///
+/// The handle is `None` if some other tracing subscriber was already installed
+/// globally - be it by the application that embeds the driver, or by the
+/// driver's own unit tests. In such case the driver does not own the logging
+/// configuration, and thus must not (and cannot) change the log level.
+static LOG_LEVEL_HANDLE: LazyLock<Option<LogLevelHandle>> = LazyLock::new(|| {
+    let (filter, handle) = reload::Layer::new(LevelFilter::from_level(DEFAULT_LOG_LEVEL));
+
     tracing::subscriber::set_global_default(
         tracing_subscriber::registry()
-            .with(LevelFilter::from_level(level))
+            .with(filter)
             .with(CustomLayer),
     )
-    .unwrap_or(()) // Ignore if it is set already
+    .ok()
+    .map(|()| handle)
+});
+
+/// Makes sure that the driver's tracing subscriber is installed.
+///
+/// This is idempotent and cheap (an atomic load after the first call), so it
+/// can be called from any entry point that could be the first one that the
+/// application calls.
+pub(crate) fn init_logging() {
+    LazyLock::force(&LOG_LEVEL_HANDLE);
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_log_set_level(log_level: CassLogLevel) {
+    init_logging();
+
     if log_level == CassLogLevel::CASS_LOG_DISABLED {
         debug!("Logging is disabled!");
         return;
     }
 
-    let level = Level::try_from(log_level).unwrap_or(Level::WARN);
+    let level = Level::try_from(log_level).unwrap_or(DEFAULT_LOG_LEVEL);
 
-    // Sets the tracing subscriber with new log level.
-    set_tracing_subscriber_with_level(level);
+    let Some(handle) = LOG_LEVEL_HANDLE.as_ref() else {
+        // Some other tracing subscriber is installed globally. Not ours to reconfigure.
+        return;
+    };
+
+    // The only possible error is a poisoned lock inside the handle, which can
+    // only happen if a previous `modify` panicked. Nothing we can do about it.
+    let _ = handle.modify(|filter| *filter = LevelFilter::from_level(level));
+
+    // Emitted after the update, so that it appears iff the new level admits it.
     debug!("Log level is set to {}", level);
 }
 

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -205,6 +205,12 @@ pub(crate) fn init_logging() {
     LazyLock::force(&LOG_LEVEL_HANDLE);
 }
 
+/// Sets the log level.
+///
+/// Only setting the log level before any other interaction with the driver's
+/// API is fully supported. Support for altering the log level during the
+/// driver's operation is experimental, might misbehave (by displaying more or
+/// fewer logs than expected), and may be removed in the future.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_log_set_level(log_level: CassLogLevel) {
     init_logging();

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -400,5 +400,77 @@ mod tests {
             unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_ERROR) };
             assert!(make_request_span().is_disabled());
         }
+
+        #[test]
+        /// Verifies that log events follow the current log level even when they
+        /// are emitted from inside a span that was created before the level
+        /// changed - possibly while that span was disabled.
+        ///
+        /// This is what makes the logs of the driver's long-running tasks
+        /// (the per-connection router, the connection pool refiller, the
+        /// cluster and metadata workers) react to a level change. Those tasks
+        /// are not instrumented with any span at all, and all their events are
+        /// plain callsites, so both cases covered here apply to them.
+        ///
+        /// The enabledness of a span, on the other hand, is fixed when the span
+        /// is constructed and never re-evaluated - this test asserts that too,
+        /// in both directions, so that the limitation is documented rather than
+        /// assumed. It does not affect the driver, whose spans never outlive a
+        /// single request, but it does mean that span *fields* recorded on a
+        /// long-lived span (and any work guarded by its enabledness) would not
+        /// react to a level change.
+        ///
+        /// Run with rusty_fork for the same reason as
+        /// `log_level_is_mutable` - see the comment there.
+        fn long_lived_spans_do_not_freeze_the_log_level() {
+            let counter = EventCounter::default();
+            let data = std::ptr::from_ref(&counter).cast::<c_void>().cast_mut();
+            unsafe { cass_log_set_callback(Some(counting_log_callback), data) };
+
+            let make_span = || trace_span!("Long-running task");
+            let emit_info = || info!("An INFO event");
+
+            // Created at the default (WARN) level, so the span is disabled.
+            let long_lived = make_span();
+            assert!(long_lived.is_disabled());
+
+            unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_TRACE) };
+            counter.take(); // Discard the driver's own log about the change.
+
+            // An event emitted from inside that disabled span is admitted, as
+            // its enabledness depends on the event's own callsite and the
+            // current level only.
+            {
+                let _guard = long_lived.enter();
+                emit_info();
+                assert_eq!(counter.take(), 1);
+            }
+
+            // The same holds with no span in scope at all, which is how the
+            // driver's long-running tasks emit their events.
+            emit_info();
+            assert_eq!(counter.take(), 1);
+
+            // Raising the level silences them again, still inside that span.
+            unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_ERROR) };
+            counter.take();
+            {
+                let _guard = long_lived.enter();
+                emit_info();
+                assert_eq!(counter.take(), 0);
+            }
+
+            // The span itself, however, keeps the enabledness it was created
+            // with. It was created while disabled, and stays disabled even
+            // though TRACE was enabled in between.
+            assert!(long_lived.is_disabled());
+
+            // And the other way around: a span created while enabled stays
+            // enabled after the level is raised.
+            unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_TRACE) };
+            let created_while_enabled = make_span();
+            unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_ERROR) };
+            assert!(!created_while_enabled.is_disabled());
+        }
     }
 }

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -278,7 +278,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use rusty_fork::rusty_fork_test;
-    use tracing::{error, info, warn};
+    use tracing::{error, info, trace_span, warn};
 
     use crate::argconv::{CConst, CassBorrowedSharedPtr};
     use crate::cass_log_types::{CassLogLevel, CassLogMessage};
@@ -366,6 +366,39 @@ mod tests {
             counter.take();
             emit_warn();
             assert_eq!(counter.take(), 1);
+        }
+
+        #[test]
+        /// Verifies that the enabledness of a newly created span follows the
+        /// current log level.
+        ///
+        /// The Rust driver relies on this to skip costly work: it creates a
+        /// fresh `trace_span!` per request (`RequestSpan` in the driver's
+        /// `observability/driver_tracing.rs`) and builds the replica listing
+        /// for that request only `if !span.span().is_disabled()` (in the
+        /// driver's `client/session.rs`). Were span enabledness not to follow
+        /// the log level, lowering the level at runtime would not make the
+        /// driver start collecting that information.
+        ///
+        /// Run with rusty_fork for the same reason as
+        /// `log_level_is_mutable` - see the comment there.
+        fn span_enabledness_follows_log_level() {
+            // A single callsite, called repeatedly - just like the driver,
+            // which creates all its request spans from a handful of callsites.
+            let make_request_span = || trace_span!("Request");
+
+            // The default level (WARN) does not admit a TRACE span, so the
+            // driver skips building the replica listing.
+            assert!(make_request_span().is_disabled());
+
+            // Lowering the level enables the spans created from now on, so new
+            // requests do collect the replica listing.
+            unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_TRACE) };
+            assert!(!make_request_span().is_disabled());
+
+            // Raising it back makes the driver skip that work again.
+            unsafe { cass_log_set_level(CassLogLevel::CASS_LOG_ERROR) };
+            assert!(make_request_span().is_disabled());
         }
     }
 }

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -73,6 +73,19 @@ impl TryFrom<CassLogLevel> for Level {
     }
 }
 
+impl TryFrom<CassLogLevel> for LevelFilter {
+    type Error = ();
+
+    fn try_from(log_level: CassLogLevel) -> Result<Self, Self::Error> {
+        match log_level {
+            // `CASS_LOG_DISABLED` has no `Level` counterpart - disabling logging
+            // is expressed as a filter that admits nothing.
+            CassLogLevel::CASS_LOG_DISABLED => Ok(LevelFilter::OFF),
+            other => Level::try_from(other).map(LevelFilter::from),
+        }
+    }
+}
+
 pub(crate) const CASS_LOG_MAX_MESSAGE_SIZE: usize = 1024;
 
 pub(crate) unsafe extern "C" fn stderr_log_callback(
@@ -158,7 +171,7 @@ where
 
 /// The log level that the driver starts with, before the user calls
 /// [`cass_log_set_level`]. It matches the cpp-driver's default.
-const DEFAULT_LOG_LEVEL: Level = Level::WARN;
+const DEFAULT_LOG_LEVEL_FILTER: LevelFilter = LevelFilter::WARN;
 
 /// A handle that allows mutating the level of the filter of the tracing
 /// subscriber installed by the driver.
@@ -172,7 +185,7 @@ type LogLevelHandle = reload::Handle<LevelFilter, tracing_subscriber::Registry>;
 /// driver's own unit tests. In such case the driver does not own the logging
 /// configuration, and thus must not (and cannot) change the log level.
 static LOG_LEVEL_HANDLE: LazyLock<Option<LogLevelHandle>> = LazyLock::new(|| {
-    let (filter, handle) = reload::Layer::new(LevelFilter::from_level(DEFAULT_LOG_LEVEL));
+    let (filter, handle) = reload::Layer::new(DEFAULT_LOG_LEVEL_FILTER);
 
     tracing::subscriber::set_global_default(
         tracing_subscriber::registry()
@@ -196,24 +209,24 @@ pub(crate) fn init_logging() {
 pub unsafe extern "C" fn cass_log_set_level(log_level: CassLogLevel) {
     init_logging();
 
-    if log_level == CassLogLevel::CASS_LOG_DISABLED {
-        debug!("Logging is disabled!");
-        return;
-    }
-
-    let level = Level::try_from(log_level).unwrap_or(DEFAULT_LOG_LEVEL);
+    let filter = LevelFilter::try_from(log_level).unwrap_or(DEFAULT_LOG_LEVEL_FILTER);
 
     let Some(handle) = LOG_LEVEL_HANDLE.as_ref() else {
         // Some other tracing subscriber is installed globally. Not ours to reconfigure.
         return;
     };
 
+    if filter == LevelFilter::OFF {
+        // Emitted before the update, so that it is not filtered out by it.
+        debug!("Logging is disabled!");
+    }
+
     // The only possible error is a poisoned lock inside the handle, which can
     // only happen if a previous `modify` panicked. Nothing we can do about it.
-    let _ = handle.modify(|filter| *filter = LevelFilter::from_level(level));
+    let _ = handle.modify(|f| *f = filter);
 
     // Emitted after the update, so that it appears iff the new level admits it.
-    debug!("Log level is set to {}", level);
+    debug!("Log level is set to {}", filter);
 }
 
 #[unsafe(no_mangle)]

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -236,6 +236,8 @@ pub unsafe extern "C" fn cass_log_level_string(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_log_set_callback(callback: CassLogCallback, data: *mut c_void) {
+    init_logging();
+
     let logger = Logger {
         cb: Some(callback.unwrap_or(noop_log_callback)),
         data,

--- a/scylla-rust-wrapper/src/logging.rs
+++ b/scylla-rust-wrapper/src/logging.rs
@@ -12,6 +12,7 @@ use tracing::Level;
 use tracing::debug;
 use tracing::field::Field;
 use tracing_subscriber::Layer;
+use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::prelude::*;
 
@@ -158,10 +159,7 @@ where
 pub(crate) fn set_tracing_subscriber_with_level(level: Level) {
     tracing::subscriber::set_global_default(
         tracing_subscriber::registry()
-            .with(
-                tracing_subscriber::EnvFilter::from_default_env()
-                    .add_directive(level.to_owned().into()),
-            )
+            .with(LevelFilter::from_level(level))
             .with(CustomLayer),
     )
     .unwrap_or(()) // Ignore if it is set already

--- a/scylla-rust-wrapper/src/session.rs
+++ b/scylla-rust-wrapper/src/session.rs
@@ -6,6 +6,7 @@ use crate::cql_types::data_type::get_column_type;
 use crate::cql_types::uuid::CassUuid;
 use crate::exec_profile::{CassExecProfile, ExecProfileName, PerStatementExecProfile};
 use crate::future::{CassFuture, CassFutureResult, CassResultValue};
+use crate::logging::init_logging;
 use crate::metadata::create_table_metadata;
 use crate::metadata::{CassKeyspaceMeta, CassMaterializedViewMeta, CassSchemaMeta};
 use crate::query_result::{CassResult, CassResultKind};
@@ -227,6 +228,8 @@ impl FFI for CassSession {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_session_new() -> CassOwnedSharedPtr<CassSession, CMut> {
+    init_logging();
+
     let session = Arc::new(RwLock::new(CassSessionInner {
         connected: None,
         client_id: uuid::Uuid::new_v4(),

--- a/scylla-rust-wrapper/src/ssl.rs
+++ b/scylla-rust-wrapper/src/ssl.rs
@@ -4,6 +4,7 @@ use crate::argconv::{
 };
 use crate::cass_error::CassError;
 use crate::cass_ssl_types::CassSslVerifyFlags;
+use crate::logging::init_logging;
 use crate::types::size_t;
 use libc::{c_int, strlen};
 use openssl::ssl::SslVerifyMode;
@@ -46,6 +47,8 @@ pub unsafe extern "C" fn cass_ssl_new() -> CassOwnedSharedPtr<CassSsl, CMut> {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn cass_ssl_new_no_lib_init() -> CassOwnedSharedPtr<CassSsl, CMut> {
+    init_logging();
+
     let ssl_context: *mut SSL_CTX = unsafe { SSL_CTX_new(TLS_method()) };
     let trusted_store: *mut X509_STORE = unsafe { X509_STORE_new() };
 

--- a/tests/src/integration/tests/test_logging.cpp
+++ b/tests/src/integration/tests/test_logging.cpp
@@ -16,13 +16,18 @@
 
 #include "integration.hpp"
 
+#include <atomic>
+
 class LoggingTests : public Integration {
 public:
   LoggingTests() { is_ccm_requested_ = false; }
 
+  // The driver emits log events from its own background threads, so the flag
+  // is atomic - both the write here and the read done by the assertion in the
+  // test body can race with those threads.
   static void log(const CassLogMessage* log, void* data) {
-    bool* is_triggered = static_cast<bool*>(data);
-    *is_triggered = true;
+    std::atomic<bool>* is_triggered = static_cast<std::atomic<bool>*>(data);
+    is_triggered->store(true);
   }
 };
 
@@ -32,10 +37,10 @@ public:
 CASSANDRA_INTEGRATION_TEST_F(LoggingTests, Callback) {
   CHECK_FAILURE;
 
-  bool is_triggered = false;
+  std::atomic<bool> is_triggered(false);
   cass_log_set_callback(LoggingTests::log, &is_triggered);
   // This will emit a log event in on debug level which will trigger the `log` callback.
   cass_log_set_level(CASS_LOG_DEBUG);
   default_cluster().connect("", false);
-  EXPECT_TRUE(is_triggered);
+  EXPECT_TRUE(is_triggered.load());
 }

--- a/tests/src/integration/tests/test_logging.cpp
+++ b/tests/src/integration/tests/test_logging.cpp
@@ -29,6 +29,24 @@ public:
     std::atomic<bool>* is_triggered = static_cast<std::atomic<bool>*>(data);
     is_triggered->store(true);
   }
+
+  // Strictly speaking, `CassLogCallback` is a function type with C language
+  // linkage (the typedef sits inside the `extern "C"` block in cassandra.h),
+  // whereas this is a C++ function, so passing it as a `CassLogCallback` is
+  // ill-formed by the letter of the standard. It cannot be fixed here either:
+  // `extern "C"` on a class member is ill-formed as well; it would take a free
+  // function at namespace scope.
+  // In practice this is a non-issue: no mainstream compiler implements that
+  // rule (CWG 1555 - GCC, Clang and MSVC all ignore language linkage in the
+  // type system), and no supported platform uses a different calling
+  // convention for `extern "C"` and `extern "C++"` functions. The sibling
+  // `log` callback above and the test framework's own `Logger::log` rely on
+  // exactly the same thing.
+  // Atomic for the same reason as `log` above.
+  static void count(const CassLogMessage* log, void* data) {
+    std::atomic<int>* counter = static_cast<std::atomic<int>*>(data);
+    ++(*counter);
+  }
 };
 
 /**
@@ -43,4 +61,42 @@ CASSANDRA_INTEGRATION_TEST_F(LoggingTests, Callback) {
   cass_log_set_level(CASS_LOG_DEBUG);
   default_cluster().connect("", false);
   EXPECT_TRUE(is_triggered.load());
+}
+
+/**
+ * Ensure that the log level can be changed at any time, any number of times.
+ *
+ * This used to be impossible: only the first call to `cass_log_set_level` had
+ * any effect, and it had to happen before anything logged.
+ */
+CASSANDRA_INTEGRATION_TEST_F(LoggingTests, SetLevelIsMutable) {
+  CHECK_FAILURE;
+
+  std::atomic<int> count(0);
+  cass_log_set_callback(LoggingTests::count, &count);
+
+  // `cass_log_set_level` itself emits a DEBUG event confirming the new level,
+  // so the callback is triggered iff the new level admits DEBUG events.
+  cass_log_set_level(CASS_LOG_DEBUG);
+  EXPECT_GT(count.load(), 0);
+
+  // Raising the level must take effect...
+  count.store(0);
+  cass_log_set_level(CASS_LOG_ERROR);
+  EXPECT_EQ(count.load(), 0);
+
+  // ...and so must lowering it back.
+  cass_log_set_level(CASS_LOG_TRACE);
+  EXPECT_GT(count.load(), 0);
+
+  // CASS_LOG_DISABLED silences everything, including the events emitted while
+  // the driver attempts (and fails) to connect.
+  cass_log_set_level(CASS_LOG_DISABLED);
+  count.store(0);
+  default_cluster().connect("", false);
+  EXPECT_EQ(count.load(), 0);
+
+  // Logging can be enabled back again.
+  cass_log_set_level(CASS_LOG_TRACE);
+  EXPECT_GT(count.load(), 0);
 }


### PR DESCRIPTION
Fixes: #498
Fixes: #115

# What

`cass_log_set_level` had two big limitations, both stemming from its implementation: it *installed* a whole new global `tracing` subscriber, with the requested level baked into that subscriber's `EnvFilter`.

1. It had to be called before anything that could log. Until the first call there was no subscriber at all, so every earlier event was dropped on the floor and the user's log callback never saw it.
2. It had to be called at most once. `tracing::subscriber::set_global_default` succeeds only once per process, and its error was swallowed with `.unwrap_or(())`, so every later call silently did nothing - the level was frozen for the rest of the program.

Both are lifted here. The subscriber is now installed exactly once, independently of `cass_log_set_level`, and its filter is a *reloadable* `LevelFilter` whose handle lives in a static. Setting the level is then an ordinary mutation, valid at any point of the driver's lifetime and repeatable.

Two related bugs are fixed on the way, and both were called out in #498:

3. `CASS_LOG_DISABLED` never disabled anything. It only logged "Logging is disabled!" and returned. It appeared to work when it happened to be the very first call - no subscriber was installed then, so nothing was logged anyway - but after any other level had been set, logging just kept flowing at that level.
4. The driver reacted to `RUST_LOG`. `EnvFilter::from_default_env()` meant a C/C++ application's log level could be silently overridden by an environment variable of a foreign ecosystem.

## Purposeful decisions

### Lazy initialization from entry points, not a library constructor

To lift limitation 1, the subscriber must be up before the first log event. The obvious tool is a `#[ctor]`-style library constructor running at `dlopen` time, but I chose a `LazyLock` forced from `init_logging()`, called at the top of the entry points that can plausibly be the first `cass_*` function an application calls: `cass_cluster_new`, `cass_session_new`, `cass_ssl_new_no_lib_init` (and thus `cass_ssl_new`) and `cass_log_set_callback`. Reasons:

- no new dependency;
- the crate is also built as a `staticlib`, where a linker is free to garbage-collect an `.init_array` entry that nothing references;
- it composes with the crate's own unit tests, which install their own subscriber via `setup_tracing()`. A constructor would always win that race and silently take logging away from every existing test.

`init_logging()` is a `LazyLock::force` - one atomic load after the first call.

### `cass_log_set_callback` initializes logging too

An application that only installs a callback and relies on the default level now receives events. Previously it received nothing at all, because nothing had installed a subscriber.

### A foreign global subscriber is respected

If a subscriber is already installed globally - by the application embedding the driver, or by a unit test - the reload handle is `None` and `cass_log_set_level` becomes a no-op, rather than pretending to reconfigure logging that isn't the driver's to reconfigure.

### `RUST_LOG` support is dropped deliberately

Point 3 of #498. The driver's own subscriber filters with a plain `LevelFilter`. The `env-filter` feature is still enabled because the unit tests' `setup_tracing()` uses it.

### The default level is now actually WARN

`include/cassandra.h` has always documented `CASS_LOG_WARN` as the default. Until now that was only true in the sense that nothing was logged at all before the first `cass_log_set_level` call. Now `DEFAULT_LOG_LEVEL_FILTER` makes it true.

## Testing

- A `rusty_fork` unit test in `logging.rs` covering both lifted limitations: an event emitted before `cass_log_set_level` was ever called reaches the callback, and the level then follows repeated calls - lowered, raised, disabled, enabled back. Events are emitted through closures, so every level change is exercised against callsites already used under the previous level; this makes the test cover invalidation of `tracing`'s per-callsite interest cache, which would otherwise keep a callsite filtered out after a level change. A fresh process is needed because the subscriber is global and installable once, hence   `rusty_fork`.
- `LoggingTests.SetLevelIsMutable` in `test_logging.cpp`. `cass_log_set_level` emits a DEBUG event confirming the level it just set, which makes it its own log source: the callback fires iff the new level admits DEBUG. That is enough to test the whole sequence without a running cluster. Before the fix it fails at the very first level change.
- Both are picked up by CI with no filter changes: `LoggingTests.*` is already listed as a wildcard in both `SCYLLA_TEST_FILTER` and `CASSANDRA_TEST_FILTER`, and the unit test is not a `ccm` test, so `make run-test-unit` runs it.

## Drive-by

`LoggingTests.Callback` had a data race, in a separate commit: the driver emits log events from its own background threads, so the `bool` flag its callback sets was written from those threads while the test thread read it, with no synchronisation. It is now atomic, as is the new test's counter.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~ (no new public items)
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.