### PR TITLE
treewide: Avoid relying on names of unnamed markers

### DIFF
--- a/docs/source/topics/using/prepared-statements.md
+++ b/docs/source/topics/using/prepared-statements.md
@@ -1,12 +1,12 @@
 # Prepared Statements
 
-Prepared statements can be used to improve the performance of frequently executed queries. Preparing the query caches it on the ScyllaDB/Cassandra cluster and only needs to be performed once. Once created, prepared statements should be reused with different bind variables. Prepared queries use the `?` marker to denote bind variables in the query string. You can also specify bind variables as `:name`.
+Prepared statements can be used to improve the performance of frequently executed queries. Preparing the query caches it on the ScyllaDB/Cassandra cluster and only needs to be performed once. Once created, prepared statements should be reused with different bind variables. Prepared queries use the `?` marker to denote bind variables in the query string. You can also specify bind variables as `:name`. Note that binding by name requires named (`:name`) markers; the names that the server generates for unnamed `?` markers should not be relied upon.
 
 ```c
 void prepare_statement(CassSession* session) {
   /* Prepare the statement on the ScyllaDB/Cassandra cluster */
   CassFuture* prepare_future
-    = cass_session_prepare(session, "INSERT INTO example (key, value) VALUES (?, ?)");
+    = cass_session_prepare(session, "INSERT INTO example (key, value) VALUES (:key, :value)");
 
   /* Wait for the statement to prepare and get the result */
   CassError rc = cass_future_error_code(prepare_future);

--- a/examples/bind_by_name/bind_by_name.c
+++ b/examples/bind_by_name/bind_by_name.c
@@ -186,8 +186,9 @@ int main(int argc, char* argv[]) {
   char* hosts = "127.0.0.1";
 
   const char* insert_query =
-      "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);";
-  const char* select_query = "SELECT * FROM examples.basic WHERE key = ?";
+      "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) "
+      "VALUES (:key, :bln, :flt, :dbl, :i32, :i64);";
+  const char* select_query = "SELECT * FROM examples.basic WHERE key = :key";
 
   if (argc > 1) {
     hosts = argv[1];

--- a/examples/concurrent_executions/concurrent_executions.c
+++ b/examples/concurrent_executions/concurrent_executions.c
@@ -86,7 +86,8 @@ CassError execute_query(CassSession* session, const char* query) {
 
 CassError prepare_insert(CassSession* session, const CassPrepared** prepared) {
   CassError rc = CASS_OK;
-  const char* query = "INSERT INTO examples.concurrent_executions (id, value) VALUES (?, ?);";
+  const char* query =
+      "INSERT INTO examples.concurrent_executions (id, value) VALUES (:id, :value);";
 
   CassFuture* future = cass_session_prepare(session, query);
   cass_future_wait(future);

--- a/examples/named_parameters/named_parameters.c
+++ b/examples/named_parameters/named_parameters.c
@@ -124,7 +124,7 @@ CassError select_from_basic(CassSession* session, const char* key, Basic* basic)
   CassStatement* statement = NULL;
   CassFuture* future = NULL;
 
-  const char* query = "SELECT * FROM examples.basic WHERE key = ?";
+  const char* query = "SELECT * FROM examples.basic WHERE key = :key";
 
   statement = cass_statement_new(query, 1);
 


### PR DESCRIPTION
In the binary CQL protocol, each bind marker in a PREPARED response must have a name. If a user didn't provide one (because they used an unnamed `?` marker), then the server must generate one. In general we should advise users to not rely on those names, in case they unexpectedly change between server versions.

To do that, we need to avoid relying on those generated names in our examples and docs. This commit does just that.

The integration tests that exercise `cass_statement_bind_*_by_name()` against unnamed markers are intentionally left as they are: `ByNameTests` in `tests/src/integration/tests/test_by_name.cpp` and `CassandraTypesTests.ByName` in
`tests/src/integration/tests/test_cassandra_types.cpp`. Those tests are useful to tell us if even such basic behavior breaks.

--------------------------------------

This mirrors scylladb/scylla-rust-driver#1870.
Fixes: https://scylladb.atlassian.net/browse/DRIVER-905

--------------------------------------

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- ~~[ ] I have implemented Rust unit tests for the features/changes introduced.~~
- ~~[ ] I have enabled appropriate tests in `Makefile` in `{SCYLLA,CASSANDRA}_(NO_VALGRIND_)TEST_FILTER`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
