### PR TITLE
Release 1.1.2

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,16 +15,16 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Global variables
 
 # Builds documentation for the following tags and branches.
-TAGS = ["v1.0.0", "v1.0.1", "v1.1.0", "v1.1.1"]
+TAGS = ["v1.0.0", "v1.0.1", "v1.1.0", "v1.1.1", "v1.1.2"]
 BRANCHES = [
     "master",
 ]
 # Sets the latest version.
-LATEST_VERSION = "v1.1.1"
+LATEST_VERSION = "v1.1.2"
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = ["v1.0.0", "v1.0.1", "v1.1.0"]
+DEPRECATED_VERSIONS = ["v1.0.0", "v1.0.1", "v1.1.0", "v1.1.1"]
 # Sets custom build.
 FLAGS = ["theme"]
 

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -53,7 +53,7 @@
 
 #define CASS_VERSION_MAJOR 1
 #define CASS_VERSION_MINOR 1
-#define CASS_VERSION_PATCH 1
+#define CASS_VERSION_PATCH 2
 #define CASS_VERSION_SUFFIX ""
 
 #ifdef __cplusplus

--- a/scylla-rust-wrapper/Cargo.lock
+++ b/scylla-rust-wrapper/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "scylla-rust-wrapper"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "arc-swap",
  "assert_matches",

--- a/scylla-rust-wrapper/Cargo.toml
+++ b/scylla-rust-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-rust-wrapper"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 description = "Wrapper for Scylla's Rust driver, exports functions to be used by C"
 repository = "https://github.com/scylladb/scylla-rust-driver"


### PR DESCRIPTION
The ScyllaDB team is pleased to announce ScyllaDB CPP RS Driver 1.1.2, an API-compatible rewrite of https://github.com/scylladb/cpp-driver as a wrapper for the Rust driver. It fully replaces the CPP driver, which has already reached its End of Life.

Some minor features still need to be included. See Limitations section in README.md.

The underlying Rust Driver used version: 1.8.0.

## Changes since 1.1.1:

Changes from Rust Driver that can impact this driver are included in the changelog. Those changes are be marked with the crab emoji 🦀.

Entries that require special attention (e.g. because of potential build system or application breakage) are marked with the warning emoji ⚠️.

## Changes

**New features / enhancements:**
- 🦀 Internal metadata fetching procedures were greatly improved, dropping many unnecessary false dependencies between internal driver tasks, which should improve the delay of some of them ([#1792](https://github.com/scylladb/scylla-rust-driver/pull/1792), [#1823](https://github.com/scylladb/scylla-rust-driver/pull/1823), [#1835](https://github.com/scylladb/scylla-rust-driver/pull/1835)).
- 🦀 Metadata fetching now supports client-side timeouts ([#1837](https://github.com/scylladb/scylla-rust-driver/pull/1837)).
- 🦀 `RetrySession` is now created lazily when needed, to save an allocation on the hot path ([#1833](https://github.com/scylladb/scylla-rust-driver/pull/1833)).
- Bumped Rust Driver to 1.8.0 ([#496](https://github.com/scylladb/cpp-rs-driver/pull/496)).
- Added experimental support for changing log level on the fly ([#499](https://github.com/scylladb/cpp-rs-driver/pull/499)).

**Bug fixes:**
- 🦀 Fixed a deadlock happening when driver was flooded with CQL events during metadata refresh ([#1835](https://github.com/scylladb/scylla-rust-driver/pull/1835)).

**Documentation:**
- Avoided relying on names of unnamed markers in code examples ([#500](https://github.com/scylladb/cpp-rs-driver/pull/500)).

**CI / testing improvements:**
- Introduced `cargo deny` ([#495](https://github.com/scylladb/cpp-rs-driver/pull/495)).
- Enabled more `ControlConnectionTests` ([#497](https://github.com/scylladb/cpp-rs-driver/pull/497)).

Congrats to all contributors and thanks everyone for using our driver!

----------

The source code of the driver can be found here:
- [https://github.com/scylladb/cpp-rs-driver](https://github.com/scylladb/cpp-rs-driver)

Contributions are most welcome!

Thank you for your attention, please do not hesitate to contact us if you have any questions, issues, feature requests, or are simply interested in our driver!


Contributors since 1.1.1:

| commits | author                 |
|---------|------------------------|
| 34      | Wojciech Przytuła      |
